### PR TITLE
Update kinder-vlm-planning dependencies and docs

### DIFF
--- a/kinder-vlm-planning/README.md
+++ b/kinder-vlm-planning/README.md
@@ -1,11 +1,35 @@
-# VLM Planning Baselines for KinDER
+# LLm/VLM Planning Baselines for KinDER
 
 ![workflow](https://github.com/yichao-liang/kinder-vlm-planning/actions/workflows/ci.yml/badge.svg)
 
 ## Experiment
 
+Set `rgb_observation=false` to test LLM planning (text-only, no image observations) instead of VLM planning.
+
+Running on a single environment with a single seed:
+```bash
+python experiments/run_experiment.py env=Motion2D-p0-v0 seed=0 vlm_model=gpt-5 \
+    temperature=1
+python experiments/run_experiment.py -m env=StickButton2D-b1-v0 seed=0 \
+    vlm_model=gpt-5 temperature=1
+```
+
+Running on multiple environments and multiple seeds (sequential):
+```bash
+python experiments/run_experiment.py -m seed='range(0,3)' \
+    env=Motion2D-p0-v0,StickButton2D-b1-v0 \
+    vlm_model=gpt-5 rgb_observation=true,false temperature=1
+```
+
+Running on multiple environments and multiple seeds (parallel via joblib):
+```bash
+python experiments/run_experiment.py -m seed='range(0,3)' \
+    env=BaseMotion3D-v0,Transport3D-o2-v0,Shelf3D-o1-v0 \
+    vlm_model=gpt-5 rgb_observation=true,false temperature=1 hydra/launcher=joblib \
+    hydra.launcher.n_jobs=-1
+```
 
 ## Installation
 
 1. Recommended: create and source a virtualenv (perhaps with [uv](https://github.com/astral-sh/uv))
-2. Install this repo: `pip install -e ".[develop]"`
+2. Install this repo: `uv pip install -e ".[develop]"`

--- a/kinder-vlm-planning/README.md
+++ b/kinder-vlm-planning/README.md
@@ -1,4 +1,4 @@
-# LLm/VLM Planning Baselines for KinDER
+# LLM/VLM Planning Baselines for KinDER
 
 ![workflow](https://github.com/yichao-liang/kinder-vlm-planning/actions/workflows/ci.yml/badge.svg)
 

--- a/kinder-vlm-planning/README.md
+++ b/kinder-vlm-planning/README.md
@@ -31,5 +31,9 @@ python experiments/run_experiment.py -m seed='range(0,3)' \
 
 ## Installation
 
-1. Recommended: create and source a virtualenv (perhaps with [uv](https://github.com/astral-sh/uv))
-2. Install this repo: `uv pip install -e ".[develop]"`
+We strongly recommend uv. The steps below assume that you have uv installed. If you do not, just remove uv from the commands and the installation should still work.
+
+# Install PRPL dependencies.
+uv pip install -r prpl_requirements.txt
+# Install this package and third-party dependencies.
+uv pip install -e ".[develop]"

--- a/kinder-vlm-planning/experiments/run_experiment.py
+++ b/kinder-vlm-planning/experiments/run_experiment.py
@@ -7,10 +7,12 @@ Examples:
     python experiments/run_experiment.py -m env=StickButton2D-b1-v0 seed=0 \
         vlm_model=gpt-5 temperature=1
 
-- Running on multiple environments and multiple seeds:
+- Running on multiple environments and multiple seeds (sequential):
     python experiments/run_experiment.py -m seed='range(0,3)' \
         env=Motion2D-p0-v0,StickButton2D-b1-v0 \
         vlm_model=gpt-5 rgb_observation=true,false temperature=1
+
+- Running on multiple environments and multiple seeds (parallel via joblib):
     python experiments/run_experiment.py -m seed='range(0,3)' \
         env=BaseMotion3D-v0,Transport3D-o2-v0,Shelf3D-o1-v0 \
         vlm_model=gpt-5 rgb_observation=true,false temperature=1 hydra/launcher=joblib \

--- a/kinder-vlm-planning/pyproject.toml
+++ b/kinder-vlm-planning/pyproject.toml
@@ -17,7 +17,9 @@ dependencies = [
    "hydra-joblib-launcher",
    "omegaconf",
    "kindergarden>=0.0.7",
-   "prpl_llm_utils@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=prpl-llm-utils",
+   "prpl_llm_utils",
+   "kinder_models@git+https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git#subdirectory=kinder-models",
+   "bilevel_planning@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=bilevel-planning",
 ]
 
 [project.optional-dependencies]

--- a/kinder-vlm-planning/pyproject.toml
+++ b/kinder-vlm-planning/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
    "omegaconf",
    "kindergarden>=0.0.7",
    "prpl_llm_utils@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=prpl-llm-utils",
-   "kinder_models@git+https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git#subdirectory=kinder-models",
    "bilevel_planning@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=bilevel-planning",
 ]
 

--- a/kinder-vlm-planning/pyproject.toml
+++ b/kinder-vlm-planning/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
    "hydra-joblib-launcher",
    "omegaconf",
    "kindergarden>=0.0.7",
-   "prpl_llm_utils",
+   "prpl_llm_utils@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=prpl-llm-utils",
    "kinder_models@git+https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git#subdirectory=kinder-models",
    "bilevel_planning@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=bilevel-planning",
 ]


### PR DESCRIPTION
- Add `kinder_models` and `bilevel_planning` as git dependencies so the package can be installed standalone
- Add experiment usage instructions to README with sequential vs parallel examples