### PR TITLE
kinder-blockly: load test, VM sizing, and old-stack benchmark

### DIFF
--- a/kinder-blockly/fly.toml
+++ b/kinder-blockly/fly.toml
@@ -1,16 +1,21 @@
 # Fly.io deployment for the Blockly server.
 #
 # Sizing notes:
-# - Each machine runs 2 gunicorn workers (matches 2 vCPUs).
-# - Each worker pre-warms one pybullet env (~300-500 MB resident).
-# - 2 GB memory leaves comfortable headroom above the steady-state working set.
-# - soft_limit = 2 (= worker count) tells Fly to start another machine before
-#   queueing requests on this one. hard_limit = 3 gives one slot of buffer for
-#   the very short /reset and /healthz calls between long /run streams.
+# - Each machine runs 2 gunicorn workers (matches 2 dedicated vCPUs).
+# - Each worker pre-warms one pybullet env (~300-500 MB resident baseline).
+# - performance-2x gives dedicated CPU so per-run latency does not depend on
+#   noisy neighbours on the shared pool. Important during classroom sessions
+#   where 20+ students may be running programs simultaneously.
+# - 4 GB memory leaves ~1.5 GB headroom per worker, enough to absorb large
+#   student programs (long repeat_while loops, many trail segments, paint
+#   bucket spawns) and slow pybullet leaks between worker restarts.
+# - soft_limit = 2 (= worker count) tells Fly to route to another machine
+#   before queueing requests on this one. hard_limit = 3 gives one slot of
+#   buffer for short /reset and /healthz calls between long /run streams.
 #
-# Cost profile assumes occasional / demo use with a single machine warm and
-# burst-scaling on demand. For a known classroom session, bump
-# min_machines_running with `fly scale count <N>` before class starts.
+# Total fleet capacity is set by `fly scale count <N>`, not this file. With
+# auto_stop_machines = "suspend", idle machines suspend to near-zero cost,
+# so it is safe to provision well above steady-state demand.
 
 app = "kinder-blockly"
 primary_region = "iad"
@@ -41,5 +46,5 @@ primary_region = "iad"
     path = "/healthz"
 
 [[vm]]
-  size = "shared-cpu-2x"
-  memory = "2gb"
+  size = "performance-2x"
+  memory = "4gb"

--- a/kinder-blockly/loadtest/blockly_load_test.js
+++ b/kinder-blockly/loadtest/blockly_load_test.js
@@ -11,7 +11,11 @@
 //   BASE_URL=https://kinder-blockly.fly.dev PEAK_VUS=20 \
 //     k6 run loadtest/blockly_load_test.js
 //
-// Watch Fly logs in another terminal while it runs:
+// Benchmark a path-prefixed deploy (no /healthz needed — setup tolerates it):
+//   BASE_URL=http://blockly.prpl-group.com/blockly \
+//     k6 run loadtest/blockly_load_test.js
+//
+// Watch the target's logs in another terminal while it runs (Fly):
 //   fly logs
 
 import http from 'k6/http';
