### PR TITLE
kinder-blockly: drop count from Delete Blocks context menu

### DIFF
--- a/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
+++ b/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
@@ -536,6 +536,14 @@
       try { Blockly.ContextMenuRegistry.registry.unregister(id); } catch (_) {}
     }
 
+    // Blockly's default DELETE_X_BLOCKS label is "Delete %1 Blocks", where %1
+    // is computed from the block + every descendant in connection inputs.
+    // For our compound blocks (start/define_skill bodies, shadow number
+    // children inside movement inputs) that count is misleading — students
+    // see "Delete 4 Blocks" when right-clicking a single visible block.
+    // Drop the count entirely.
+    Blockly.Msg.DELETE_X_BLOCKS = 'Delete Blocks';
+
     try { Blockly.ContextMenuRegistry.registry.unregister('duplicateFromHere'); } catch (_) {}
     Blockly.ContextMenuRegistry.registry.register({
       id: 'duplicateFromHere',


### PR DESCRIPTION
## Summary

Removes the misleading block count from the right-click "Delete N Blocks" context menu item. The menu now simply reads "Delete Blocks".

### Why

Blockly's default `DELETE_X_BLOCKS` is `"Delete %1 Blocks"`, where `%1` is the block plus every descendant reachable through its connections. For our compound blocks that count overshoots what a student perceives:

- `start` and `define_skill` count every nested body block, even when collapsed.
- Every movement block (`move_base_to_target`, `move_base_by`, `repeat`, `set_pen_color`, `spawn_paint_bucket`) carries `kinder_num` shadow children inside its value inputs — those also count.

Net effect: right-clicking what looks like a single block can show "Delete 4 Blocks", which is confusing and visibly wrong to a kindergartener counting blocks on the screen.

Computing a "visible block count" that matches user intuition is fiddly (shadows vs. real children, collapsed vs. expanded, custom-summary inputs); dropping the count entirely is cleaner.

### Fix

Override `Blockly.Msg.DELETE_X_BLOCKS = 'Delete Blocks'` inside `onMount` in `BlocklyWorkspace.svelte`, right after the existing context-menu unregister loop. The single-block case (`DELETE_BLOCK`) is already "Delete Block" and is unchanged.

### Not addressed

- Other Blockly i18n messages with `%1` placeholders are not audited here. If similar counts surface elsewhere we will need to override them too.

## Test plan

- [ ] Right-click a leaf block (e.g. a standalone `pen_down`). Menu reads "Delete Block" (singular, unchanged).
- [ ] Right-click a `move_base_by` with its default `kinder_num` shadows attached. Menu reads "Delete Blocks" (no number).
- [ ] Right-click a `start` with several body blocks. Menu reads "Delete Blocks".
- [ ] Confirm clicking the item still deletes the block + descendants (behaviour unchanged; only the label changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
