### PR TITLE
kinder-blockly: wire Sentry error tracking into the server

### DIFF
--- a/kinder-blockly/pyproject.toml
+++ b/kinder-blockly/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
    "numpy",
    "pillow",
    "kindergarden>=0.1.0",
+   "sentry-sdk[flask]>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/kinder-blockly/src/kinder_blockly/server.py
+++ b/kinder-blockly/src/kinder_blockly/server.py
@@ -3,6 +3,7 @@
 import base64
 import io
 import json
+import os
 import threading
 import time
 import uuid
@@ -11,8 +12,10 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import sentry_sdk
 from flask import Flask, Response, g, request, stream_with_context
 from PIL import Image
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from kinder_blockly.challenges import get_challenge, list_challenges, score_trail
 from kinder_blockly.executor import (
@@ -24,6 +27,23 @@ from kinder_blockly.executor import (
     render_initial_frame,
     validate_program,
 )
+
+# Initialise Sentry before creating the Flask app so the integration can hook
+# request handlers. No-ops when SENTRY_DSN is unset (e.g. local dev), so this
+# never gates the server on having Sentry configured.
+_SENTRY_DSN = os.environ.get("SENTRY_DSN")
+if _SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=_SENTRY_DSN,
+        integrations=[FlaskIntegration()],
+        environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
+        release=os.environ.get("FLY_IMAGE_REF") or os.environ.get("SENTRY_RELEASE"),
+        # Capture all exceptions; this is a low-volume service.
+        sample_rate=1.0,
+        # No performance tracing — we have k6 + Fly metrics for that.
+        traces_sample_rate=0.0,
+        send_default_pii=False,
+    )
 
 STATIC_DIR = Path(__file__).parent / "static"
 


### PR DESCRIPTION
## Summary

Wires the Sentry Python SDK into the Blockly server so unhandled exceptions in production are captured with full stack traces, request context, and breadcrumbs. Without a `SENTRY_DSN` environment variable, the SDK does not initialise — local development, tests, and any unconfigured deployment continue to behave exactly as before.

## What this gives us

Today, if a request handler raises (e.g. a pybullet operation fails mid-stream, a malformed program slips past `validate_program`, a kindergarden API change breaks an executor path), the only signal is a Heroku/Fly log line that nobody reads until a student reports a broken Blockly button. With Sentry:

- Every unhandled exception is captured with the full Python traceback.
- The originating request is captured: method, path, headers, query params, session cookie, body.
- Recent log lines and Flask routing events are attached as breadcrumbs.
- Errors are grouped by signature so a recurring bug is one issue, not a hundred.
- Each error is tagged with `FLY_IMAGE_REF` so it's clear which deploy introduced or fixed it.
- The Sentry dashboard mails / Slack-pings on first-seen or high-volume issues.

This is the simplest production observability we can add today, and removes the "student reported X is broken but I don't know what happened" failure mode.

## Code shape

`pyproject.toml` adds `sentry-sdk[flask]>=2.0` as a runtime dependency. The `[flask]` extra pulls in nothing extra — just signals the Flask integration is intended.

`server.py` initialises the SDK at module load, before `Flask(__name__)` is constructed, so `FlaskIntegration()` can hook the request lifecycle:

```python
_SENTRY_DSN = os.environ.get("SENTRY_DSN")
if _SENTRY_DSN:
    sentry_sdk.init(
        dsn=_SENTRY_DSN,
        integrations=[FlaskIntegration()],
        environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
        release=os.environ.get("FLY_IMAGE_REF") or os.environ.get("SENTRY_RELEASE"),
        sample_rate=1.0,
        traces_sample_rate=0.0,
        send_default_pii=False,
    )
```

Design choices:

- `sample_rate=1.0` — capture every exception. This is a low-volume educational service; we are not at scale where sampling is needed.
- `traces_sample_rate=0.0` — performance tracing is disabled. Fly already gives us request metrics, and the k6 load test in PR #47 covers latency under load. Tracing would just consume Sentry quota for no incremental value today.
- `send_default_pii=False` — do not auto-attach IP addresses or other user identifiers. The session cookie value is harmless (it is a UUID minted by us) but defaults err on the side of less.
- Initialisation is unconditional on import; nothing else in the file changes.

## Activation steps (after merge)

These can happen before, during, or after merge — the code is safe either way because Sentry init is gated on the env var being present.

1. Sign up at https://sentry.io (free Developer tier: 5K errors/month, more than enough for this service).
2. Create a project — pick **Python > Flask** as the platform. Sentry will display a DSN that looks like `https://abc123@o000000.ingest.sentry.io/123456`.
3. Set the DSN as a Fly secret (this triggers a deploy automatically):

```bash
fly secrets set SENTRY_DSN="https://abc123@o000000.ingest.sentry.io/123456"
```

4. Verify by visiting `https://kinder-blockly.fly.dev` and submitting a deliberately broken program, or by SSHing in and raising a test exception in the Python REPL. Confirm the issue appears in the Sentry dashboard within ~30 seconds.

## What this PR does NOT do

- No frontend integration. Sentry has a `@sentry/svelte` SDK that would capture client-side errors and surface API failures from the user's perspective. Worth adding later; not in scope here.
- No performance tracing. Re-enable by raising `traces_sample_rate` if we ever want flame-graph views.
- No PII attachment. If we add user accounts later, set `send_default_pii=True` and use `sentry_sdk.set_user` with the account id.
- No custom `before_send` filtering. If specific noisy exceptions surface in production, drop them at the SDK with a filter.

## Test plan

- [x] `./run_ci_checks.sh` passes locally (black, mypy, pylint, pytest 2 passed).
- [x] Server starts locally without `SENTRY_DSN` set — confirms no-DSN path is a no-op.
- [ ] After `fly secrets set SENTRY_DSN=...` and the auto-redeploy, trigger an error and confirm it appears in the Sentry dashboard.
- [ ] After first real error in production, confirm the Fly image ref is attached so we can correlate to a specific deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