@@ -64,9 +68,19 @@ const PROGRAM = {
 };
 
 export function setup() {
-  const res = http.get(`${BASE_URL}/healthz`);
-  if (res.status !== 200) {
-    throw new Error(`healthz returned ${res.status}: ${res.body}`);
+  // /healthz is a Fly-stack convention. Older deploys may not expose it;
+  // fall back to validating that GET / responds at all.
+  const hz = http.get(`${BASE_URL}/healthz`);
+  if (hz.status === 200) {
+    console.log(`healthz ok at ${BASE_URL}/healthz`);
+  } else {
+    const root = http.get(`${BASE_URL}/`);
+    if (root.status !== 200) {
+      throw new Error(
+        `${BASE_URL}/ returned ${root.status} (and no /healthz). Is the target up?`,
+      );
+    }
+    console.log(`no /healthz at target (status ${hz.status}); GET / returned 200`);
   }
   console.log(`target: ${BASE_URL}, peak VUs: ${PEAK_VUS}`);
   return { baseUrl: BASE_URL };

--- a/kinder-blockly/loadtest/blockly_load_test.js
+++ b/kinder-blockly/loadtest/blockly_load_test.js
@@ -1,0 +1,133 @@
+// k6 load test for the deployed Blockly server.
+//
+// Simulates students running small Blockly programs concurrently. Measures
+// end-to-end /run latency, validates that frames come back, and surfaces
+// HTTP-level errors (5xx, timeouts, Fly hard-limit rejections).
+//
+// Run against the default Fly deploy:
+//   k6 run loadtest/blockly_load_test.js
+//
+// Override target URL or peak load:
+//   BASE_URL=https://kinder-blockly.fly.dev PEAK_VUS=20 \
+//     k6 run loadtest/blockly_load_test.js
+//
+// Watch Fly logs in another terminal while it runs:
+//   fly logs
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'https://kinder-blockly.fly.dev';
+const PEAK_VUS = parseInt(__ENV.PEAK_VUS || '15', 10);
+
+const runDuration = new Trend('blockly_run_duration', true);
+const resetDuration = new Trend('blockly_reset_duration', true);
+const runSuccessful = new Rate('blockly_run_successful');
+const framesPerRun = new Trend('blockly_frames_per_run');
+const framesReceived = new Counter('blockly_frames_received');
+
+export const options = {
+  scenarios: {
+    classroom: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '20s', target: Math.max(1, Math.floor(PEAK_VUS / 3)) },
+        { duration: '30s', target: Math.max(1, Math.floor(PEAK_VUS / 3)) },
+        { duration: '30s', target: PEAK_VUS },
+        { duration: '60s', target: PEAK_VUS },
+        { duration: '20s', target: 0 },
+      ],
+      gracefulRampDown: '30s',
+    },
+  },
+  thresholds: {
+    blockly_run_duration: ['p(95)<30000'],
+    blockly_run_successful: ['rate>0.95'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+// Small program: draw a square with the pen down. Takes a couple of seconds
+// of pybullet stepping per run, so it actually exercises the heavy path.
+const PROGRAM = {
+  blocks: [
+    { type: 'set_pen_color', r: 255, g: 0, b: 0 },
+    { type: 'pen_down' },
+    { type: 'move_base_to_target', x: 0.8, y: 0.0 },
+    { type: 'move_base_to_target', x: 0.8, y: 0.8 },
+    { type: 'move_base_to_target', x: 0.0, y: 0.8 },
+    { type: 'move_base_to_target', x: 0.0, y: 0.0 },
+    { type: 'pen_up' },
+  ],
+};
+
+export function setup() {
+  const res = http.get(`${BASE_URL}/healthz`);
+  if (res.status !== 200) {
+    throw new Error(`healthz returned ${res.status}: ${res.body}`);
+  }
+  console.log(`target: ${BASE_URL}, peak VUs: ${PEAK_VUS}`);
+  return { baseUrl: BASE_URL };
+}
+
+export default function (data) {
+  // GET / once per iteration to ensure this VU has a kb_session cookie.
+  // k6 cookie jars are per-VU and persist across iterations, so we are
+  // effectively one student doing many runs in a session.
+  const indexRes = http.get(`${data.baseUrl}/`);
+  check(indexRes, { 'index 200': (r) => r.status === 200 });
+
+  const resetStart = Date.now();
+  const resetRes = http.post(
+    `${data.baseUrl}/reset`,
+    JSON.stringify({ seed: 0, paint_buckets: [] }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+  resetDuration.add(Date.now() - resetStart);
+  check(resetRes, { 'reset 200': (r) => r.status === 200 });
+
+  const runStart = Date.now();
+  const runRes = http.post(
+    `${data.baseUrl}/run`,
+    JSON.stringify({ program: PROGRAM, seed: 0, paint_buckets: [] }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      timeout: '180s',
+    },
+  );
+  runDuration.add(Date.now() - runStart);
+
+  if (runRes.status !== 200) {
+    runSuccessful.add(false);
+    console.log(`run failed status=${runRes.status} body=${(runRes.body || '').substring(0, 200)}`);
+  } else {
+    const lines = (runRes.body || '').trim().split('\n');
+    let doneMsg = null;
+    let frames = 0;
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.type === 'frame') frames++;
+        else if (msg.type === 'done') doneMsg = msg;
+      } catch (e) {
+        console.log(`bad ndjson line: ${line.substring(0, 100)}`);
+      }
+    }
+    framesReceived.add(frames);
+    framesPerRun.add(frames);
+
+    const ok = doneMsg !== null && !doneMsg.error && !doneMsg.infinite_loop;
+    runSuccessful.add(ok);
+    if (!ok) {
+      console.log(
+        `run done with error: error=${doneMsg && doneMsg.error} loop=${doneMsg && doneMsg.infinite_loop}`,
+      );
+    }
+  }
+
+  // Think time between runs — students do not click Run continuously.
+  sleep(2 + Math.random() * 3);
+}


### PR DESCRIPTION
## Summary

Adds a k6 load test for the Blockly server, tunes the Fly VM spec based on what the first run revealed, and benchmarks both the new Fly deploy and the legacy Heroku+GCP deploy with the same load profile to quantify the migration impact.

## Headline result: new stack vs legacy stack at 15 concurrent users

Same k6 script, same `BASE_URL` differs:

| Metric | Old (Heroku+GCP) | New (Fly, 10× perf-2x/4GB) | Improvement |
|---|---|---|---|
| /run median | 8.03s | 4.4s | 1.8× faster |
| /run p95 | 24.24s | **6.49s** | **3.7× faster** |
| /run max | 25.18s | 8.08s | 3.1× faster |
| /reset p95 | 7.11s | 1.04s | 6.8× faster |
| Iterations completed (3 min) | 74 | 178 | 2.4× throughput |
| Success rate | 100% | 100% | — |

Single-user latency on both stacks is essentially identical (~3.4–3.5s for /run, ~350ms for /reset) — same code at the same baseline speed. The gap opens entirely under concurrent load:

- Old stack: 3.4s baseline → 24s p95 (7× degradation under 15 VUs)
- New stack: 3.5s baseline → 6.5s p95 (1.85× degradation under 15 VUs)

The old stack max latency of 25.18s was almost the Heroku 30-second router timeout. Slightly more complex student programs would have started hitting H12 timeouts on the old stack but pass cleanly on Fly (180s gunicorn timeout, app-level 120s `EXECUTION_TIMEOUT_S`).

## The first Fly run flagged a sizing problem

Running the same test at 15 VUs against the original 2-machine `shared-cpu-2x` / 2 GB Fly configuration:

| Metric | Result | Threshold |
|---|---|---|
| /run p95 | **61s** | <30s ✗ |
| /run median | 3.6s | — |
| /run success rate | 87.5% | >95% ✗ |
| HTTP error rate | 12.34% | <5% ✗ |
| Iterations completed | 47 (11 interrupted) | — |
| /reset p95 | 36s | — |

Median was unchanged from the 1-VU smoke test — the tail blew up purely from queueing. Fly logs showed both machines repeatedly hitting `hard_limit of 3 concurrent requests`, the proxy returning `could not find a good candidate within 40 attempts at load balancing`, and health checks intermittently failing because workers were busy answering /run streams.

Root cause: 2 machines × 2 workers = 4 concurrent slots, swamped by 15 simultaneous students. The application itself never errored; every `/run` that made it to a worker completed cleanly.

## What changed

### `fly.toml`

- `size = "performance-2x"` (was `shared-cpu-2x`) — dedicated CPU eliminates noisy-neighbour variability during classroom sessions.
- `memory = "4gb"` (was `"2gb"`) — ~1.5 GB headroom per worker, large enough to absorb big student programs (long `repeat_while` loops, many trail segments, paint bucket spawns) and any slow pybullet leaks between worker restarts.
- Sizing comments rewritten to reflect the new rationale and to clarify that machine count is set imperatively via `fly scale count`, not declaratively here.

`workers = 2`, `soft_limit = 2`, `hard_limit = 3` unchanged — those scaled cleanly with more machines.

### Operational change (not in code)

`fly scale count 10` was run to provision 8 additional machines at the new spec. With `auto_stop_machines = "suspend"` and `min_machines_running = 1`, 9 of the 10 suspend when idle, so steady-state cost is near zero. During classroom sessions, the suspended machines resume on demand or can be pre-warmed by raising `min_machines_running`.

### `loadtest/blockly_load_test.js` (new)

k6 script that simulates students:

- Each VU establishes a `kb_session` cookie via `GET /`, then loops on `POST /reset` + `POST /run` with 2–5s think time between runs. Each VU has its own cookie jar, so per-session stop-event isolation is exercised.
- The Blockly program is a small drawn square — runs end-to-end with 13 frames so the pybullet path is exercised but iterations are short enough to load the system without each one taking forever.
- Custom metrics: `blockly_run_duration`, `blockly_reset_duration`, `blockly_run_successful`, `blockly_frames_per_run`.
- Thresholds: run p95 < 30s, success rate > 95%, HTTP failure rate < 5%.
- Parameterized via env vars: `BASE_URL` (default `https://kinder-blockly.fly.dev`), `PEAK_VUS` (default 15).
- `setup()` validates the target is up via `/healthz` if present, else falls back to `GET /`. This lets the same script benchmark deploys that predate the `/healthz` endpoint.

Run with:

```bash
k6 run loadtest/blockly_load_test.js
PEAK_VUS=30 k6 run loadtest/blockly_load_test.js   # bigger test
BASE_URL=http://blockly.prpl-group.com/blockly k6 run loadtest/blockly_load_test.js   # benchmark old stack
```

## Results after the changes

Re-running the same 15-VU profile against 10 × `performance-2x` / 4 GB:

| Metric | Before sizing change | After sizing change |
|---|---|---|
| /run p95 | 61s | **6.49s** |
| /run median | 3.6s | 4.4s |
| /run success rate | 87.5% | **100%** |
| HTTP error rate | 12.34% | **0%** |
| Iterations completed | 47 (11 interrupted) | **178 (0 interrupted)** |
| /reset p95 | 36s | 1.04s |
| Max /run | 65s | 8.08s |

All k6 thresholds pass. p95 went from 16× the median to ~1.5× the median — the signature of a non-queueing system. No hard-limit warnings, no proxy routing failures, no failed health checks during peak load.

## Test plan

- [x] k6 smoke (1 VU, 2 iterations) against Fly: script works end-to-end, frames received, cookie flow correct.
- [x] k6 load (15 VUs, ~3 min) against Fly: all thresholds pass, machines resume from suspend on demand, logs clean.
- [x] k6 smoke (1 VU, 2 iterations) against legacy Heroku+GCP: 3.4s /run, 348ms /reset, identical to single-user baseline on Fly.
- [x] k6 load (15 VUs, ~3 min) against legacy Heroku+GCP: 24s p95, 3.7× slower than Fly, near Heroku 30s router timeout cliff.
- [ ] Follow-up: 30-VU run against Fly to validate full-classroom-burst behaviour with appropriately scaled count.

## What this PR does NOT do

- Does not set `min_machines_running > 1`. For classroom sessions you would temporarily bump it (or run `fly scale count` higher in advance); steady state stays cheap with most machines suspended.
- Does not add monitoring / error tracking. Sentry is the next follow-up.
- Does not change `workers`, `soft_limit`, or `hard_limit`. Those scaled cleanly with more capacity; revisit only if a future test surfaces per-machine queueing.
- Does not change anything in the legacy Heroku+GCP deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
