### PR TITLE
Fix broken bilevel-planning README link in notebook

### DIFF
--- a/kinder-bilevel-planning/notebooks/bilevel_planning.ipynb
+++ b/kinder-bilevel-planning/notebooks/bilevel_planning.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Bilevel Planning in KinDER\n",
-    "\n",
-    "See the [bilevel-planning README](../../bilevel-planning/README.md) for background on bilevel planning. This notebook demonstrates how to use it in a KinDER environment."
-   ]
+   "source": "# Bilevel Planning in KinDER\n\nSee the [bilevel-planning README](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono/blob/main/bilevel-planning/README.md) for background on bilevel planning. This notebook demonstrates how to use it in a KinDER environment."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Updates the broken `../../bilevel-planning/README.md` link at the top of `kinder-bilevel-planning/notebooks/bilevel_planning.ipynb` to point at the upstream README in `prpl-mono`.

Fixes #25

## Test plan
- [x] Open the notebook in GitHub and confirm the README link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)