### PR TITLE
kinder-blockly: drop difficulty asterisks from challenge picker

### DIFF
--- a/kinder-blockly/frontend/src/lib/Header.svelte
+++ b/kinder-blockly/frontend/src/lib/Header.svelte
@@ -19,8 +19,7 @@
   <select id="challenge-select" bind:value={selectedId} on:change={onChallengeChange}>
     <option value="">FREE DRAW</option>
     {#each challenges as c}
-      {@const stars = c.difficulty === 'easy' ? '*' : c.difficulty === 'medium' ? '**' : '***'}
-      <option value={c.id}>[{stars}] {c.name.toUpperCase()}</option>
+      <option value={c.id}>{c.name.toUpperCase()}</option>
     {/each}
   </select>
   <span id="status">{status}</span>


### PR DESCRIPTION
## Summary

Removes the `[*]` / `[**]` / `[***]` difficulty prefix from challenge options in the header select. Options now render as just the uppercased challenge name (FREE DRAW path unchanged).

The `difficulty` field on each challenge is still returned by the server and now unused only at the UI layer, so it remains available if we want to bring back a difficulty indicator later (e.g. via a colour or icon instead of asterisks).

## Test plan

- [ ] Open the workspace, click the challenge dropdown, and confirm options read like `DRAW A SQUARE` rather than `[*] DRAW A SQUARE`.
- [ ] Select a challenge and confirm it still loads / scores correctly (i.e. the value passed to `challengeChange` is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
