### PR TITLE
kinder-blockly: scale Fly.io down to idle sizing post-event

### DIFF
--- a/kinder-blockly/fly.toml
+++ b/kinder-blockly/fly.toml
@@ -1,21 +1,21 @@
 # Fly.io deployment for the Blockly server.
 #
 # Sizing notes:
-# - Each machine runs 2 gunicorn workers (matches 2 dedicated vCPUs).
-# - Each worker pre-warms one pybullet env (~300-500 MB resident baseline).
-# - performance-2x gives dedicated CPU so per-run latency does not depend on
-#   noisy neighbours on the shared pool. Important during classroom sessions
-#   where 20+ students may be running programs simultaneously.
-# - 4 GB memory leaves ~1.5 GB headroom per worker, enough to absorb large
-#   student programs (long repeat_while loops, many trail segments, paint
-#   bucket spawns) and slow pybullet leaks between worker restarts.
+# - Each machine runs 2 gunicorn workers.
+# - Each worker pre-warms one pybullet env (~300-500 MB resident baseline),
+#   so 2 GB memory leaves only modest headroom — adequate for occasional /
+#   single-user traffic but not for concurrent classroom load.
+# - shared-cpu-2x is the idle-period sizing. Per-run latency may vary with
+#   neighbour activity; that's acceptable when no class is in session.
+# - Before a classroom session, upsize to performance-2x / 4 GB (the
+#   previous classroom configuration) via `fly scale vm performance-2x
+#   --memory 4096` and bump count with `fly scale count 15+`.
 # - soft_limit = 2 (= worker count) tells Fly to route to another machine
 #   before queueing requests on this one. hard_limit = 3 gives one slot of
 #   buffer for short /reset and /healthz calls between long /run streams.
 #
 # Total fleet capacity is set by `fly scale count <N>`, not this file. With
-# auto_stop_machines = "suspend", idle machines suspend to near-zero cost,
-# so it is safe to provision well above steady-state demand.
+# auto_stop_machines = "suspend", idle machines suspend to near-zero cost.
 
 app = "kinder-blockly"
 primary_region = "iad"
@@ -53,5 +53,5 @@ primary_region = "iad"
     path = "/healthz"
 
 [[vm]]
-  size = "performance-2x"
-  memory = "4gb"
+  size = "shared-cpu-2x"
+  memory = "2gb"


### PR DESCRIPTION
## Summary
- Drops the Fly.io VM size from `performance-2x` / 4 GB to `shared-cpu-2x` / 2 GB to match post-event traffic levels.
- Updates the sizing-notes comment block in `fly.toml` to describe what this sizing is for (idle-period / occasional use) and how to upsize before the next classroom session.
- Fleet count was scaled down out-of-band from 10 → 2 via `fly scale count 2` (count is imperative, not tracked in `fly.toml`).

## Rationale
The main classroom event is over, so the perf-2x/4GB × 10 sizing (chosen for concurrent classroom load per PR #47) is no longer needed. shared-cpu-2x / 2 GB is tight-but-workable for the current 2 gunicorn workers (each pre-warms one pybullet env at ~300–500 MB resident) for the occasional / single-user traffic we now expect. Suspended machines were already near-zero cost, so the count drop is minor savings; the VM downsize is where the actual reduction comes from.

`min_machines_running = 1` and `auto_start_machines = true` mean one machine stays warm and the second auto-starts on demand — no cold-start hit for the first user.

## Results
Deployed and verified on the live app:
- Before: 10 × performance-2x / 4 GB in `iad` (1 started, 4 suspended, 5 stopped).
- After: 2 × shared-cpu-2x / 2 GB in `iad` (1 started, 1 stopped), on deployment version 17.
- `curl https://kinder-blockly.fly.dev/healthz` → 200.
- `./run_ci_checks.sh` green inside the `uv` venv.

## Upsize path (documented in fly.toml)
Before a known classroom session:

    fly scale vm performance-2x --memory 4096
    fly scale count 15+

## Not addressed
- No changes to the legacy Heroku + GCP hot spare at `blockly.prpl-group.com/blockly`.
- `GUNICORN_WORKERS=2` is unchanged. With 2 GB memory and ~300–500 MB per worker baseline, headroom is modest; if pybullet memory grows we may want to drop to 1 worker (or revert VM size) — flagging rather than pre-emptively changing.
- Concurrency limits (`soft_limit = 2`, `hard_limit = 3`) unchanged; they still match the worker count.
- No load-test rerun against the new sizing — shared CPU latency variance is expected and acceptable for idle-period traffic, but it has not been measured.

## Test plan
- [x] `fly deploy` succeeded with rolling strategy on both machines
- [x] `/healthz` returns 200 on the deployed app
- [x] `./run_ci_checks.sh` passes
- [x] Manual: load https://kinder-blockly.fly.dev/ and run one Blockly program end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
