### PR TITLE
kinder-blockly: await Silkscreen before injecting Blockly

### DIFF
--- a/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
+++ b/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
@@ -502,7 +502,15 @@
     pendingDeleteStartId = null;
   }
 
-  onMount(() => {
+  onMount(async () => {
+    // Wait for Silkscreen before injecting Blockly. Blockly measures glyph
+    // widths during block construction, and if the retro font has not yet
+    // arrived blocks get sized with fallback-font metrics and look wrong
+    // until the next reload. document.fonts.ready is not enough here: with
+    // Google Fonts + display=swap the woff2 fetch can be deferred past the
+    // point where `ready` resolves, so request the specific face explicitly.
+    try { await document.fonts.load("12px 'Silkscreen'"); } catch {}
+
     workspace = Blockly.inject(blocklyDiv, {
       toolbox,
       theme: retroTheme,
@@ -736,18 +744,20 @@
       workspace.scroll(blocklyDiv.clientWidth / 2, blocklyDiv.clientHeight / 2);
       updateEnabledStates();
 
-      // Re-layout once web fonts are loaded. Blockly measures glyph widths
-      // when sizing each block; if the custom retro/silkscreen font has not
-      // arrived yet, blocks get sized with fallback-font metrics and look
-      // misaligned. On a reload the font is cached so this never triggers,
-      // which is why the issue "fixes itself" after refresh.
-      document.fonts?.ready.then(() => {
+      // Belt-and-braces guard: even with the pre-inject await, the FontFace
+      // for Silkscreen could in principle still be settling (e.g. cached
+      // bytes that have not finished decoding) by the time the first blocks
+      // render. Re-render once the specific face is fully ready. We use
+      // document.fonts.load rather than document.fonts.ready because the
+      // latter resolves whenever nothing is currently loading, which is not
+      // the same as "Silkscreen is available".
+      document.fonts?.load("12px 'Silkscreen'").then(() => {
         if (!workspace || workspace.isDisposed?.()) return;
         for (const block of workspace.getAllBlocks(false)) {
           block.render(false);
         }
         Blockly.svgResize(workspace);
-      });
+      }).catch(() => {});
     });
 
     blocklyDiv.addEventListener('wheel', onWheel, { passive: false });


### PR DESCRIPTION
## Summary

The previous starter-program PR (#53) added a defensive `document.fonts.ready.then(re-render)` intended to fix blocks being sized with fallback-font metrics on first paint. In practice the issue persisted: on a fresh browser, the starter program renders with wrong proportions and only "fixes itself" after a manual reload (when Silkscreen is in the HTTP cache).

### Root cause

`document.fonts.ready` resolves whenever no font is **currently** being loaded — that is not the same as "Silkscreen has loaded". With Google Fonts + `display=swap`, the woff2 fetch can be deferred past the moment `ready` resolves, so the re-render the previous fix scheduled still happened with fallback-font metrics.

### Fix

Switch to `document.fonts.load("12px 'Silkscreen'")`, which forces that specific face to begin loading (if not already) and resolves only when it is available. Apply it in two places:

- **Awaited before `Blockly.inject(...)`** in `onMount`, so the very first block render uses correct font metrics — no flicker / re-render needed in the common case. `onMount` is now async; that is fine here because cleanup lives in `onDestroy`, not in the `onMount` return value.
- **Kept on the post-load re-render** as a belt-and-braces guard for the rare case of a cached-but-not-yet-decoded FontFace at inject time.

### Not addressed

- The `await` adds a small first-paint delay for browsers without Silkscreen cached (single woff2, typically <200 ms). I did not gate this behind a timeout — if the font CDN is unreachable for several seconds, the workspace will be blank until the `try/catch` falls through. If that becomes a concern, we can race the await against `setTimeout`.
- This does not touch the `kinder` renderer or `FixedSizeMetricsManager`. If first-paint sizing still looks off after this change, those would be the next places to look (Blockly's renderer caches block dimensions, which could survive a re-render).

## Test plan

- [ ] Open the deployed site (or a local `npm run dev`) in **Incognito** so Silkscreen is not cached. Confirm the starter program renders with correct font sizing on first paint, with no visible relayout flicker.
- [ ] Open in a normal window where Silkscreen is already cached. Confirm the workspace still loads promptly and the saved workspace path looks identical to before.
- [ ] Block a `fonts.googleapis.com` request in DevTools and reload. Confirm the workspace still loads (falling back to monospace) rather than hanging on the `await`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
