### PR TITLE
kinder-blockly: UI error and warnings, better challenges

### DIFF
--- a/kinder-blockly/frontend/src/App.svelte
+++ b/kinder-blockly/frontend/src/App.svelte
@@ -42,6 +42,8 @@
   let tamaMsg = '';
   let tamaVisible = false;
   let tamaIsError = false;
+  let tamaIsWarning = false;
+  let tamaErrorDetail = '';
   let tamaTimer = null;
 
   const TAMA_IDLE_TIPS = [
@@ -65,22 +67,32 @@
   ];
 
   function tamaSay(msg, duration = 5000) {
-    tamaMsg = msg; tamaVisible = true; tamaIsError = false;
+    tamaMsg = msg; tamaVisible = true; tamaIsError = false; tamaIsWarning = false;
     if (tamaTimer) clearTimeout(tamaTimer);
     tamaTimer = setTimeout(() => { tamaVisible = false; }, duration);
   }
 
-  function tamaSayError(msg, duration = 6000) {
-    tamaMsg = msg; tamaVisible = true; tamaIsError = true;
+  function tamaSayError(msg, duration = 6000, detail = '') {
+    tamaMsg = msg; tamaVisible = true; tamaIsError = true; tamaIsWarning = false; tamaErrorDetail = detail;
     if (tamaTimer) clearTimeout(tamaTimer);
     tamaTimer = setTimeout(() => { tamaVisible = false; tamaIsError = false; }, duration);
   }
 
-  function tamaPoke() {
-    tamaSay(TAMA_IDLE_TIPS[Math.floor(Math.random() * TAMA_IDLE_TIPS.length)], 4000);
+  function tamaSayWarning(msg, duration = 6000) {
+    tamaMsg = msg; tamaVisible = true; tamaIsError = false; tamaIsWarning = true;
+    if (tamaTimer) clearTimeout(tamaTimer);
+    tamaTimer = setTimeout(() => { tamaVisible = false; tamaIsWarning = false; }, duration);
   }
 
-  const onKey = e => { if (e.key === 'Escape') { tamaVisible = false; tamaIsError = false; if (tamaTimer) clearTimeout(tamaTimer); } };
+  function tamaPoke() {
+    if (tamaIsError && tamaErrorDetail) {
+      tamaSayWarning(tamaErrorDetail, 6000);
+    } else {
+      tamaSay(TAMA_IDLE_TIPS[Math.floor(Math.random() * TAMA_IDLE_TIPS.length)], 4000);
+    }
+  }
+
+  const onKey = e => { if (e.key === 'Escape') { tamaVisible = false; tamaIsError = false; tamaIsWarning = false; if (tamaTimer) clearTimeout(tamaTimer); } };
   onDestroy(() => document.removeEventListener('keydown', onKey));
 
   onMount(async () => {
@@ -119,6 +131,7 @@
     if (!id) {
       currentChallenge = null; targetTrail = []; paintBuckets = []; visitedBuckets = [];
       blocklyWorkspace.setPenColorEnabled(true);
+      blocklyWorkspace.setSpawnBucketEnabled(true);
       tamaSay("FREE DRAW! No rules, no limits! Just me and the canvas. *chef's kiss*", 4000);
       await loadInitialFrame([]);
       return;
@@ -129,6 +142,7 @@
       currentChallenge = c; targetTrail = c.target_trail || [];
       paintBuckets = c.paint_buckets || []; visitedBuckets = [];
       blocklyWorkspace.setPenColorEnabled((c.paint_buckets?.length ?? 0) === 0);
+      blocklyWorkspace.setSpawnBucketEnabled(false);
       tamaSay(c.hint || c.description || 'Good luck!', 5000);
       await loadInitialFrame(paintBuckets);
     } catch { tamaSay("Failed to load challenge!", 4000); }
@@ -195,7 +209,7 @@
 
         if (doneMsg.error) {
           status = 'ERROR!';
-          tamaSayError(doneMsg.error, 7000);
+          tamaSayError(doneMsg.error, 7000, doneMsg.error_detail || '');
         } else if (doneMsg.infinite_loop) {
           status = 'LOOP!';
           tamaSayError("I'm going in circles!! My while loop ran 100 times and never stopped — I think I'm stuck forever. Could you check that condition?", 7000);
@@ -214,7 +228,16 @@
         visitedBuckets = doneMsg.visited_buckets || [];
         spawnedBuckets = doneMsg.spawned_buckets || [];
 
-        if (currentChallenge && studentTrail.length > 0) {
+        const penEvents = doneMsg.pen_events || [];
+        const penWentDown = penEvents.some(e => e.type === 'down');
+        const usedDefaultColor = penWentDown && penEvents
+          .filter(e => e.type === 'down')
+          .every(e => e.r === 128 && e.g === 128 && e.b === 128);
+        if (!penWentDown && !doneMsg.error && !doneMsg.infinite_loop && !isStopped) {
+          tamaSayWarning("Psst — my pen never touched the canvas! Try adding a PEN DOWN block so I can actually draw something.", 7000);
+        } else if (usedDefaultColor && !doneMsg.error && !doneMsg.infinite_loop && !isStopped) {
+          tamaSayWarning("I drew in default gray! Add a SET PEN COLOR block if you'd like to use a different colour.", 6000);
+        } else if (currentChallenge && studentTrail.length > 0) {
           await requestScore(currentChallenge.id, studentTrail);
         } else if (!currentChallenge && !doneMsg.error && !doneMsg.infinite_loop && !isStopped) {
           tamaSay("Nice drawing! Pick a challenge to get scored!", 4000);
@@ -258,7 +281,7 @@
     paintBuckets={allPaintBuckets} {visitedBuckets}
     showTarget={currentChallenge !== null}
     {canGoPrev} {canGoNext}
-    tamaMsg={tamaMsg} tamaVisible={tamaVisible} {tamaIsError} onTamaPoke={tamaPoke}
+    tamaMsg={tamaMsg} tamaVisible={tamaVisible} {tamaIsError} {tamaIsWarning} onTamaPoke={tamaPoke}
     on:gridClick={e => blocklyWorkspace.setMoveCoords(e.detail.x, e.detail.y)}
     on:gridDrag={e => blocklyWorkspace.setMoveDelta(e.detail.dx, e.detail.dy)}
     on:prevFrame={prevFrame}

--- a/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
+++ b/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
@@ -3,7 +3,7 @@
 
   const dispatch = createEventDispatcher();
   import * as Blockly from 'blockly';
-  import { registerBlocks, toolbox, buildToolbox } from './blocks.js';
+  import { registerBlocks, toolbox, buildToolbox, getPythonMode, setPythonMode } from './blocks.js';
   import ColorPicker from './ColorPicker.svelte';
 
   registerBlocks();
@@ -75,6 +75,12 @@
       selectedPenBlock.setFieldValue(String(b), 'B');
     } else if (selectedColorSwatch && !selectedColorSwatch.getSourceBlock()?.isDisposed()) {
       selectedColorSwatch.setRGB(r, g, b);
+      const swatchBlock = selectedColorSwatch.getSourceBlock();
+      if (swatchBlock?.type === 'spawn_paint_bucket') {
+        swatchBlock.setFieldValue(String(r), 'SR');
+        swatchBlock.setFieldValue(String(g), 'SG');
+        swatchBlock.setFieldValue(String(b), 'SB');
+      }
     } else {
       pickerVisible = false; return;
     }
@@ -151,10 +157,29 @@
   }
 
   let penColorEnabled = true;
+  let spawnBucketEnabled = true;
+
+  function rebuildToolbox() {
+    if (!workspace) return;
+    const toolbox = workspace.getToolbox();
+    const selectedName = toolbox?.getSelectedItem()?.getName?.();
+    workspace.updateToolbox(buildToolbox(penColorEnabled, spawnBucketEnabled));
+    if (selectedName) {
+      const newToolbox = workspace.getToolbox();
+      const match = (newToolbox?.getToolboxItems?.() ?? []).find(item => item.getName?.() === selectedName);
+      if (match) newToolbox.setSelectedItem(match);
+    }
+  }
 
   export function setPenColorEnabled(enabled) {
     penColorEnabled = enabled;
-    if (workspace) workspace.updateToolbox(buildToolbox(enabled));
+    rebuildToolbox();
+    setTimeout(() => updateEnabledStates(), 0);
+  }
+
+  export function setSpawnBucketEnabled(enabled) {
+    spawnBucketEnabled = enabled;
+    rebuildToolbox();
     setTimeout(() => updateEnabledStates(), 0);
   }
 
@@ -227,6 +252,7 @@
       }
       if (should) should = !hasInvalidParamRef(block);
       if (!penColorEnabled && block.type === 'set_pen_color') should = false;
+      if (!spawnBucketEnabled && (block.type === 'spawn_paint_bucket' || block.type === 'remove_paint_bucket')) should = false;
       if (block.isEnabled() !== should) block.setEnabled(should);
     }
     } finally { _updatingEnabled = false; }
@@ -257,6 +283,8 @@
       while (block) {
         if (!penColorEnabled && block.type === 'set_pen_color')
           return "This challenge uses paint buckets — remove the Set Pen Color block to run!";
+        if (!spawnBucketEnabled && (block.type === 'spawn_paint_bucket' || block.type === 'remove_paint_bucket'))
+          return "Spawn/remove bucket blocks are not available in challenges — remove them to run!";
         if (block.type === 'use_skill') {
           const defs = block.paramDefs_ || [];
           for (let i = 0; i < defs.length; i++) {
@@ -388,12 +416,20 @@
               entry.b = Number(block.getFieldValue('B'));
             }
           } else if (block.type === 'spawn_paint_bucket') {
-            const f = block.getField('COLOR');
             entry.x = getNumFromInput(block, 'INPUT_X', params);
             entry.y = getNumFromInput(block, 'INPUT_Y', params);
-            entry.r = f?.r_ ?? 255;
-            entry.g = f?.g_ ?? 0;
-            entry.b = f?.b_ ?? 0;
+            const colorBlock = block.getInput('COLOR_PARAM')?.connection?.targetBlock();
+            if (colorBlock?.type === 'param_ref') {
+              const colorVal = params?.[colorBlock.getFieldValue('PARAM')];
+              entry.r = colorVal?.type === 'color' ? colorVal.r : 0;
+              entry.g = colorVal?.type === 'color' ? colorVal.g : 0;
+              entry.b = colorVal?.type === 'color' ? colorVal.b : 0;
+            } else {
+              const f = block.getField('COLOR');
+              entry.r = f?.r_ ?? 255;
+              entry.g = f?.g_ ?? 0;
+              entry.b = f?.b_ ?? 0;
+            }
           }
           output.push(entry);
         }
@@ -488,7 +524,9 @@
   function saveWorkspace() {
     if (!workspace) return;
     try {
-      const next = JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+      const state = Blockly.serialization.workspaces.save(workspace);
+      state._pythonMode = getPythonMode();
+      const next = JSON.stringify(state);
       const prev = localStorage.getItem(WS_KEY);
       if (prev) localStorage.setItem(WS_KEY + '-backup', prev);
       localStorage.setItem(WS_KEY, next);
@@ -535,6 +573,26 @@
                        'collapseWorkspace', 'expandWorkspace', 'cleanWorkspace']) {
       try { Blockly.ContextMenuRegistry.registry.unregister(id); } catch (_) {}
     }
+
+    Blockly.ContextMenuRegistry.registry.register({
+      id: 'toggle_python_mode',
+      weight: 99,
+      scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
+      displayText: () => getPythonMode() ? 'Disable Python mode' : 'Enable Python mode',
+      preconditionFn: () => 'enabled',
+      callback: () => {
+        const collapsedIds = new Set(
+          workspace.getAllBlocks(false).filter(b => b.isCustomCollapsed_).map(b => b.id)
+        );
+        const state = Blockly.serialization.workspaces.save(workspace);
+        setPythonMode(!getPythonMode());
+        workspace.clear();
+        Blockly.serialization.workspaces.load(state, workspace);
+        for (const block of workspace.getAllBlocks(false)) {
+          if (collapsedIds.has(block.id)) block.customCollapse_?.();
+        }
+      },
+    });
 
     // Blockly's default DELETE_X_BLOCKS label is "Delete %1 Blocks", where %1
     // is computed from the block + every descendant in connection inputs.
@@ -694,7 +752,9 @@
       const saved = localStorage.getItem(WS_KEY);
       if (saved) {
         try {
-          Blockly.serialization.workspaces.load(JSON.parse(saved), workspace);
+          const parsed = JSON.parse(saved);
+          if (parsed._pythonMode) setPythonMode(true);
+          Blockly.serialization.workspaces.load(parsed, workspace);
           // Refresh use_skill blocks now that all define_skill blocks are loaded.
           // (During deserialization the SKILL field change fires before define_skill
           // blocks exist, so updateParamInputs_ may have had nothing to look up.)

--- a/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
+++ b/kinder-blockly/frontend/src/lib/BlocklyWorkspace.svelte
@@ -584,10 +584,27 @@
         const collapsedIds = new Set(
           workspace.getAllBlocks(false).filter(b => b.isCustomCollapsed_).map(b => b.id)
         );
-        const state = Blockly.serialization.workspaces.save(workspace);
-        setPythonMode(!getPythonMode());
+        let state;
+        try {
+          state = Blockly.serialization.workspaces.save(workspace);
+        } catch (e) {
+          console.error('Python mode toggle: failed to snapshot workspace, aborting.', e);
+          return;
+        }
+        const prevMode = getPythonMode();
+        setPythonMode(!prevMode);
         workspace.clear();
-        Blockly.serialization.workspaces.load(state, workspace);
+        try {
+          Blockly.serialization.workspaces.load(state, workspace);
+        } catch (e) {
+          // Loading failed — try to restore the original workspace so the
+          // student doesn't lose their program. Revert the mode flag too.
+          console.error('Python mode toggle: failed to reload workspace, restoring.', e);
+          setPythonMode(prevMode);
+          workspace.clear();
+          try { Blockly.serialization.workspaces.load(state, workspace); } catch (_) {}
+          return;
+        }
         for (const block of workspace.getAllBlocks(false)) {
           if (collapsedIds.has(block.id)) block.customCollapse_?.();
         }

--- a/kinder-blockly/frontend/src/lib/OutputPanel.svelte
+++ b/kinder-blockly/frontend/src/lib/OutputPanel.svelte
@@ -20,6 +20,7 @@
   export let tamaMsg = '';
   export let tamaVisible = false;
   export let tamaIsError = false;
+  export let tamaIsWarning = false;
   export let onTamaPoke = () => {};
 
   let el;
@@ -160,7 +161,7 @@
     {/if}
 
     <div id="tama-area">
-      <TamaBot message={tamaMsg} visible={tamaVisible} isError={tamaIsError} onPoke={onTamaPoke} />
+      <TamaBot message={tamaMsg} visible={tamaVisible} isError={tamaIsError} isWarning={tamaIsWarning} onPoke={onTamaPoke} />
     </div>
   </div>
 </div>

--- a/kinder-blockly/frontend/src/lib/TamaBot.svelte
+++ b/kinder-blockly/frontend/src/lib/TamaBot.svelte
@@ -2,12 +2,13 @@
   export let message = '';
   export let visible = false;
   export let isError = false;
+  export let isWarning = false;
   export let onPoke = () => {};
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 <div id="tama-container">
-  <div id="tama-bubble" class:visible class:error={isError} on:click={onPoke}>{message}</div>
+  <div id="tama-bubble" class:visible class:error={isError} class:warning={isWarning} on:click={onPoke}>{message}</div>
   <div id="tama-bot" on:click={onPoke} title="Click me!">
     <div id="tama-pixel"></div>
   </div>
@@ -40,6 +41,12 @@
     background: #1a0505;
     color: #fca5a5;
   }
+  #tama-bubble.warning {
+    border-color: #eab308;
+    box-shadow: var(--px) var(--px) 0 rgba(234,179,8,.4);
+    background: #1a1500;
+    color: #fde047;
+  }
   #tama-bubble::after {
     content: ''; position: absolute; right: -8px; bottom: 28px;
     width: 0; height: 0;
@@ -47,6 +54,7 @@
     border-left: 8px solid var(--accent);
   }
   #tama-bubble.error::after { border-left-color: #ef4444; }
+  #tama-bubble.warning::after { border-left-color: #eab308; }
   #tama-bot {
     flex-shrink: 0;
     width: 96px; height: 108px; position: relative;

--- a/kinder-blockly/frontend/src/lib/blocks.js
+++ b/kinder-blockly/frontend/src/lib/blocks.js
@@ -4,7 +4,9 @@ import * as Blockly from 'blockly';
 // `if __name__ == "__main__":` for start, `for _ in range(N):` for repeat).
 // When false, the same compact summary view is shown but with human-readable
 // labels that match each block's expanded form.
-const PYTHON_STYLE_LABELS = false;
+let PYTHON_STYLE_LABELS = false;
+export function getPythonMode() { return PYTHON_STYLE_LABELS; }
+export function setPythonMode(val) { PYTHON_STYLE_LABELS = val; }
 
 class FieldLabelUnderline extends Blockly.FieldLabel {
   initView() {
@@ -88,9 +90,23 @@ class FieldDropdownDark extends Blockly.FieldDropdown {
   }
 }
 
-// Like FieldDropdownDark but without forced dark text — used on dark-coloured blocks.
-class FieldDropdownPermissive extends Blockly.FieldDropdown {
+
+// Forces white text — used on dark-background blocks (define_skill, use_skill).
+class FieldDropdownLight extends Blockly.FieldDropdown {
   doClassValidation_(newVal) { return newVal ?? null; }
+  initView() { super.initView(); this.forceTextLight_(); }
+  applyColour() {
+    super.applyColour();
+    this.forceTextLight_();
+    if (this.arrow) this.arrow.style.setProperty('fill', '#ffffff', 'important');
+  }
+  render_() { super.render_(); this.forceTextLight_(); }
+  forceTextLight_() {
+    this.fieldGroup_?.querySelectorAll('text, tspan').forEach(el => {
+      el.style.setProperty('fill', '#ffffff', 'important');
+    });
+    if (this.textElement_) this.textElement_.style.setProperty('fill', '#ffffff', 'important');
+  }
 }
 
 // Walk up the parent chain to find the topmost block.
@@ -117,7 +133,7 @@ export function registerBlocks() {
   };
 
   // Parameter reference block — yellow, dropdown of params from enclosing define_skill.
-  // Supports an optional scale multiplier (e.g. -1 × SIDE) for arithmetic on params.
+  // Supports an optional scale multiplier (e.g. -1 * SIDE) for arithmetic on params.
   Blockly.Blocks['param_ref'] = {
     init: function() {
       const getOptions = function() {
@@ -130,7 +146,10 @@ export function registerBlocks() {
         let expectedKind = null;
         const parent = block.getParent();
         if (parent) {
+          const parentInput = block.outputConnection?.targetConnection?.getParentInput?.();
           if (parent.type === 'set_pen_color') expectedKind = 'color';
+          else if (parent.type === 'spawn_paint_bucket' && parentInput?.name === 'COLOR_PARAM') expectedKind = 'color';
+          else if (parent.type === 'spawn_paint_bucket') expectedKind = 'num';
           else if (parent.type === 'move_base_to_target' || parent.type === 'move_base_by'
                 || parent.type === 'repeat' || parent.type === 'condition') expectedKind = 'num';
         }
@@ -148,13 +167,24 @@ export function registerBlocks() {
         }
         return opts.length ? opts : [['(no params)', '__NONE__']];
       };
-      this.appendDummyInput()
+      this.appendDummyInput('SCALE_ROW')
         .appendField(new Blockly.FieldNumber(1), 'SCALE')
-        .appendField('×')
+        .appendField(new FieldLabelColored('*', '#000000'));
+      this.appendDummyInput('PARAM_ROW')
         .appendField(new FieldDropdownDark(getOptions), 'PARAM');
+      this.setInputsInline(true);
       this.setOutput(true, 'Param');
       this.setStyle('param_style');
-      this.setTooltip('Reference a skill parameter, optionally scaled (e.g. -1 × SIDE).');
+      this.setTooltip('Reference a skill parameter, optionally scaled (e.g. -1 * SIDE).');
+
+      this.setOnChange(function(_evt) {
+        if (this.isInFlyout) return;
+        const parentInput = this.outputConnection?.targetConnection?.getParentInput?.();
+        const parent = this.getParent();
+        const isColor = parent?.type === 'set_pen_color' ||
+          (parent?.type === 'spawn_paint_bucket' && parentInput?.name === 'COLOR_PARAM');
+        this.getInput('SCALE_ROW')?.setVisible(!isColor);
+      });
     }
   };
 
@@ -253,9 +283,9 @@ export function registerBlocks() {
         };
       }
 
-      const rField = new Blockly.FieldNumber(255, 0, 255, 1);
-      const gField = new Blockly.FieldNumber(0,   0, 255, 1);
-      const bField = new Blockly.FieldNumber(0,   0, 255, 1);
+      const rField = new Blockly.FieldNumber(128, 0, 255, 1);
+      const gField = new Blockly.FieldNumber(128, 0, 255, 1);
+      const bField = new Blockly.FieldNumber(128, 0, 255, 1);
       rField.setValidator(makeValidator('R'));
       gField.setValidator(makeValidator('G'));
       bField.setValidator(makeValidator('B'));
@@ -268,7 +298,7 @@ export function registerBlocks() {
       this.setInputsInline(true);
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
-      this.setColour('#ff0000');
+      this.setColour('#808080');
       this.setTooltip('Set the drawing colour (RGB 0-255 or a color parameter).');
 
       this.setOnChange(function(evt) {
@@ -335,7 +365,7 @@ export function registerBlocks() {
       this.appendDummyInput('HEADER')
         .appendField('Define skill')
         .appendField(new Blockly.FieldTextInput('my skill'), 'NAME')
-        .appendField(new Blockly.FieldDropdown([
+        .appendField(new FieldDropdownLight([
           ['0 params','0'],['1 param','1'],['2 params','2'],
           ['3 params','3'],['4 params','4'],['5 params','5'],
         ]), 'ARGS');
@@ -365,7 +395,7 @@ export function registerBlocks() {
           .appendField('  • ')
           .appendField(new Blockly.FieldTextInput(saved[i]?.name ?? 'param' + (i + 1)), 'PARAM_NAME_' + i)
           .appendField(' : ')
-          .appendField(new Blockly.FieldDropdown(types), 'PARAM_TYPE_' + i);
+          .appendField(new FieldDropdownLight(types), 'PARAM_TYPE_' + i);
         if (saved[i]?.type) this.setFieldValue(saved[i].type, 'PARAM_TYPE_' + i);
       }
       // Keep BODY at the end (params were appended after it).
@@ -440,7 +470,7 @@ export function registerBlocks() {
       };
       this.appendDummyInput('HEADER')
         .appendField('Use skill')
-        .appendField(new FieldDropdownPermissive(getOptions), 'SKILL');
+        .appendField(new FieldDropdownLight(getOptions), 'SKILL');
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour('#0f766e');
@@ -771,36 +801,92 @@ export function registerBlocks() {
   Blockly.Blocks['spawn_paint_bucket'] = {
     init: function() {
       this.isCustomCollapsed_ = false;
+
+      function makeSwatchValidator(ch) {
+        return function(newVal) {
+          const src = this.getSourceBlock();
+          if (!src) return newVal;
+          const r = ch === 'SR' ? Number(newVal) : Number(src.getFieldValue('SR'));
+          const g = ch === 'SG' ? Number(newVal) : Number(src.getFieldValue('SG'));
+          const b = ch === 'SB' ? Number(newVal) : Number(src.getFieldValue('SB'));
+          src.getField('COLOR')?.setRGB(r, g, b);
+          return newVal;
+        };
+      }
+
+      const rField = new Blockly.FieldNumber(255, 0, 255, 1);
+      const gField = new Blockly.FieldNumber(0,   0, 255, 1);
+      const bField = new Blockly.FieldNumber(0,   0, 255, 1);
+      rField.setValidator(makeSwatchValidator('SR'));
+      gField.setValidator(makeSwatchValidator('SG'));
+      bField.setValidator(makeSwatchValidator('SB'));
+
       this.appendValueInput('INPUT_X').setCheck(['Number', 'Param']).appendField('Spawn bucket at x');
       this.appendValueInput('INPUT_Y').setCheck(['Number', 'Param']).appendField('y');
-      this.appendDummyInput('COLOR_ROW').appendField('color').appendField(new FieldColorSwatch(), 'COLOR');
+      this.appendEndRowInput('ROW_BREAK');
+      this.appendValueInput('COLOR_PARAM').setCheck(['Param']).appendField('color');
+      this.appendDummyInput('COLOR_ROW')
+        .appendField(new FieldColorSwatch(), 'COLOR')
+        .appendField('R').appendField(rField, 'SR')
+        .appendField('G').appendField(gField, 'SG')
+        .appendField('B').appendField(bField, 'SB');
       this.setInputsInline(true);
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour(310);
       this.setTooltip('Spawn a paint bucket at (x, y) with the chosen colour.');
+
+      this.setOnChange(function(evt) {
+        if ([Blockly.Events.BLOCK_MOVE, Blockly.Events.BLOCK_CHANGE,
+             Blockly.Events.BLOCK_CREATE, Blockly.Events.BLOCK_DELETE].includes(evt.type)) {
+          if (!this.isCustomCollapsed_) {
+            const hasParam = !!this.getInput('COLOR_PARAM')?.connection?.targetBlock();
+            this.getInput('COLOR_ROW')?.setVisible(!hasParam);
+          }
+        }
+      });
     },
     customCollapse_: function() {
       this.isCustomCollapsed_ = true;
       this.getInput('INPUT_X')?.setVisible(false);
       this.getInput('INPUT_Y')?.setVisible(false);
+      this.getInput('ROW_BREAK')?.setVisible(false);
+      this.getInput('COLOR_PARAM')?.setVisible(false);
       this.getInput('COLOR_ROW')?.setVisible(false);
       if (this.getInput('SUM')) this.removeInput('SUM');
       const x = collapseValueInput(this, 'INPUT_X');
       const y = collapseValueInput(this, 'INPUT_Y');
-      const f = this.getField('COLOR');
-      const r = f?.r_ ?? 255; const g = f?.g_ ?? 0; const b = f?.b_ ?? 0;
-      this.appendDummyInput('SUM')
-        .appendField(PYTHON_STYLE_LABELS
-          ? `spawn bucket (${x.text}, ${y.text}) rgb(${r},${g},${b})`
-          : `Spawn bucket at (${x.text}, ${y.text}) color (${r}, ${g}, ${b})`);
+      const colorBlock = this.getInput('COLOR_PARAM')?.connection?.targetBlock();
+      if (colorBlock) {
+        const paramName = colorBlock.getFieldValue('PARAM') || '?';
+        const label = PYTHON_STYLE_LABELS ? 'spawn bucket(' : 'Spawn bucket at (';
+        const suffix = PYTHON_STYLE_LABELS ? `)` : `)`;
+        this.appendDummyInput('SUM')
+          .appendField(label)
+          .appendField(x.isParam ? new FieldLabelUnderline(x.text) : x.text)
+          .appendField(', ')
+          .appendField(y.isParam ? new FieldLabelUnderline(y.text) : y.text)
+          .appendField(PYTHON_STYLE_LABELS ? ', ' : ') color (')
+          .appendField(new FieldLabelUnderline(paramName))
+          .appendField(suffix);
+      } else {
+        const f = this.getField('COLOR');
+        const r = f?.r_ ?? 255; const g = f?.g_ ?? 0; const b = f?.b_ ?? 0;
+        this.appendDummyInput('SUM')
+          .appendField(PYTHON_STYLE_LABELS
+            ? `spawn bucket(${x.text}, ${y.text}, (${r},${g},${b}))`
+            : `Spawn bucket at (${x.text}, ${y.text}) color (${r}, ${g}, ${b})`);
+      }
     },
     customExpand_: function() {
       this.isCustomCollapsed_ = false;
       if (this.getInput('SUM')) this.removeInput('SUM');
       this.getInput('INPUT_X')?.setVisible(true);
       this.getInput('INPUT_Y')?.setVisible(true);
-      this.getInput('COLOR_ROW')?.setVisible(true);
+      this.getInput('ROW_BREAK')?.setVisible(true);
+      this.getInput('COLOR_PARAM')?.setVisible(true);
+      const hasParam = !!this.getInput('COLOR_PARAM')?.connection?.targetBlock();
+      this.getInput('COLOR_ROW')?.setVisible(!hasParam);
     },
   };
 
@@ -818,7 +904,7 @@ export function registerBlocks() {
   };
 }
 
-export function buildToolbox(penColorEnabled = true) {
+export function buildToolbox(penColorEnabled = true, spawnBucketEnabled = true) {
   return {
     kind: 'categoryToolbox',
     contents: [
@@ -847,11 +933,11 @@ export function buildToolbox(penColorEnabled = true) {
         { kind: 'block', type: 'pen_down' },
         { kind: 'block', type: 'pen_up' },
         { kind: 'block', type: 'dip_arm' },
-        { kind: 'block', type: 'spawn_paint_bucket', inputs: {
+        { kind: 'block', type: 'spawn_paint_bucket', disabled: !spawnBucketEnabled, inputs: {
             INPUT_X: { shadow: { type: 'kinder_num', fields: { NUM: 0 } } },
             INPUT_Y: { shadow: { type: 'kinder_num', fields: { NUM: 0 } } },
         }},
-        { kind: 'block', type: 'remove_paint_bucket' },
+        { kind: 'block', type: 'remove_paint_bucket', disabled: !spawnBucketEnabled },
       ]},
       { kind: 'category', name: 'Abstraction', colour: '#1e3a8a', contents: [
         { kind: 'block', type: 'define_skill' },

--- a/kinder-blockly/src/kinder_blockly/challenges.py
+++ b/kinder-blockly/src/kinder_blockly/challenges.py
@@ -63,92 +63,12 @@ CHALLENGES: list[dict] = [
         ),
     },
     {
-        "id": "triangle",
-        "name": "Triangle",
-        "difficulty": "easy",
-        "description": "Draw a blue triangle.",
-        "hint": "Grab the blue paint bucket first, "
-        "then connect three points to close the shape!",
-        "paint_buckets": [
-            {"id": "blue_bucket", "x": 1.5, "y": -1.5, "r": 0, "g": 80, "b": 255},
-        ],
-        "target_trail": _segments_from_waypoints(
-            [(0.0, 1.0), (1.0, -0.5), (-1.0, -0.5)],
-            r=0,
-            g=80,
-            b=255,
-            closed=True,
-        ),
-    },
-    {
-        "id": "letter_l",
-        "name": "Letter L",
-        "difficulty": "easy",
-        "description": "Draw a green letter L.",
-        "hint": "Fetch the green paint, then two straight lines: "
-        "one going down, one going right.",
-        "paint_buckets": [
-            {"id": "green_bucket", "x": 1.5, "y": 1.5, "r": 0, "g": 200, "b": 0},
-        ],
-        "target_trail": _segments_from_waypoints(
-            [(0.5, 1.0), (0.5, -0.5), (-0.5, -0.5)],
-            r=0,
-            g=200,
-            b=0,
-            closed=False,
-        ),
-    },
-    {
-        "id": "diamond",
-        "name": "Diamond",
-        "difficulty": "medium",
-        "description": "Draw a red diamond (rotated square).",
-        "hint": "Dip into the red paint first, then make four diagonal moves "
-        "connecting top, right, bottom, and left.",
-        "paint_buckets": [
-            {"id": "red_bucket", "x": 1.5, "y": -1.5, "r": 255, "g": 0, "b": 0},
-        ],
-        "target_trail": _segments_from_waypoints(
-            [(0.0, 1.0), (-1.0, 0.0), (0.0, -1.0), (1.0, 0.0)],
-            r=255,
-            g=0,
-            b=0,
-            closed=True,
-        ),
-    },
-    {
-        "id": "zigzag",
-        "name": "Zigzag",
-        "difficulty": "medium",
-        "description": "Draw an orange zigzag line from left to right.",
-        "hint": "Pick up the orange paint, then alternate "
-        "between moving up-right and down-right.",
-        "paint_buckets": [
-            {"id": "orange_bucket", "x": 1.5, "y": 1.5, "r": 255, "g": 140, "b": 0},
-        ],
-        "target_trail": _segments_from_waypoints(
-            [
-                (1.0, 0.0),
-                (0.5, 0.5),
-                (0.0, 0.0),
-                (-0.5, 0.5),
-                (-1.0, 0.0),
-            ],
-            r=255,
-            g=140,
-            b=0,
-            closed=False,
-        ),
-    },
-    {
         "id": "house",
         "name": "House",
-        "difficulty": "hard",
+        "difficulty": "easy",
         "description": "Draw a house: red square base with a blue triangle roof.",
         "hint": "Find the red paint bucket first, dip your arm in, then draw the square "
         "base. Next, find the blue bucket, dip again, and draw the triangle roof!",
-        # Two paint buckets in the lower corners of the world (robot coords),
-        # clear of the house drawing which occupies the upper-centre region.
         "paint_buckets": [
             {"id": "red_bucket", "x": 1.5, "y": -1.5, "r": 255, "g": 0, "b": 0},
             {"id": "blue_bucket", "x": 1.5, "y": 1.5, "r": 0, "g": 80, "b": 255},
@@ -157,44 +77,68 @@ CHALLENGES: list[dict] = [
             # base (red square)
             _segments_from_waypoints(
                 [(0.5, -0.5), (0.5, 0.5), (0.0, 0.5), (0.0, -0.5)],
-                r=255,
-                g=0,
-                b=0,
+                r=255, g=0, b=0,
                 closed=True,
             )
             +
             # roof (blue triangle)
             _segments_from_waypoints(
                 [(0.0, -0.5), (-1.0, 0.0), (0.0, 0.5)],
-                r=0,
-                g=80,
-                b=255,
+                r=0, g=80, b=255,
                 closed=False,
             )
         ),
     },
     {
-        "id": "star",
-        "name": "Star",
-        "difficulty": "hard",
-        "description": "Draw a yellow five-pointed star.",
-        "hint": "Get the yellow paint first, then connect every other vertex "
-        "of a regular pentagon to draw the star.",
+        "id": "fast_forward",
+        "name": "Fast Forward",
+        "difficulty": "medium",
+        "description": "Draw a blue fast-forward icon: two right-pointing triangles.",
+        "hint": "Grab the blue paint bucket, then draw two triangles side by side — "
+        "each one points to the right!",
         "paint_buckets": [
-            {"id": "yellow_bucket", "x": 1.5, "y": -1.5, "r": 220, "g": 180, "b": 0},
+            {"id": "blue_bucket", "x": 1.5, "y": -1.5, "r": 0, "g": 80, "b": 255},
         ],
-        "target_trail": _segments_from_waypoints(
-            [
-                (0.0, 1.0),
-                (-0.5, -0.5),
-                (1.0, 0.5),
-                (-1.0, 0.5),
-                (0.5, -0.5),
-            ],
-            r=220,
-            g=180,
-            b=0,
-            closed=True,
+        "target_trail": (
+            _segments_from_waypoints(
+                [(1.0, -1.0), (0.0, 0.0), (-1.0, -1.0)],
+                r=0, g=80, b=255,
+                closed=True,
+            )
+            + _segments_from_waypoints(
+                [(1.0, 0.0), (0.0, 1.0), (-1.0, 0.0)],
+                r=0, g=80, b=255,
+                closed=True,
+            )
+        ),
+    },
+    {
+        "id": "four_squares",
+        "name": "Four Squares",
+        "difficulty": "hard",
+        "description": "Draw a 2×2 grid of green squares centered at the origin.",
+        "hint": "Dip into the green paint bucket, then draw four 1×1 squares "
+        "arranged in a 2×2 grid — they share edges in the middle!",
+        "paint_buckets": [
+            {"id": "green_bucket", "x": 1.5, "y": 1.5, "r": 0, "g": 200, "b": 0},
+        ],
+        "target_trail": (
+            _segments_from_waypoints(
+                [(-1.0, -1.0), (-1.0, 0.0), (0.0, 0.0), (0.0, -1.0)],
+                r=0, g=200, b=0, closed=True,
+            )
+            + _segments_from_waypoints(
+                [(0.0, -1.0), (0.0, 0.0), (1.0, 0.0), (1.0, -1.0)],
+                r=0, g=200, b=0, closed=True,
+            )
+            + _segments_from_waypoints(
+                [(-1.0, 0.0), (-1.0, 1.0), (0.0, 1.0), (0.0, 0.0)],
+                r=0, g=200, b=0, closed=True,
+            )
+            + _segments_from_waypoints(
+                [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)],
+                r=0, g=200, b=0, closed=True,
+            )
         ),
     },
 ]
@@ -304,7 +248,7 @@ def score_trail(
                 break
     precision = precise / len(student_pts)
 
-    color_score = sum(color_diffs) / len(color_diffs) if color_diffs else 0.0
+    color_score = min(1.0, sum(color_diffs) / len(color_diffs)) if color_diffs else 0.0
 
     raw = 0.45 * coverage + 0.30 * precision + 0.25 * color_score
     final = round(raw * 100)
@@ -314,6 +258,6 @@ def score_trail(
         "breakdown": {
             "coverage": round(coverage * 100),
             "precision": round(precision * 100),
-            "color": round(color_score * 100),
+            "color": 100 if round(color_score * 100) == 99 else round(color_score * 100),
         },
     }

--- a/kinder-blockly/src/kinder_blockly/executor.py
+++ b/kinder-blockly/src/kinder_blockly/executor.py
@@ -236,7 +236,7 @@ class _PenState:
     # down draws in a colour that does not match any challenge target trail
     # (challenges use red, blue, green, orange, yellow) — they fail the
     # colour score and are nudged toward using the paint bucket.
-    color_rgb: tuple[int, int, int] = (135, 206, 235)
+    color_rgb: tuple[int, int, int] = (128, 128, 128)
     prev_xy: list[float] | None = None
     trail: list[TrailSegment] = field(default_factory=list)
     events: list[PenEvent] = field(default_factory=list)
@@ -372,13 +372,31 @@ def validate_program(program: dict[str, Any]) -> dict[str, Any]:
                 ry = float(blk.get("x", 0.0))
                 err = _oob_error(rx, ry)
                 if err:
-                    return {"error": err, "error_block_id": block_id}
+                    ui_x = float(blk.get("x", 0.0))
+                    ui_y = float(blk.get("y", 0.0))
+                    detail = (
+                        f"Target ({ui_x:g}, {ui_y:g}) is outside my world. "
+                        "Both X and Y must stay between -2 and 2."
+                    )
+                    return {"error": err, "error_detail": detail, "error_block_id": block_id}
                 pos[0], pos[1] = rx, ry
 
             elif btype == "move_base_by":
-                # Real executor clips; abstract sim mirrors that.
-                pos[0] = max(-2.0, min(2.0, pos[0] - float(blk.get("dy", 0.0))))
-                pos[1] = max(-2.0, min(2.0, pos[1] + float(blk.get("dx", 0.0))))
+                new_rx = pos[0] - float(blk.get("dy", 0.0))
+                new_ry = pos[1] + float(blk.get("dx", 0.0))
+                err = _oob_error(new_rx, new_ry)
+                if err:
+                    cur_ui_x = pos[1] + 0.0
+                    cur_ui_y = -pos[0] + 0.0
+                    dx = float(blk.get("dx", 0.0))
+                    dy = float(blk.get("dy", 0.0))
+                    detail = (
+                        f"I'm at ({cur_ui_x:g}, {cur_ui_y:g}). "
+                        f"Moving by ({dx:g}, {dy:g}) would reach ({new_ry + 0.0:g}, {-new_rx + 0.0:g}) — "
+                        "outside the -2 to 2 bounds!"
+                    )
+                    return {"error": err, "error_detail": detail, "error_block_id": block_id}
+                pos[0], pos[1] = new_rx, new_ry
 
             elif btype == "repeat_while":
                 var = blk.get("var", "X")

--- a/kinder-blockly/src/kinder_blockly/executor.py
+++ b/kinder-blockly/src/kinder_blockly/executor.py
@@ -378,7 +378,11 @@ def validate_program(program: dict[str, Any]) -> dict[str, Any]:
                         f"Target ({ui_x:g}, {ui_y:g}) is outside my world. "
                         "Both X and Y must stay between -2 and 2."
                     )
-                    return {"error": err, "error_detail": detail, "error_block_id": block_id}
+                    return {
+                        "error": err,
+                        "error_detail": detail,
+                        "error_block_id": block_id,
+                    }
                 pos[0], pos[1] = rx, ry
 
             elif btype == "move_base_by":
@@ -390,12 +394,17 @@ def validate_program(program: dict[str, Any]) -> dict[str, Any]:
                     cur_ui_y = -pos[0] + 0.0
                     dx = float(blk.get("dx", 0.0))
                     dy = float(blk.get("dy", 0.0))
+                    dest = f"({new_ry + 0.0:g}, {-new_rx + 0.0:g})"
                     detail = (
                         f"I'm at ({cur_ui_x:g}, {cur_ui_y:g}). "
-                        f"Moving by ({dx:g}, {dy:g}) would reach ({new_ry + 0.0:g}, {-new_rx + 0.0:g}) — "
+                        f"Moving by ({dx:g}, {dy:g}) would reach {dest} — "
                         "outside the -2 to 2 bounds!"
                     )
-                    return {"error": err, "error_detail": detail, "error_block_id": block_id}
+                    return {
+                        "error": err,
+                        "error_detail": detail,
+                        "error_block_id": block_id,
+                    }
                 pos[0], pos[1] = new_rx, new_ry
 
             elif btype == "repeat_while":

--- a/kinder-blockly/src/kinder_blockly/server.py
+++ b/kinder-blockly/src/kinder_blockly/server.py
@@ -195,6 +195,7 @@ def run_program() -> Response:
                 {
                     "type": "done",
                     "error": validation.get("error"),
+                    "error_detail": validation.get("error_detail"),
                     "infinite_loop": validation.get("infinite_loop", False),
                     "error_block_id": validation.get("error_block_id"),
                     "trail": [],


### PR DESCRIPTION
* OOB error on `move_base_by`; clicking the red bubble shows a yellow detail message with the exact position
* Right-click workspace to toggle Python mode (persists across reloads); `spawn bucket` label uses `spawn bucket(x, y, (r,g,b))` syntax
* `spawn_paint_bucket` uses two-row expanded layout and accepts color params; `param_ref` multiplier hidden for color-typed params
* `define_skill` / `use_skill` dropdowns use white text; TidyBot warns in yellow if pen never goes down or stays default gray
* Challenges updated: Square → House (easy) → Fast Forward (medium) → Four Squares (hard); Fast Forward icon fixed to point right; color score 99% rounds up to 100%