### PR TITLE
kinder-blockly: halve render resolution to 320x180 for ~2.5x speedup

### DIFF
--- a/kinder-blockly/src/kinder_blockly/executor.py
+++ b/kinder-blockly/src/kinder_blockly/executor.py
@@ -44,8 +44,12 @@ _CAM_DISTANCE = 4.0  # original was 2.8; 4.0 gives ~40% more world coverage
 _CAM_PITCH = -35  # original was -30; 5° steeper keeps the floor in frame
 _CAM_YAW = 90
 _CAM_TARGET = (0.0, 0.0, 0.0)
-_RENDER_W = 640
-_RENDER_H = 360
+# Rendered at 320x180 (half each dimension of the original 640x360). PyBullet's
+# TINY_RENDERER on the CPU is roughly linear in pixel count, so this gives a
+# ~4x speedup per frame. The frontend img element scales the JPEG back up to
+# fit its container, so visual impact is mild pixelation, not a smaller view.
+_RENDER_W = 320
+_RENDER_H = 180
 
 
 def _render(client_id: int) -> NDArray[np.uint8]:


### PR DESCRIPTION
## Summary

Drops the rendered frame size from 640×360 to 320×180 to roughly halve per-frame /run latency. Verified with the same timing probe that characterised the original behaviour: a 50-move program goes from 52s to 21s wall-clock, with per-frame cost dropping from ~330ms to ~136ms.

## Background

The classroom stress page exposed that large programs were slow in a way that scaled linearly with program size — about 1s per move on Fly perf-2x machines. Probing /run latency with programs of 5, 10, 20, 30, and 50 moves confirmed:

- Total time scales linearly with moves (no quadratic blowup).
- Per-frame intervals stay flat throughout each run (no degradation as accumulated trail boxes grow — the natural hypothesis turned out to be wrong).
- The cost is ~330ms per emitted frame, dominated by `capture_image` (pybullet TINY_RENDERER CPU rasterisation) and `env.step` (~5 steps per emitted frame, FRAME_SKIP=5).

Lowering resolution attacks the render half of that cost directly. PyBullet's CPU renderer is roughly linear in pixel count, so 4× fewer pixels predicts ~4× faster rendering. Total frame cost is render + env.step, so the headline speedup is closer to 2.5× rather than 4×.

## What changed

`src/kinder_blockly/executor.py` — `_RENDER_W` and `_RENDER_H` go from 640×360 to 320×180. Comment added explaining the rationale and the fact that the frontend img element scales the JPEG back up to fit its container, so the user-visible impact is mild pixelation rather than a smaller view.

No other changes: same physics, same motion planning, same FRAME_SKIP, same JPEG quality, same number of frames per move. Just smaller frames.

## Measurements

Same `timing_probe.py` script run before and after deploy:

| Moves | Before (640×360) | After (320×180) | Speedup |
|---|---|---|---|
| 5 | 7.62s | 2.32s | 3.3× |
| 10 | 10.63s | 4.32s | 2.5× |
| 20 | 19.35s | 8.32s | 2.3× |
| 30 | 25.10s | 12.76s | 2.0× |
| 50 | 51.96s | 20.65s | 2.5× |

Per-frame cost: 330ms → 136ms (2.4× faster).

First-frame latency also improves (0.5–0.8s → 0.2s) because rendering the initial reset frame goes through the same path.

## Why not lower still?

320×180 is small enough that the JPEG already approaches the "noticeably pixelated" threshold when scaled up to fit a typical browser viewport. Going further would degrade the visible 3D view past the point where students can read frame labels or recognise the robot pose. If we need more speed, the next lever is FRAME_SKIP, which trades motion smoothness for total time and doesn't touch image quality.

## Test plan

- [x] `./run_ci_checks.sh` passes locally.
- [x] Local visual check via `python -m kinder_blockly` + Vite dev server — frames are pixelated but the robot, trail, and frame label are all clearly readable.
- [x] Deployed to Fly; timing probe confirms the predicted speedup.
- [x] Stress page at `/static/stress.html` still works end-to-end with all five programs.
- [ ] In-classroom validation — that's the actual goal of the speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
