### PR TITLE
kinder-bilevel-planning: add large obstruction2d visualizer example

### DIFF
--- a/kinder-bilevel-planning/examples/visualize_obstruction2d_large/README.md
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d_large/README.md
@@ -1,0 +1,62 @@
+# Visualizing a large bilevel planning graph
+
+A scaling stress test for the
+[bilevel planning visualizer](https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono/tree/main/bilevel-planning):
+a real `kinder/Obstruction2D-o2-v0` solve with a generous search budget, to see
+how the visualization holds up on a graph an order of magnitude larger than the
+other examples.
+
+## The scenario
+
+Two obstructions must be cleared before the target block can be placed, and the
+search runs with **5 abstract plans** and **5 samples per step**. The result is a
+graph with a few thousand concrete states and substantial branching -- roughly
+9x the size of the `visualize_obstruction2d` (o1) example.
+
+This is a plain random instance (no hand-designed geometry). With two
+obstructions and this budget the problem is hard: the chosen seed solves in about
+ten seconds, but many other seeds instead blow up to ~15-19k states and time out
+without finding a plan, so changing the seed may stop it from solving.
+
+For the small, easy-to-read cases start with `visualize_obstruction2d_basic`,
+then `visualize_obstruction2d_resampling`, then `visualize_obstruction2d`.
+
+## Prerequisites
+
+Use the kinder-baselines virtualenv, set up per the repo README
+(`uv pip install -r prpl_requirements.txt` then `uv pip install -e ".[develop]"`).
+It already has `kinder` (for the renderer) and the `bilevel_planning` visualizer.
+
+If `python -m bilevel_planning.visualizer` fails to import `flask_cors`, install
+the visualizer's server dependency into the venv: `uv pip install flask-cors`.
+
+## 1. Generate the bundle
+
+The bundle is not committed (it's a regenerable artifact under the gitignored
+`data/`). Build it with a real planner run (takes ~10-15s):
+
+```bash
+python examples/visualize_obstruction2d_large/generate_bundle.py
+```
+
+This solves the instance with the `SesamePlanner`, exports the
+`BilevelPlanningGraph` to `data/obstruction2d_o2_large.pkl`, and prints the
+launch command.
+
+## 2. View it
+
+```bash
+python -m bilevel_planning.visualizer \
+    --bundle examples/visualize_obstruction2d_large/data/obstruction2d_o2_large.pkl \
+    --renderer examples/visualize_obstruction2d_large/renderer.py
+```
+
+A browser opens to the graph. Expect a dense concrete (lower) plane; click a
+concrete node to render that state.
+
+## Files
+
+- `generate_bundle.py` -- runs the planner and exports the bundle. The seed and
+  the `MAX_ABSTRACT_PLANS` / `SAMPLES_PER_STEP` budget are documented at the top.
+- `renderer.py` -- the `render_state(state) -> HxWx3 uint8` function the
+  visualizer execs; draws an Obstruction2D state via kinder's `render_2dstate`.

--- a/kinder-bilevel-planning/examples/visualize_obstruction2d_large/__init__.py
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d_large/__init__.py
@@ -1,0 +1,1 @@
+"""Large Obstruction2D-o2 visualizer example (scaling stress test)."""

