### PR TITLE
Add bilevel planning models for kinder/Ground3D

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/ground3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/ground3d.py
@@ -1,0 +1,180 @@
+"""Bilevel planning models for the Ground3D environment.
+
+Simplification of shelf3d.py for the "pick a cube off the floor" task:
+
+* No `Kinematic3DFixtureType` — Ground3D has no shelf to place on.
+* Predicates: `OnGround`, `Holding`, `HandEmpty` (drop `OnFixture`).
+* Single `Pick` operator (drop `Place`, even though
+  `kinder_models.kinematic3d.ground3d.parameterized_skills` exposes a
+  place controller — Ground3D's goal is just to grasp).
+* Goal: `Holding(robot, cube0)` — the planner picks the first declared
+  cube. For Ground3D-o1 there's only one cube so this is unambiguous;
+  for Ground3D-o{>1} any obstructing cubes still surface in the state
+  abstractor but only `cube0` is the goal target.
+"""
+
+import numpy as np
+from bilevel_planning.structs import (
+    LiftedSkill,
+    RelationalAbstractGoal,
+    RelationalAbstractState,
+    SesameModels,
+)
+from gymnasium.spaces import Space
+from kinder.envs.kinematic3d.ground3d import (
+    Ground3DObjectCentricState,
+    Kinematic3DRobotType,
+    ObjectCentricGround3DEnv,
+)
+from kinder.envs.kinematic3d.object_types import Kinematic3DCuboidType
+from kinder.envs.kinematic3d.utils import (
+    Kinematic3DRobotActionSpace,
+)
+from kinder_models.kinematic3d.ground3d.parameterized_skills import (
+    create_lifted_controllers,
+)
+from numpy.typing import NDArray
+from relational_structs import (
+    GroundAtom,
+    LiftedAtom,
+    LiftedOperator,
+    ObjectCentricState,
+    Predicate,
+    Variable,
+)
+from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
+
+GRIPPER_OPEN_THRESHOLD = 0.01
+
+
+def create_bilevel_planning_models(
+    observation_space: Space,
+    action_space: Space,
+    num_objects: int = 1,
+) -> SesameModels:
+    """Create the env models for Ground3D."""
+    assert isinstance(observation_space, ObjectCentricBoxSpace)
+    assert isinstance(action_space, Kinematic3DRobotActionSpace)
+
+    sim = ObjectCentricGround3DEnv(num_cubes=num_objects, allow_state_access=True)
+
+    # Convert observations into states. The important thing is that states are hashable.
+    def observation_to_state(o: NDArray[np.float32]) -> ObjectCentricState:
+        """Convert the vectors back into (hashable) object-centric states."""
+        return observation_space.devectorize(o)
+
+    # Create the transition function.
+    def transition_fn(
+        x: ObjectCentricState,
+        u: NDArray[np.float32],
+    ) -> ObjectCentricState:
+        """Simulate the action."""
+        state = x.copy()
+        assert isinstance(state, Ground3DObjectCentricState)
+        sim.set_state(state)
+        obs, _, _, _, _ = sim.step(u)
+        return obs.copy()
+
+    # Types.
+    types = {Kinematic3DCuboidType, Kinematic3DRobotType}
+
+    # Create the state space.
+    state_space = ObjectCentricStateSpace(types)
+
+    # Predicates.
+    OnGround = Predicate("OnGround", [Kinematic3DCuboidType])
+    Holding = Predicate("Holding", [Kinematic3DRobotType, Kinematic3DCuboidType])
+    HandEmpty = Predicate("HandEmpty", [Kinematic3DRobotType])
+    predicates = {OnGround, Holding, HandEmpty}
+
+    # State abstractor.
+    def state_abstractor(x: ObjectCentricState) -> RelationalAbstractState:
+        """Get the abstract state for the current state."""
+        robot = x.get_objects(Kinematic3DRobotType)[0]
+        target_objects = x.get_objects(Kinematic3DCuboidType)
+
+        atoms: set[GroundAtom] = set()
+
+        assert isinstance(x, Ground3DObjectCentricState)
+        sim.set_state(x)
+
+        # OnGround.
+        on_ground_tol = 0.01
+        for target in target_objects:
+            z = x.get(target, "pose_z")
+            bb_z = x.get(target, "half_extent_z")
+            if np.isclose(z, bb_z, atol=on_ground_tol):
+                atoms.add(GroundAtom(OnGround, [target]))
+
+        # HandEmpty.
+        if x.grasped_object is None:
+            if x.get(robot, "finger_state") < GRIPPER_OPEN_THRESHOLD:
+                atoms.add(GroundAtom(HandEmpty, [robot]))
+
+        # Holding.
+        for target in target_objects:
+            if (
+                x.get(target, "pose_z") > 0.3
+                and x.get(robot, "finger_state") > GRIPPER_OPEN_THRESHOLD
+            ):
+                if target.name == x.grasped_object:
+                    atoms.add(GroundAtom(Holding, [robot, target]))
+
+        objects = {robot} | set(target_objects)
+        return RelationalAbstractState(atoms, objects)
+
+    # Goal abstractor.
+    def goal_deriver(x: ObjectCentricState) -> RelationalAbstractGoal:
+        """The goal is to hold the first cube.
+
+        Any obstructing cubes (Ground3D-o{>1}) appear in the state abstractor but are
+        not themselves goal targets — the planner picks them up only if it needs to
+        clear them out of the way of cube0.
+        """
+        target_objects = x.get_objects(Kinematic3DCuboidType)
+        robot = x.get_objects(Kinematic3DRobotType)[0]
+        atoms: set[GroundAtom] = {
+            GroundAtom(Holding, [robot, target_objects[0]]),
+        }
+        return RelationalAbstractGoal(atoms, state_abstractor)
+
+    # Operators.
+    robot_var = Variable("?robot", Kinematic3DRobotType)
+    target_var = Variable("?target", Kinematic3DCuboidType)
+
+    PickOperator = LiftedOperator(
+        "Pick",
+        [robot_var, target_var],
+        preconditions={
+            LiftedAtom(HandEmpty, [robot_var]),
+            LiftedAtom(OnGround, [target_var]),
+        },
+        add_effects={LiftedAtom(Holding, [robot_var, target_var])},
+        delete_effects={
+            LiftedAtom(HandEmpty, [robot_var]),
+            LiftedAtom(OnGround, [target_var]),
+        },
+    )
+
+    # Get lifted controllers from kinder_models. The ground3d skills package
+    # also exposes "place" but Ground3D doesn't need it — the goal is grasping.
+    lifted_controllers = create_lifted_controllers(action_space, sim)
+    PickController = lifted_controllers["pick"]
+
+    skills = {
+        LiftedSkill(PickOperator, PickController),
+    }
+
+    # Finalize the models.
+    return SesameModels(
+        observation_space,
+        state_space,
+        action_space,
+        transition_fn,
+        types,
+        predicates,
+        observation_to_state,
+        state_abstractor,
+        goal_deriver,
+        skills,
+    )

