### PR TITLE
kinder-blockly: default pen colour to sky blue

### DIFF
--- a/kinder-blockly/src/kinder_blockly/executor.py
+++ b/kinder-blockly/src/kinder_blockly/executor.py
@@ -232,7 +232,11 @@ class _PenState:
     """Mutable pen state threaded through block execution."""
 
     down: bool = False
-    color_rgb: tuple[int, int, int] = (255, 0, 0)
+    # Sky blue. Chosen so that a student who skips `dip_arm` and just pens
+    # down draws in a colour that does not match any challenge target trail
+    # (challenges use red, blue, green, orange, yellow) — they fail the
+    # colour score and are nudged toward using the paint bucket.
+    color_rgb: tuple[int, int, int] = (135, 206, 235)
     prev_xy: list[float] | None = None
     trail: list[TrailSegment] = field(default_factory=list)
     events: list[PenEvent] = field(default_factory=list)


### PR DESCRIPTION
## Summary

Changes the runtime default pen colour from red `(255, 0, 0)` to sky blue `(135, 206, 235)` in `_PenState`.

### Why

A student who ran a challenge program without ever calling `dip_arm` still drew in red, which exactly matches the target colour for the Square, Diamond, and red half of the House challenges. They could pass the colour portion of the score by accident, defeating the point of forcing a paint-bucket dip.

The current challenge palette is red, blue, green, orange, yellow. Sky blue does not match any of them, so a no-dip run now visibly fails the colour score and nudges the student toward `dip_arm`.

### Scope

- Only the runtime default (the `_PenState` dataclass field in `executor.py`) changes.
- The `set_pen_color` block's UI default in `blocks.js` is **not** changed: it only matters in Free Draw, where students edit the RGB fields anyway, and the challenge runner blocks `set_pen_color` outright when paint buckets are present.

### Not addressed

- The starter program (`start → pen_down → move left → move up`) does not set a colour, so it will now draw in light blue instead of red on a new student's very first run. That seems fine, and arguably better since it doesn't suggest "red is special", but worth eyeballing.
- The colour score thresholds in `challenges.py` are unchanged. If sky blue happens to score above zero against the red target due to the scoring formula's tolerance, we can dial that up later.

## Test plan

- [ ] Open the "Square" challenge with a no-`dip_arm` program (e.g. `pen_down` + four moves). Confirm the trail draws in light blue and the colour score is clearly worse than the coverage / precision scores.
- [ ] Open the "Square" challenge with `dip_arm` into the red bucket. Confirm the trail draws red and the colour score returns to ~100.
- [ ] Run the first-visit starter program and confirm the light-blue trail looks reasonable on the dark grid.
- [ ] In Free Draw, drag out a `set_pen_color` block and confirm the default fields still read R=255 G=0 B=0 (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
