### PR TITLE
BilevelPlanningAgent subclasses PlanningAgent

### DIFF
--- a/kinder-bilevel-planning/pyproject.toml
+++ b/kinder-bilevel-planning/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
    "hydra-joblib-launcher",
    "omegaconf",
    "kindergarden>=0.1.0",
-   "prpl_utils>=0.0.1",
+   "prpl_utils>=0.0.7",
    "relational_structs>=0.0.1",
    "tomsgeoms2d>=0.0.1",
    "pybullet_helpers>=0.0.1",

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/agent.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/agent.py
@@ -21,18 +21,26 @@ from bilevel_planning.utils import (
     RelationalAbstractSuccessorGenerator,
     RelationalControllerGenerator,
 )
-from prpl_utils.gym_agent import Agent
+from prpl_utils.planning_agent import PlanningAgent
 
 _O = TypeVar("_O", bound=Hashable)
 _U = TypeVar("_U", bound=Hashable)
+_X = TypeVar("_X", bound=Hashable)
 
 
 class AgentFailure(BaseException):
     """Raised when the agent fails to find a plan."""
 
 
-class BilevelPlanningAgent(Agent[_O, _U]):
-    """A general interface for an agent that runs bilevel planning."""
+class BilevelPlanningAgent(PlanningAgent[_O, _U, _X]):
+    """A general interface for an agent that runs bilevel planning.
+
+    The full state-action trajectory is computed once in :meth:`reset` and
+    cached. Callers using the per-action :meth:`Agent.step` API pop actions one
+    at a time; callers using the per-trajectory :meth:`plan` API receive the
+    whole (state, action) sequence in one call. Mixing the two within an
+    episode is unsupported.
+    """
 
     def __init__(
         self,
@@ -45,7 +53,14 @@ class BilevelPlanningAgent(Agent[_O, _U]):
         planning_timeout: float = 30.0,
     ) -> None:
         self._env_models = env_models
+        # `_current_plan` is the remaining action queue consumed by `_get_action`.
+        # `_planned_states` / `_planned_actions` are the immutable record of what
+        # the planner returned in the last `reset`, used by `plan` to expose the
+        # full state-action trajectory.
         self._current_plan: list[_U] | None = None
+        self._planned_states: list[_X] = []
+        self._planned_actions: list[_U] = []
+        self._plan_consumed: bool = False
         self._max_abstract_plans = max_abstract_plans
         self._samples_per_step = samples_per_step
         self._max_skill_horizon = max_skill_horizon
@@ -60,14 +75,28 @@ class BilevelPlanningAgent(Agent[_O, _U]):
         info: dict[str, Any],
     ) -> None:
         super().reset(obs, info)
-        self._current_plan = self._run_planning()
+        self._planned_states, self._planned_actions = self._run_planning()
+        self._current_plan = list(self._planned_actions)
+        self._plan_consumed = False
 
     def _get_action(self) -> _U:
         if not self._current_plan:
             raise AgentFailure("Ran out of planning steps, failure!")
         return self._current_plan.pop(0)
 
-    def _run_planning(self) -> list[_U]:
+    def plan(self) -> list[tuple[_X, _U]]:
+        """Return the full state-action trajectory from the last reset.
+
+        The bilevel planner produces a single plan in :meth:`reset` and does not
+        replan, so the second call within an episode raises :class:`AgentFailure`
+        — matching the per-action exhaust behaviour of :meth:`Agent.step`.
+        """
+        if self._plan_consumed:
+            raise AgentFailure("Ran out of planning steps, failure!")
+        self._plan_consumed = True
+        return list(zip(self._planned_states[:-1], self._planned_actions))
+
+    def _run_planning(self) -> tuple[list[_X], list[_U]]:
         # Create planning problem.
         initial_state = self._env_models.observation_to_state(self._last_observation)
         goal = self._env_models.goal_deriver(initial_state)
@@ -121,4 +150,4 @@ class BilevelPlanningAgent(Agent[_O, _U]):
         if plan is None:
             raise AgentFailure("No plan found")
 
-        return plan.actions
+        return plan.states, plan.actions

--- a/kinder-bilevel-planning/tests/env_models/dynamic2d/test_dynpushpullhook2d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic2d/test_dynpushpullhook2d.py
@@ -381,6 +381,14 @@ def test_dynpushpullhook2d_bilevel_planning_agent():
     plan = agent._current_plan  # pylint: disable=protected-access
     assert plan is not None and len(plan) > 0, "Agent should have a non-empty plan"
 
+    # The new PlanningAgent.plan() entry point exposes the same trajectory as
+    # (state, action) pairs. Calling it before any agent.step() is intentional:
+    # plan() and step() share an underlying plan but track consumption
+    # independently, so this check doesn't disturb the execution phase below.
+    trajectory = agent.plan()
+    assert len(trajectory) == len(plan)
+    assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in trajectory)
+
     # Execution phase.
     success = False
     for _ in range(3000):


### PR DESCRIPTION
## Summary

Part 2 of a three-PR change. Depends on [prpl-mono#470](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono/pull/470), which adds the `PlanningAgent` abstract base. Hold for merge until the prpl-tidybot side (PR3) is also up.

- `BilevelPlanningAgent[_O, _U]` → `BilevelPlanningAgent[_O, _U, _X]`, subclassing the new `PlanningAgent` instead of plain `Agent`.
- Adds `plan() -> list[tuple[_X, _U]]` that pairs `plan.states[:-1]` with `plan.actions` from the bilevel planner's `Plan` struct. Second call within an episode raises `AgentFailure`, matching the per-action exhaust behaviour of `Agent.step`.
- `_current_plan` is preserved as the popped action queue for per-action `step()` consumers. `plan()` and `step()` share the underlying plan but track consumption independently (`plan()` flips a `_plan_consumed` flag; `step()` pops the queue), so the two contracts coexist without interfering. Mixing them in one rollout is still unsupported by contract.

## Test plan

- [x] `./run_ci_checks.sh` in `kinder-bilevel-planning/` — mypy clean, pylint clean, 74 tests + 1 notebook pass.
- [x] The three previously `_current_plan`-touching tests (`test_dynpushpullhook2d_bilevel_planning_agent`, `test_tidybot3d_cupboard_bilevel_planning`, `test_tidybot3d_sweep_bilevel_planning`) still pass with the restructured internals.
- [x] Added a `plan()` assertion to `test_dynpushpullhook2d_bilevel_planning_agent` to verify the new method returns `(state, action)` pairs of the expected length and shape.