--- a/kinder-bilevel-planning/tests/env_models/geom3d/test_ground3d.py
+++ b/kinder-bilevel-planning/tests/env_models/geom3d/test_ground3d.py
@@ -1,0 +1,214 @@
+"""Tests for ground3d.py."""
+
+import kinder
+import numpy as np
+import pytest
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+
+from kinder_bilevel_planning.agent import BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+kinder.register_all_environments()
+
+
+def test_ground3d_observation_to_state():
+    """Tests for observation_to_state() in the Ground3D environment."""
+    env = kinder.make("kinder/Ground3D-o1-v0")
+    env_models = create_bilevel_planning_models(
+        "ground3d", env.observation_space, env.action_space
+    )
+    observation_to_state = env_models.observation_to_state
+    obs, _ = env.reset(seed=123)
+    state = observation_to_state(obs)
+    assert isinstance(hash(state), int)
+    assert env_models.state_space.contains(state)
+    assert env_models.observation_space == env.observation_space
+    env.close()
+
+
+def test_ground3d_transition_fn():
+    """Tests for transition_fn() in the Ground3D environment."""
+    env = kinder.make("kinder/Ground3D-o1-v0")
+    env.action_space.seed(123)
+    env_models = create_bilevel_planning_models(
+        "ground3d", env.observation_space, env.action_space
+    )
+    transition_fn = env_models.transition_fn
+    obs, _ = env.reset(seed=123)
+    state = env_models.observation_to_state(obs)
+
+    for _ in range(10):
+        executable = env.action_space.sample()
+        next_state = transition_fn(state, executable)
+        assert env_models.state_space.contains(next_state)
+        assert isinstance(hash(next_state), int)
+        state = next_state
+    env.close()
+
+
+def test_ground3d_goal_deriver():
+    """Tests for goal_deriver() in the Ground3D environment.
+
+    The goal is a single `Holding(robot, cube0)` atom, regardless of how many cubes the
+    variant has.
+    """
+    env = kinder.make("kinder/Ground3D-o1-v0")
+    env_models = create_bilevel_planning_models(
+        "ground3d", env.observation_space, env.action_space
+    )
+    goal_deriver = env_models.goal_deriver
+    obs, _ = env.reset(seed=123)
+    state = env_models.observation_to_state(obs)
+    goal = goal_deriver(state)
+    assert len(goal.atoms) == 1
+    env.close()
+
+
+def test_ground3d_state_abstractor():
+    """Tests for state_abstractor() in the Ground3D environment.
+
+    Initially the hand should be empty and the cube should be on the ground.
+    """
+    env = kinder.make("kinder/Ground3D-o1-v0")
+    env_models = create_bilevel_planning_models(
+        "ground3d", env.observation_space, env.action_space
+    )
+    state_abstractor = env_models.state_abstractor
+    pred_name_to_pred = {p.name: p for p in env_models.predicates}
+    OnGround = pred_name_to_pred["OnGround"]
+    Holding = pred_name_to_pred["Holding"]
+    HandEmpty = pred_name_to_pred["HandEmpty"]
+
+    obs, _ = env.reset(seed=123)
+    state = env_models.observation_to_state(obs)
+    abstract_state = state_abstractor(state)
+    obj_name_to_obj = {o.name: o for o in abstract_state.objects}
+    robot = obj_name_to_obj["robot"]
+    target = obj_name_to_obj["cube0"]
+
+    assert HandEmpty([robot]) in abstract_state.atoms
+    assert OnGround([target]) in abstract_state.atoms
+    assert Holding([robot, target]) not in abstract_state.atoms
+
+    env.close()
+
+
+def _skill_test_helper(ground_skill, env_models, env, obs, params=None):
+    """Helper function to test a skill execution."""
+    rng = np.random.default_rng(123)
+    state = env_models.observation_to_state(obs)
+    abstract_state = env_models.state_abstractor(state)
+    operator = ground_skill.operator
+    assert operator.preconditions.issubset(abstract_state.atoms)
+    controller = ground_skill.controller
+    if params is None:
+        params = controller.sample_parameters(state, rng)
+    controller.reset(state, params)
+    for _ in range(500):
+        action = controller.step()
+        obs, _, _, _, _ = env.step(action)
+        next_state = env_models.observation_to_state(obs)
+        controller.observe(next_state)
+        state = next_state
+
+        if controller.terminated():
+            break
+    return obs
+
+
+def test_ground3d_skills():
+    """Tests that the Pick skill picks up the cube as expected."""
+    env = kinder.make("kinder/Ground3D-o1-v0")
+    env_models = create_bilevel_planning_models(
+        "ground3d", env.observation_space, env.action_space
+    )
+    skill_name_to_skill = {s.operator.name: s for s in env_models.skills}
+    Pick = skill_name_to_skill["Pick"]
+
+    obs0, _ = env.reset(seed=123)
+    state0 = env_models.observation_to_state(obs0)
+    abstract_state = env_models.state_abstractor(state0)
+    obj_name_to_obj = {o.name: o for o in abstract_state.objects}
+    robot = obj_name_to_obj["robot"]
+    target = obj_name_to_obj["cube0"]
+
+    pick_skill = Pick.ground((robot, target))
+    obs1 = _skill_test_helper(pick_skill, env_models, env, obs0)
+
+    state1 = env_models.observation_to_state(obs1)
+    abstract_state1 = env_models.state_abstractor(state1)
+    pred_name_to_pred = {p.name: p for p in env_models.predicates}
+    Holding = pred_name_to_pred["Holding"]
+    HandEmpty = pred_name_to_pred["HandEmpty"]
+    OnGround = pred_name_to_pred["OnGround"]
+    assert HandEmpty([robot]) not in abstract_state1.atoms
+    assert OnGround([target]) not in abstract_state1.atoms
+    assert Holding([robot, target]) in abstract_state1.atoms
+
+    env.close()
+
+
+@pytest.mark.parametrize("seed", [123])
+def test_ground3d_bilevel_planning(seed):
+    """End-to-end bilevel planning test in the Ground3D-o1 environment.
+
+    Ground3D's env-side `goal_reached()` returns False unconditionally
+    (unlike Shelf3D, which signals when the gripper is closed after
+    placing), so we check abstract-goal satisfaction via the state
+    abstractor each tick instead of waiting for `terminated`.
+    """
+
+    num_objects = 1
+    env = kinder.make(
+        f"kinder/Ground3D-o{num_objects}-v0",
+        render_mode="rgb_array",
+    )
+
+    if MAKE_VIDEOS:
+        env = RecordVideo(
+            env, "unit_test_videos", name_prefix=f"Ground3D-bilevel-{seed}"
+        )
+
+    env_models = create_bilevel_planning_models(
+        "ground3d",
+        env.observation_space,
+        env.action_space,
+        num_objects=num_objects,
+    )
+    agent = BilevelPlanningAgent(
+        env_models,
+        seed=seed,
+        max_abstract_plans=1,
+        samples_per_step=1,
+        planning_timeout=60.0,
+        max_skill_horizon=500,
+    )
+    obs, info = env.reset(seed=seed)
+    goal = env_models.goal_deriver(env_models.observation_to_state(obs))
+    try:
+        agent.reset(obs, info)
+    except Exception as e:
+        env.close()
+        pytest.skip(f"Planning failed for seed {seed}: {e}")
+
+    for _ in range(1000):
+        action = agent.step()
+        obs, reward, terminated, truncated, info = env.step(action)
+        agent.update(obs, reward, terminated or truncated, info)
+        abstract_state = env_models.state_abstractor(
+            env_models.observation_to_state(obs)
+        )
+        if goal.atoms.issubset(abstract_state.atoms):
+            break
+        if terminated or truncated:
+            break
+    else:
+        assert False, "Did not reach abstract goal within step budget"
+
+    abstract_state = env_models.state_abstractor(env_models.observation_to_state(obs))
+    assert goal.atoms.issubset(
+        abstract_state.atoms
+    ), f"Abstract goal not satisfied; missing {goal.atoms - abstract_state.atoms}"
+
+    env.close()