--- a/kinder-bilevel-planning/examples/visualize_obstruction2d_large/generate_bundle.py
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d_large/generate_bundle.py
@@ -1,0 +1,159 @@
+"""Generate a large visualizer bundle from an obstruction2d-o2 solve.
+
+This example exists to see how the visualizer scales: it runs a real solve of a
+two-obstruction instance with a generous search budget (5 abstract plans, 5
+samples per step), which produces a graph an order of magnitude larger than the
+other examples -- a few thousand concrete states with substantial branching.
+
+Unlike the hand-designed o0 examples, this is a plain random instance (like
+``visualize_obstruction2d``); the seed is chosen so the solve finishes and yields
+a big-but-still-solvable graph. With two obstructions and this budget many seeds
+instead blow up to ~15-19k states and time out without a plan, so don't be
+surprised if changing the seed stops solving.
+
+Run from the kinder-bilevel-planning package root:
+
+    python examples/visualize_obstruction2d_large/generate_bundle.py
+"""
+
+import pickle
+from pathlib import Path
+
+import kinder
+from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
+    AbstractPlanGenerator,
+)
+from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
+    RelationalHeuristicSearchAbstractPlanGenerator,
+)
+from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
+from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
+from bilevel_planning.structs import PlanningProblem
+from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
+    ParameterizedControllerTrajectorySampler,
+)
+from bilevel_planning.utils import (
+    RelationalAbstractSuccessorGenerator,
+    RelationalControllerGenerator,
+)
+
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+ENV_NAME = "kinder/Obstruction2D-o2-v0"
+NUM_OBSTRUCTIONS = 2
+# Solves in ~11s with a ~2.6k-state graph; most other seeds blow up and time out.
+SEED = 0
+# Generous budget so the graph is large and branchy.
+MAX_ABSTRACT_PLANS = 5
+SAMPLES_PER_STEP = 5
+MAX_SKILL_HORIZON = 100
+HEURISTIC_NAME = "hff"
+PLANNING_TIMEOUT = 60.0
+
+
+def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object]:
+    """Solve the obstruction2d-o2 instance.
+
+    Returns ``(final_state, BilevelPlanningGraph, constant_state)``. The constant
+    state holds the static objects (table, walls) that the env keeps separate
+    from the dynamic per-step state; the caller bakes it into the pickled states
+    so the renderer draws the full scene.
+    """
+    kinder.register_all_environments()
+    env = kinder.make(ENV_NAME)
+    env_models = create_bilevel_planning_models(
+        "obstruction2d",
+        env.observation_space,
+        env.action_space,
+        num_obstructions=NUM_OBSTRUCTIONS,
+    )
+    obs, _ = env.reset(seed=SEED)
+    object_centric_env = getattr(env.unwrapped, "_object_centric_env")
+    constant_state = object_centric_env.initial_constant_state
+
+    initial_state = env_models.observation_to_state(obs)
+    goal = env_models.goal_deriver(initial_state)
+    problem = PlanningProblem(
+        env_models.state_space,
+        env_models.action_space,
+        initial_state,
+        env_models.transition_fn,
+        goal,
+    )
+    trajectory_sampler = ParameterizedControllerTrajectorySampler(
+        controller_generator=RelationalControllerGenerator(env_models.skills),
+        transition_function=env_models.transition_fn,
+        state_abstractor=env_models.state_abstractor,
+        max_trajectory_steps=MAX_SKILL_HORIZON,
+    )
+    abstract_plan_generator: AbstractPlanGenerator = (
+        RelationalHeuristicSearchAbstractPlanGenerator(
+            env_models.types,
+            env_models.predicates,
+            env_models.operators,
+            HEURISTIC_NAME,
+            seed=SEED,
+            precomputed_ground_operators=env_models.ground_operators,
+        )
+    )
+    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
+        env_models.operators,
+        precomputed_ground_operators=env_models.ground_operators,
+    )
+    planner = SesamePlanner(
+        abstract_plan_generator,
+        trajectory_sampler,
+        MAX_ABSTRACT_PLANS,
+        SAMPLES_PER_STEP,
+        abstract_successor_fn,
+        env_models.state_abstractor,
+        seed=SEED,
+    )
+
+    plan, bpg = planner.run(problem, timeout=PLANNING_TIMEOUT)
+    if plan is None:
+        raise RuntimeError("Planner found no plan for the obstruction2d-o2 instance.")
+    return plan.states[-1], bpg, constant_state
+
+
+def _bake_constants_into_states(bundle_path: Path, constant_state: object) -> None:
+    """Merge the constant (static) objects into each pickled state in place.
+
+    The exported bundle's ``states`` map is what the visualizer renders. Each
+    planner state holds only dynamic objects, so we copy in the static objects
+    here. This touches only the rendered states, not the graph topology that
+    ``export`` already wrote.
+    """
+    with open(bundle_path, "rb") as f:
+        bundle = pickle.load(f)
+    baked = {}
+    for node_id, state in bundle["states"].items():
+        merged = state.copy()
+        merged.data.update(constant_state.data)  # type: ignore[attr-defined]
+        baked[node_id] = merged
+    bundle["states"] = baked
+    with open(bundle_path, "wb") as f:
+        pickle.dump(bundle, f)
+
+
+def main() -> None:
+    """Build the graph and export a visualizer bundle, then print how to view it."""
+    final_state, bpg, constant_state = build_bilevel_planning_graph()
+
+    out_path = Path(__file__).parent / "data" / "obstruction2d_o2_large.pkl"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    bpg.export(out_path, final_state=final_state)
+    _bake_constants_into_states(out_path, constant_state)
+    print(f"Wrote visualizer bundle to {out_path}")
+
+    renderer_path = Path(__file__).parent / "renderer.py"
+    print(
+        "\nView it with:\n"
+        f"  python -m bilevel_planning.visualizer \\\n"
+        f"      --bundle {out_path} \\\n"
+        f"      --renderer {renderer_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/kinder-bilevel-planning/examples/visualize_obstruction2d_large/renderer.py
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d_large/renderer.py
@@ -1,0 +1,33 @@
+"""Renderer for the large obstruction2d-o2 visualizer bundle.
+
+Defines ``render_state(state)``, which the bilevel_planning visualizer execs
+and calls on each clicked node. It draws an Obstruction2D state (robot, target
+block, target surface, obstructions) as a top-down 2D scene using kinder's pure
+``render_2dstate`` function -- no live environment needed, since the pickled
+states are self-contained.
+
+Pass this file to the visualizer with ``--renderer``.
+"""
+
+from kinder.envs.utils import render_2dstate
+
+# World bounds for kinder/Obstruction2D-o2-v0 (from the env config; same as the
+# o0/o1 variants). The figure size is the world extent, so dpi sets the pixel
+# size: at dpi 300 the ~1.62 x 1.0 world renders to roughly 485 x 300 px.
+WORLD_MIN_X = 0.0
+WORLD_MAX_X = 1.618033988749895
+WORLD_MIN_Y = 0.0
+WORLD_MAX_Y = 1.0
+RENDER_DPI = 300
+
+
+def render_state(state):
+    """Return an HxWx3 uint8 RGB image of an Obstruction2D state."""
+    return render_2dstate(
+        state,
+        world_min_x=WORLD_MIN_X,
+        world_max_x=WORLD_MAX_X,
+        world_min_y=WORLD_MIN_Y,
+        world_max_y=WORLD_MAX_Y,
+        render_dpi=RENDER_DPI,
+    )


### PR DESCRIPTION
## Summary

A **scaling stress test** for the visualizer: a real `Obstruction2D-o2-v0` solve
(two obstructions) with a generous budget of **5 abstract plans** and **5 samples
per step**. The resulting graph is **~2.6k concrete states, ~2.8k edges, 35
branch points** -- roughly 9x the o1 example -- to see how the rendering holds up
on a large graph.

This is a plain random instance (no hand-designed geometry), like
`visualize_obstruction2d`. With two obstructions and this budget the problem is
hard: the chosen seed solves in ~11s, but many other seeds blow up to ~15-19k
states and time out without a plan, so changing the seed may stop it from solving
(noted in the file and README).

## Notes

- Mirrors the other examples' structure (`generate_bundle.py`, `renderer.py`,
  `README.md`, `__init__.py`); the regenerable bundle (~6.9 MB) under `data/` is
  gitignored.
- Verified end-to-end: `generate_bundle.py` exports a 2646-node / 2826-edge
  bundle (115 nodes on-plan, 8 abstract). `black`/`isort`/`mypy`/`pylint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
