### PR TITLE
kinder-blockly: widen connection snap radii for chunky blocks

### DIFF
--- a/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
+++ b/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
@@ -511,6 +511,15 @@
     // point where `ready` resolves, so request the specific face explicitly.
     try { await document.fonts.load("12px 'Silkscreen'"); } catch {}
 
+    // Connection snap radii. Blockly's defaults (28 / 28 in workspace coords)
+    // are tuned for small zoom-1.0 blocks; at our 1.5× scale with chunky
+    // Silkscreen glyphs, students see two shapes visually overlapping but
+    // the underlying connection points are still further than 28 wsu apart,
+    // so the snap never fires. Bumping both radii lets the block snap as
+    // soon as the input clearly overlaps the opening.
+    Blockly.config.snapRadius = 60;
+    Blockly.config.connectingSnapRadius = 80;
+
     workspace = Blockly.inject(blocklyDiv, {
       toolbox,
       theme: retroTheme,


### PR DESCRIPTION
## Summary

Bumps Blockly's connection snap radii so blocks snap into slots as soon as they clearly overlap, rather than requiring near-pixel-perfect alignment.

### Root cause

Blockly's connection snap is **point-to-point**, not shape-overlap. Two config knobs gate it:

- `Blockly.config.snapRadius` (default `28` workspace units) — how close the dragged block's input connection point must come to an open slot's connection point for the connection to land on release.
- `Blockly.config.connectingSnapRadius` (default `28` wsu) — same threshold for the live "preview" highlight shown during dragging.

At our 1.5× default zoom plus the chunky Silkscreen glyph metrics, students see a block visibly overlapping an opening while the underlying connection points are still >28 wsu apart, so the snap silently never fires.

### Fix

Set `Blockly.config.snapRadius = 60` and `connectingSnapRadius = 80` in `BlocklyWorkspace.svelte` right before `Blockly.inject(...)`. These were eyeballed against the current slot density.

### Not addressed

- The values are tuned by feel, not measured. If two nearby slots ever start competing for the same drop in practice, the fix is to lower these numbers (or revert to defaults for slot-dense layouts).
- This does not change anything about hexagonal shape rendering — the snap was the limiting factor, not the visual shape.

## Test plan

- [ ] Drag a `param_ref` (yellow hex) toward a `move_base_by` input slot and confirm it snaps when the shapes visibly overlap, not only when perfectly aligned.
- [ ] Drag a `condition` (also hex) into the `repeat_while` slot and confirm the same.
- [ ] Drag a `kinder_num` into a movement value input; confirm rounded value blocks still snap reliably and don't accidentally hijack neighbouring slots.
- [ ] In a workspace with a `define_skill` plus several `use_skill` call sites stacked closely, confirm no slot mis-targets when dropping nearby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