### PR DESCRIPTION
## Summary

Adds the bilevel-planning env model for `kinder/Ground3D-o{N}-v0` — the "pick a cube off the floor" env, simpler than `kinder/KinematicShelf3D-o{N}-v0` (no shelf to place on, no `Place` operator). Unblocks a companion PR in prpl-tidybot that wires Ground3D through the real-mode pipeline as an intermediate-complexity hardware test (move base to a cube → pick it; no shelf).

Two files:

### `src/kinder_bilevel_planning/env_models/kinematic3d/ground3d.py`

Mirrors `shelf3d.py` structure, simplified:

- **No `Kinematic3DFixtureType`** — Ground3D has no shelf.
- **Predicates**: `OnGround`, `Holding`, `HandEmpty` (drop `OnFixture`).
- **Single `Pick` operator** (drop `Place`, even though `kinder_models.kinematic3d.ground3d.parameterized_skills` exposes a place controller — Ground3D's goal is just to grasp).
- **Goal**: `Holding(robot, cube0)`. For Ground3D-o1 this is the only cube; for Ground3D-o{>1} any obstructing cubes appear in the state abstractor but only `cube0` is the goal target (planner picks them up only if it needs to clear them).

Path-based env-model dispatch in `env_models/__init__.py` picks this up automatically once the file exists, so no registration boilerplate elsewhere.

### `tests/env_models/geom3d/test_ground3d.py`

Mirrors `test_shelf3d.py` with one adaptation: Ground3D's env-side `goal_reached()` returns `False` unconditionally (unlike Shelf3D which signals when the gripper closes after placing), so the end-to-end bilevel-planning test checks abstract-goal satisfaction via the state abstractor each tick instead of waiting for `terminated`.

## Test plan

- [x] `python -m pytest tests/env_models/geom3d/test_ground3d.py --pylint -m pylint --pylint-rcfile=.pylintrc` — pylint clean.
- [x] `./run_autoformat.sh` — clean.
- [x] Unit tests (logic-only — observation_to_state, transition_fn, goal_deriver, state_abstractor): all pass locally.
- [ ] Skill + end-to-end bilevel planning tests: pass in CI (Python 3.10). Locally they fail because of an unrelated upstream pybullet-helpers issue: IKFast tries to compile via `distutils`, which was removed in Python 3.12 (my local venv defaulted to 3.12). CI's `setup` action uses Python 3.10 so this won't reproduce.

## Followup

PR in [prpl-tidybot](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-tidybot) adding `Ground3DPerceiver` + `conf/env/ground3d.yaml`. Depends on this landing first so the dispatcher can find the env model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
