### PR TITLE
kinder-blockly: load a starter program on first visit

### DIFF
--- a/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
+++ b/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
@@ -438,6 +438,52 @@
   let pendingDeleteStartId = null;
   let saveTimer = null;
   const WS_KEY = 'kinder-blockly-ws-v3';
+  // Set after the first visit so we never show the starter program again,
+  // even if the user clears their workspace later.
+  const VISITED_KEY = 'kinder-blockly-visited';
+
+  // Starter workspace shown only on a browser's very first visit: pen down,
+  // move left by 1, move up by 1. Gives new students something to read and
+  // a Run button that produces a visible result immediately.
+  const STARTER_WORKSPACE = {
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: 'start',
+        // Placed up-and-left of world origin so the block sits roughly in the
+        // upper-left of the visible workspace after the default scroll(divW/2,
+        // divH/2). Without the negative offset the block lands in the bottom-
+        // right of the viewport and clips off the right edge.
+        x: -180,
+        y: -120,
+        inputs: {
+          BODY: {
+            block: {
+              type: 'pen_down',
+              next: {
+                block: {
+                  type: 'move_base_by',
+                  inputs: {
+                    INPUT_DX: { shadow: { type: 'kinder_num', fields: { NUM: -1 } } },
+                    INPUT_DY: { shadow: { type: 'kinder_num', fields: { NUM: 0 } } },
+                  },
+                  next: {
+                    block: {
+                      type: 'move_base_by',
+                      inputs: {
+                        INPUT_DX: { shadow: { type: 'kinder_num', fields: { NUM: 0 } } },
+                        INPUT_DY: { shadow: { type: 'kinder_num', fields: { NUM: 1 } } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }],
+    },
+  };
 
   function saveWorkspace() {
     if (!workspace) return;
@@ -671,9 +717,37 @@
         }
       }
 
+      // First-visit starter program: only loads if no prior workspace exists in
+      // either v3 or v2 storage AND this browser has never been here before.
+      // Subsequent visits skip this, even if the user has cleared their work.
+      if (workspace.getTopBlocks(false).length === 0 && !localStorage.getItem(VISITED_KEY)) {
+        try {
+          Blockly.serialization.workspaces.load(STARTER_WORKSPACE, workspace);
+          for (const block of workspace.getAllBlocks(false)) {
+            if (block.isShadow() || block.outputConnection) continue;
+            if (CUSTOM_COLLAPSE.has(block.type)) block.customCollapse_?.();
+            else if (!block.isCollapsed()) block.setCollapsed(true);
+          }
+        } catch {}
+      }
+      localStorage.setItem(VISITED_KEY, '1');
+
       workspace.setScale(1.5);
       workspace.scroll(blocklyDiv.clientWidth / 2, blocklyDiv.clientHeight / 2);
       updateEnabledStates();
+
+      // Re-layout once web fonts are loaded. Blockly measures glyph widths
+      // when sizing each block; if the custom retro/silkscreen font has not
+      // arrived yet, blocks get sized with fallback-font metrics and look
+      // misaligned. On a reload the font is cached so this never triggers,
+      // which is why the issue "fixes itself" after refresh.
+      document.fonts?.ready.then(() => {
+        if (!workspace || workspace.isDisposed?.()) return;
+        for (const block of workspace.getAllBlocks(false)) {
+          block.render(false);
+        }
+        Blockly.svgResize(workspace);
+      });
     });
 
     blocklyDiv.addEventListener('wheel', onWheel, { passive: false });


### PR DESCRIPTION
## Summary

On a browser's very first visit, populate the Blockly workspace with a small starter program (start → pen down → move left by 1 → move up by 1) instead of an empty workspace. New students arrive at a runnable program they can read, modify, and Run immediately, rather than staring at a blank canvas wondering what to drag where.

Also folds in a fix for a separate first-load rendering glitch where blocks looked misaligned until the page was refreshed.

## Behaviour

| Scenario | Workspace shown |
|---|---|
| First visit ever, fresh localStorage | Starter program (start → pen down → move left → move up) |
| Subsequent visit, blocks were saved | Saved workspace (existing behaviour) |
| Subsequent visit, user previously cleared their work | Empty workspace — starter does NOT re-appear |
| User clears site data and revisits | Starter program (treated as a brand new visit) |
| Legacy v2 storage migration | v2 migration path (unchanged) |

The "subsequent visit but cleared" semantics intentionally avoid re-imposing the starter on a user who deliberately deleted their work. The `kinder-blockly-visited` flag in localStorage is set unconditionally on every load to enforce that.

## Implementation notes

### Starter loading path

Loads through the same `Blockly.serialization.workspaces.load(...)` call the saved-state branch uses, so the existing change listener auto-saves the loaded blocks to localStorage within ~400 ms. On the next page load the workspace comes back through the saved-state path with the same blocks the user left.

The starter is gated on:
- No `kinder-blockly-ws-v3` saved state (would have been loaded by the existing path).
- No `kinder-blockly-ws-v2` legacy state (would have been migrated).
- No `kinder-blockly-visited` flag (set after every successful mount).
- Workspace currently has zero top blocks (`getTopBlocks(false).length === 0`).

### Block positioning

The start block is placed at world `(-180, -120)`. The existing `workspace.scroll(divW/2, divH/2)` call positions world origin at the geometric centre of the whole Blockly div (including the toolbox), which means a block at world `(0, 0)` lands roughly in the right-centre of the visible area and extends off the right edge for a multi-statement block like `start`. The negative offset anchors the block in the upper-left of the visible workspace area so all three child blocks fit inside the viewport.

### Font-load race fix (defensive, applies to all paths)

While testing the starter on Firefox incognito with non-default zoom, first-load rendering looked misaligned and a refresh fixed it. Diagnosis: Blockly measures glyph widths when sizing each block. On a cold visit the custom retro/silkscreen web font is still loading when Blockly does its initial measurement, so blocks get sized with fallback-font metrics. The real font arrives moments later, the text size changes, but the block backgrounds were already sized using the wrong metrics. On reload the font is cached so the issue disappears.

The fix is a single `document.fonts.ready.then(...)` handler at the end of workspace init that re-renders every block once the real font is available:

```js
document.fonts?.ready.then(() => {
  if (!workspace || workspace.isDisposed?.()) return;
  for (const block of workspace.getAllBlocks(false)) {
    block.render(false);
  }
  Blockly.svgResize(workspace);
});
```

Unconditional — runs whether the starter or a saved workspace was loaded. When fonts are already cached the promise resolves immediately and the re-render is a no-op cost on warm loads.

## Test plan

- [x] Fresh incognito window at 110% zoom: starter program appears in upper-left of workspace, text renders correctly on first paint (no reload needed).
- [x] Refresh same incognito window: blocks persist via saved state path.
- [x] Edit / delete starter blocks and refresh: edits persist, starter does NOT re-appear.
- [x] Clear localStorage and refresh: starter re-appears (treated as new visit).
- [x] `npm run build` succeeds without errors.
- [ ] Deployed Fly verification: first visit on cleared-cookies browser, same behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
