### PR TITLE
lab: add SETUP.md minimal install guide

### DIFF
--- a/kinder-bilevel-planning/lab/README.md
+++ b/kinder-bilevel-planning/lab/README.md
@@ -7,11 +7,15 @@ predicates, skills, and operators, and watch a planner use them — including a 
 
 ## Setup
 
-Use the `kinder-bilevel-planning` virtualenv (activate it however you normally
-do), and run everything from this `lab/` directory:
+**Do this before the lab:** follow [`SETUP.md`](SETUP.md) to install `uv`, clone
+the repo, and install the lab packages.
+
+Once installed, activate the environment and run everything from this `lab/`
+directory:
 
 ```bash
-cd lab
+source ../../.venv/bin/activate     # the venv created in SETUP.md
+cd kinder-bilevel-planning/lab
 python -m pytest part1_stacking -q
 ```
 

--- a/kinder-bilevel-planning/lab/SETUP.md
+++ b/kinder-bilevel-planning/lab/SETUP.md
@@ -1,0 +1,66 @@
+# Lab setup — do this **before** the lab
+
+This installs only what the lab needs (a few minutes). `uv` downloads the right
+Python for you, so nothing else needs to be preinstalled. If step 3 fails, message
+the instructors **before** the session.
+
+## 1. Install `uv`
+
+The package manager — see https://docs.astral.sh/uv/getting-started/installation/, or:
+
+```bash
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Then **restart your terminal** so `uv` is on your `PATH`.
+
+## 2. Clone the repository
+
+```bash
+git clone https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git
+cd kinder-baselines
+```
+
+## 3. Create the environment and install the lab packages
+
+Run this from the `kinder-baselines` root:
+
+```bash
+uv venv --python=3.10
+uv pip install -e "./kinder-models[develop]" -e "./kinder-bilevel-planning[develop]"
+```
+
+(This installs just the two packages the lab uses and their dependencies — not the
+other baselines.)
+
+## 4. Activate, go to the lab, and verify
+
+```bash
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+cd kinder-bilevel-planning/lab
+python -c "import kinder, kinder_models, bilevel_planning, kinder_bilevel_planning; print('install OK')"
+python -m pytest part1_stacking -q
+```
+
+You're ready if:
+
+- you see `install OK`, and
+- the tests **fail** with messages mentioning `TODO(1)` / `TODO(2)` (that's the
+  unfinished exercise — *not* an error). If you instead see `ModuleNotFoundError`,
+  the install didn't finish.
+
+Then open `README.md` and start with **Part 1**.
+
+## If something breaks
+
+- **`uv: command not found`** after step 1 → restart your terminal (or open a new
+  one) so the install lands on your `PATH`.
+- **Step 3 errors about a missing file / package** → make sure you're in the
+  `kinder-baselines` root directory (the one containing `kinder-models/` and
+  `kinder-bilevel-planning/`).
+- **`ModuleNotFoundError` in step 4** → re-run step 3 and watch for errors; make
+  sure the venv is activated (your prompt should show `(.venv)`).
+- Still stuck? Send us the exact command you ran and the full error output.


### PR DESCRIPTION
## Summary

Adds a standalone, linkable **`lab/SETUP.md`** so students can install before the lab without copying commands off slides, and links it from `lab/README.md`.

The install is **lab-only** (verified end-to-end in a fresh venv): it installs just `kinder-models` + `kinder-bilevel-planning` (and their deps) — not the other baselines / `torch` / `mujoco`. `uv` fetches Python 3.10 itself.

```bash
uv venv --python=3.10
uv pip install -e "./kinder-models[develop]" -e "./kinder-bilevel-planning[develop]"
```

Includes a verify step (import check + `pytest part1_stacking` expecting the `TODO` failures) and a short troubleshooting list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
