### PR TITLE
kinder-blockly: reset YOURS canvas on challenge switch

### DIFF
--- a/kinder-blockly/frontend/src/App.svelte
+++ b/kinder-blockly/frontend/src/App.svelte
@@ -111,7 +111,11 @@
   }
 
   async function onChallengeChange(id) {
+    // Clear everything tied to the previous challenge's run so the YOURS
+    // canvas, 3D frame label, and score do not bleed across challenges.
     scoreData = null;
+    studentTrail = []; studentPenEvents = [];
+    spawnedBuckets = []; allFrameLabels = [];
     if (!id) {
       currentChallenge = null; targetTrail = []; paintBuckets = []; visitedBuckets = [];
       blocklyWorkspace.setPenColorEnabled(true);


### PR DESCRIPTION
## Summary

Clears the student-run state when the challenge picker changes, so the YOURS canvas and the 3D frame label no longer leak across challenges.

### Bug

`onChallengeChange` in `App.svelte` was already resetting `scoreData` and the challenge-specific inputs (`currentChallenge`, `targetTrail`, `paintBuckets`, `visitedBuckets`) and refetching the initial frame. But it left the previous run's outputs in place:

- `studentTrail` and `studentPenEvents` — drive the YOURS canvas via a reactive `$:` in `OutputPanel.svelte`, so the canvas kept showing the trail from the previous challenge.
- `spawnedBuckets` — any buckets the previous program spawned via `spawn_paint_bucket` stayed in the merged `allPaintBuckets` overlay.
- `allFrameLabels` — `loadInitialFrame` resets `allFrames` to a single fresh frame but does not touch `allFrameLabels`, so the stale label from the previous run's first frame hung on the freshly loaded 3D image.

### Fix

One extra reset line added at the top of `onChallengeChange`, before the FREE-DRAW short-circuit, so the cleanup runs whether the user picks a new challenge or falls back to FREE DRAW.

### Not addressed

- `lastFrameDataUrl` (the fallback image shown when there is no current frame) is **not** cleared. In practice `loadInitialFrame` immediately repopulates `allFrames` with the new world's frame, so the fallback is not visible. If we ever surface that path again we may want to clear it too.

## Test plan

- [ ] Run a program on the Square challenge so the YOURS canvas has a trail. Switch to Triangle. Confirm YOURS is blank.
- [ ] After running, switch to FREE DRAW. Confirm YOURS is blank and the 3D frame has no leftover label.
- [ ] On a program that uses `spawn_paint_bucket`, run, then switch challenges. Confirm the spawned buckets do not appear in the new challenge's bucket overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
