### PR TITLE
kinder-bilevel-planning: use bilevel_planning.run_sesame everywhere

### DIFF
--- a/kinder-bilevel-planning/examples/visualize_obstruction2d/generate_bundle.py
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d/generate_bundle.py
@@ -11,26 +11,12 @@ Run from the kinder-bilevel-planning package root:
     python examples/visualize_obstruction2d/generate_bundle.py
 """
 
-import pickle
 from pathlib import Path
 
 import kinder
-from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
-    AbstractPlanGenerator,
-)
-from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
-    RelationalHeuristicSearchAbstractPlanGenerator,
-)
-from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
 from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
-from bilevel_planning.structs import PlanningProblem
-from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
-    ParameterizedControllerTrajectorySampler,
-)
-from bilevel_planning.utils import (
-    RelationalAbstractSuccessorGenerator,
-    RelationalControllerGenerator,
-)
+from bilevel_planning.sesame import run_sesame
+from relational_structs import ObjectCentricState
 
 from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 
@@ -41,11 +27,12 @@ SEED = 123
 MAX_ABSTRACT_PLANS = 10
 SAMPLES_PER_STEP = 1
 MAX_SKILL_HORIZON = 100
-HEURISTIC_NAME = "hff"
 PLANNING_TIMEOUT = 30.0
 
 
-def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object]:
+def build_bilevel_planning_graph() -> (
+    tuple[object, BilevelPlanningGraph, ObjectCentricState]
+):
     """Solve obstruction2d-o1.
 
     Returns ``(final_state, BilevelPlanningGraph, constant_state)``. The
@@ -73,68 +60,18 @@ def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object
     # difference is that we keep the BilevelPlanningGraph that planner.run
     # returns alongside the plan.
     initial_state = env_models.observation_to_state(obs)
-    goal = env_models.goal_deriver(initial_state)
-    problem = PlanningProblem(
-        env_models.state_space,
-        env_models.action_space,
+    plan, bpg = run_sesame(
+        env_models,
         initial_state,
-        env_models.transition_fn,
-        goal,
-    )
-    trajectory_sampler = ParameterizedControllerTrajectorySampler(
-        controller_generator=RelationalControllerGenerator(env_models.skills),
-        transition_function=env_models.transition_fn,
-        state_abstractor=env_models.state_abstractor,
-        max_trajectory_steps=MAX_SKILL_HORIZON,
-    )
-    abstract_plan_generator: AbstractPlanGenerator = (
-        RelationalHeuristicSearchAbstractPlanGenerator(
-            env_models.types,
-            env_models.predicates,
-            env_models.operators,
-            HEURISTIC_NAME,
-            seed=SEED,
-            precomputed_ground_operators=env_models.ground_operators,
-        )
-    )
-    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
-        env_models.operators,
-        precomputed_ground_operators=env_models.ground_operators,
-    )
-    planner = SesamePlanner(
-        abstract_plan_generator,
-        trajectory_sampler,
-        MAX_ABSTRACT_PLANS,
-        SAMPLES_PER_STEP,
-        abstract_successor_fn,
-        env_models.state_abstractor,
         seed=SEED,
+        max_abstract_plans=MAX_ABSTRACT_PLANS,
+        samples_per_step=SAMPLES_PER_STEP,
+        max_skill_horizon=MAX_SKILL_HORIZON,
+        timeout=PLANNING_TIMEOUT,
     )
-
-    plan, bpg = planner.run(problem, timeout=PLANNING_TIMEOUT)
     if plan is None:
         raise RuntimeError("Planner found no plan for obstruction2d-o1.")
     return plan.states[-1], bpg, constant_state
-
-
-def _bake_constants_into_states(bundle_path: Path, constant_state: object) -> None:
-    """Merge the constant (static) objects into each pickled state in place.
-
-    The exported bundle's ``states`` map is what the visualizer renders. Each
-    planner state holds only dynamic objects, so we copy in the static objects
-    here. This touches only the rendered states, not the graph topology that
-    ``export`` already wrote.
-    """
-    with open(bundle_path, "rb") as f:
-        bundle = pickle.load(f)
-    baked = {}
-    for node_id, state in bundle["states"].items():
-        merged = state.copy()
-        merged.data.update(constant_state.data)  # type: ignore[attr-defined]
-        baked[node_id] = merged
-    bundle["states"] = baked
-    with open(bundle_path, "wb") as f:
-        pickle.dump(bundle, f)
 
 
 def main() -> None:
@@ -143,8 +80,7 @@ def main() -> None:
 
     out_path = Path(__file__).parent / "data" / "obstruction2d_o1.pkl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    bpg.export(out_path, final_state=final_state)
-    _bake_constants_into_states(out_path, constant_state)
+    bpg.export(out_path, final_state=final_state, constant_state=constant_state)
     print(f"Wrote visualizer bundle to {out_path}")
 
     renderer_path = Path(__file__).parent / "renderer.py"

--- a/kinder-bilevel-planning/examples/visualize_obstruction2d_basic/generate_bundle.py
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d_basic/generate_bundle.py
@@ -21,27 +21,13 @@ Run from the kinder-bilevel-planning package root:
     python examples/visualize_obstruction2d_basic/generate_bundle.py
 """
 
-import pickle
 from pathlib import Path
 
 import kinder
 import numpy as np
-from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
-    AbstractPlanGenerator,
-)
-from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
-    RelationalHeuristicSearchAbstractPlanGenerator,
-)
-from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
 from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
-from bilevel_planning.structs import PlanningProblem
-from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
-    ParameterizedControllerTrajectorySampler,
-)
-from bilevel_planning.utils import (
-    RelationalAbstractSuccessorGenerator,
-    RelationalControllerGenerator,
-)
+from bilevel_planning.sesame import run_sesame
+from relational_structs import ObjectCentricState
 
 from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 
@@ -52,7 +38,6 @@ SEED = 0
 MAX_ABSTRACT_PLANS = 1
 SAMPLES_PER_STEP = 1
 MAX_SKILL_HORIZON = 100
-HEURISTIC_NAME = "hff"
 PLANNING_TIMEOUT = 30.0
 
 # Hand-designed geometry (world x in [0, 1.618], y in [0, 1]; robot radius 0.1).
@@ -63,7 +48,9 @@ SURFACE_X, SURFACE_WIDTH = 1.0, 0.12
 ROBOT_X, ROBOT_Y = 0.8, 0.85
 
 
-def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object]:
+def build_bilevel_planning_graph() -> (
+    tuple[object, BilevelPlanningGraph, ObjectCentricState]
+):
     """Solve the dead-simple obstruction2d-o0 instance.
 
     Returns ``(final_state, BilevelPlanningGraph, constant_state)``. The constant
@@ -98,68 +85,18 @@ def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object
     initial_state.set(target_surface, "x", SURFACE_X)
     initial_state.set(target_surface, "width", SURFACE_WIDTH)
 
-    goal = env_models.goal_deriver(initial_state)
-    problem = PlanningProblem(
-        env_models.state_space,
-        env_models.action_space,
+    plan, bpg = run_sesame(
+        env_models,
         initial_state,
-        env_models.transition_fn,
-        goal,
-    )
-    trajectory_sampler = ParameterizedControllerTrajectorySampler(
-        controller_generator=RelationalControllerGenerator(env_models.skills),
-        transition_function=env_models.transition_fn,
-        state_abstractor=env_models.state_abstractor,
-        max_trajectory_steps=MAX_SKILL_HORIZON,
-    )
-    abstract_plan_generator: AbstractPlanGenerator = (
-        RelationalHeuristicSearchAbstractPlanGenerator(
-            env_models.types,
-            env_models.predicates,
-            env_models.operators,
-            HEURISTIC_NAME,
-            seed=SEED,
-            precomputed_ground_operators=env_models.ground_operators,
-        )
-    )
-    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
-        env_models.operators,
-        precomputed_ground_operators=env_models.ground_operators,
-    )
-    planner = SesamePlanner(
-        abstract_plan_generator,
-        trajectory_sampler,
-        MAX_ABSTRACT_PLANS,
-        SAMPLES_PER_STEP,
-        abstract_successor_fn,
-        env_models.state_abstractor,
         seed=SEED,
+        max_abstract_plans=MAX_ABSTRACT_PLANS,
+        samples_per_step=SAMPLES_PER_STEP,
+        max_skill_horizon=MAX_SKILL_HORIZON,
+        timeout=PLANNING_TIMEOUT,
     )
-
-    plan, bpg = planner.run(problem, timeout=PLANNING_TIMEOUT)
     if plan is None:
         raise RuntimeError("Planner found no plan for the basic instance.")
     return plan.states[-1], bpg, constant_state
-
-
-def _bake_constants_into_states(bundle_path: Path, constant_state: object) -> None:
-    """Merge the constant (static) objects into each pickled state in place.
-
-    The exported bundle's ``states`` map is what the visualizer renders. Each
-    planner state holds only dynamic objects, so we copy in the static objects
-    here. This touches only the rendered states, not the graph topology that
-    ``export`` already wrote.
-    """
-    with open(bundle_path, "rb") as f:
-        bundle = pickle.load(f)
-    baked = {}
-    for node_id, state in bundle["states"].items():
-        merged = state.copy()
-        merged.data.update(constant_state.data)  # type: ignore[attr-defined]
-        baked[node_id] = merged
-    bundle["states"] = baked
-    with open(bundle_path, "wb") as f:
-        pickle.dump(bundle, f)
 
 
 def main() -> None:
@@ -168,8 +105,7 @@ def main() -> None:
 
     out_path = Path(__file__).parent / "data" / "obstruction2d_o0_basic.pkl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    bpg.export(out_path, final_state=final_state)
-    _bake_constants_into_states(out_path, constant_state)
+    bpg.export(out_path, final_state=final_state, constant_state=constant_state)
     print(f"Wrote visualizer bundle to {out_path}")
 
     renderer_path = Path(__file__).parent / "renderer.py"

--- a/kinder-bilevel-planning/examples/visualize_obstruction2d_large/generate_bundle.py
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d_large/generate_bundle.py
@@ -16,26 +16,12 @@ Run from the kinder-bilevel-planning package root:
     python examples/visualize_obstruction2d_large/generate_bundle.py
 """
 
-import pickle
 from pathlib import Path
 
 import kinder
-from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
-    AbstractPlanGenerator,
-)
-from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
-    RelationalHeuristicSearchAbstractPlanGenerator,
-)
-from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
 from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
-from bilevel_planning.structs import PlanningProblem
-from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
-    ParameterizedControllerTrajectorySampler,
-)
-from bilevel_planning.utils import (
-    RelationalAbstractSuccessorGenerator,
-    RelationalControllerGenerator,
-)
+from bilevel_planning.sesame import run_sesame
+from relational_structs import ObjectCentricState
 
 from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 
@@ -47,11 +33,12 @@ SEED = 0
 MAX_ABSTRACT_PLANS = 5
 SAMPLES_PER_STEP = 5
 MAX_SKILL_HORIZON = 100
-HEURISTIC_NAME = "hff"
 PLANNING_TIMEOUT = 60.0
 
 
-def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object]:
+def build_bilevel_planning_graph() -> (
+    tuple[object, BilevelPlanningGraph, ObjectCentricState]
+):
     """Solve the obstruction2d-o2 instance.
 
     Returns ``(final_state, BilevelPlanningGraph, constant_state)``. The constant
@@ -72,68 +59,18 @@ def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object
     constant_state = object_centric_env.initial_constant_state
 
     initial_state = env_models.observation_to_state(obs)
-    goal = env_models.goal_deriver(initial_state)
-    problem = PlanningProblem(
-        env_models.state_space,
-        env_models.action_space,
+    plan, bpg = run_sesame(
+        env_models,
         initial_state,
-        env_models.transition_fn,
-        goal,
-    )
-    trajectory_sampler = ParameterizedControllerTrajectorySampler(
-        controller_generator=RelationalControllerGenerator(env_models.skills),
-        transition_function=env_models.transition_fn,
-        state_abstractor=env_models.state_abstractor,
-        max_trajectory_steps=MAX_SKILL_HORIZON,
-    )
-    abstract_plan_generator: AbstractPlanGenerator = (
-        RelationalHeuristicSearchAbstractPlanGenerator(
-            env_models.types,
-            env_models.predicates,
-            env_models.operators,
-            HEURISTIC_NAME,
-            seed=SEED,
-            precomputed_ground_operators=env_models.ground_operators,
-        )
-    )
-    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
-        env_models.operators,
-        precomputed_ground_operators=env_models.ground_operators,
-    )
-    planner = SesamePlanner(
-        abstract_plan_generator,
-        trajectory_sampler,
-        MAX_ABSTRACT_PLANS,
-        SAMPLES_PER_STEP,
-        abstract_successor_fn,
-        env_models.state_abstractor,
         seed=SEED,
+        max_abstract_plans=MAX_ABSTRACT_PLANS,
+        samples_per_step=SAMPLES_PER_STEP,
+        max_skill_horizon=MAX_SKILL_HORIZON,
+        timeout=PLANNING_TIMEOUT,
     )
-
-    plan, bpg = planner.run(problem, timeout=PLANNING_TIMEOUT)
     if plan is None:
         raise RuntimeError("Planner found no plan for the obstruction2d-o2 instance.")
     return plan.states[-1], bpg, constant_state
-
-
-def _bake_constants_into_states(bundle_path: Path, constant_state: object) -> None:
-    """Merge the constant (static) objects into each pickled state in place.
-
-    The exported bundle's ``states`` map is what the visualizer renders. Each
-    planner state holds only dynamic objects, so we copy in the static objects
-    here. This touches only the rendered states, not the graph topology that
-    ``export`` already wrote.
-    """
-    with open(bundle_path, "rb") as f:
-        bundle = pickle.load(f)
-    baked = {}
-    for node_id, state in bundle["states"].items():
-        merged = state.copy()
-        merged.data.update(constant_state.data)  # type: ignore[attr-defined]
-        baked[node_id] = merged
-    bundle["states"] = baked
-    with open(bundle_path, "wb") as f:
-        pickle.dump(bundle, f)
 
 
 def main() -> None:
@@ -142,8 +79,7 @@ def main() -> None:
 
     out_path = Path(__file__).parent / "data" / "obstruction2d_o2_large.pkl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    bpg.export(out_path, final_state=final_state)
-    _bake_constants_into_states(out_path, constant_state)
+    bpg.export(out_path, final_state=final_state, constant_state=constant_state)
     print(f"Wrote visualizer bundle to {out_path}")
 
     renderer_path = Path(__file__).parent / "renderer.py"

--- a/kinder-bilevel-planning/examples/visualize_obstruction2d_resampling/generate_bundle.py
+++ b/kinder-bilevel-planning/examples/visualize_obstruction2d_resampling/generate_bundle.py
@@ -1,5 +1,5 @@
-"""Generate a visualizer bundle for an obstruction2d-o0 case where the refiner
-*must* sample more than once per step.
+"""Generate a visualizer bundle for an obstruction2d-o0 case where the refiner *must*
+sample more than once per step.
 
 Unlike ``visualize_obstruction2d`` (which solves a randomly sampled o1 instance),
 this example hand-designs an o0 instance -- no obstructions, just one target
@@ -39,27 +39,13 @@ Run from the kinder-bilevel-planning package root:
     python examples/visualize_obstruction2d_resampling/generate_bundle.py
 """
 
-import pickle
 from pathlib import Path
 
 import kinder
 import numpy as np
-from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
-    AbstractPlanGenerator,
-)
-from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
-    RelationalHeuristicSearchAbstractPlanGenerator,
-)
-from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
 from bilevel_planning.bilevel_planning_graph import BilevelPlanningGraph
-from bilevel_planning.structs import PlanningProblem
-from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
-    ParameterizedControllerTrajectorySampler,
-)
-from bilevel_planning.utils import (
-    RelationalAbstractSuccessorGenerator,
-    RelationalControllerGenerator,
-)
+from bilevel_planning.sesame import run_sesame
+from relational_structs import ObjectCentricState
 
 from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 
@@ -73,7 +59,6 @@ MAX_ABSTRACT_PLANS = 1
 # 1 fails to refine this instance; 2 is the smallest value that succeeds.
 SAMPLES_PER_STEP = 2
 MAX_SKILL_HORIZON = 100
-HEURISTIC_NAME = "hff"
 PLANNING_TIMEOUT = 30.0
 
 # Hand-designed geometry (world x in [0, 1.618], y in [0, 1]; robot radius 0.1).
@@ -88,7 +73,9 @@ SURFACE_X = WORLD_MAX_X - SURFACE_WIDTH  # right edge flush with the right wall
 ROBOT_X, ROBOT_Y = 0.8, 0.85
 
 
-def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object]:
+def build_bilevel_planning_graph() -> (
+    tuple[object, BilevelPlanningGraph, ObjectCentricState]
+):
     """Solve the hand-designed obstruction2d-o0 resampling instance.
 
     Returns ``(final_state, BilevelPlanningGraph, constant_state)``. The constant
@@ -123,68 +110,18 @@ def build_bilevel_planning_graph() -> tuple[object, BilevelPlanningGraph, object
     initial_state.set(target_surface, "x", SURFACE_X)
     initial_state.set(target_surface, "width", SURFACE_WIDTH)
 
-    goal = env_models.goal_deriver(initial_state)
-    problem = PlanningProblem(
-        env_models.state_space,
-        env_models.action_space,
+    plan, bpg = run_sesame(
+        env_models,
         initial_state,
-        env_models.transition_fn,
-        goal,
-    )
-    trajectory_sampler = ParameterizedControllerTrajectorySampler(
-        controller_generator=RelationalControllerGenerator(env_models.skills),
-        transition_function=env_models.transition_fn,
-        state_abstractor=env_models.state_abstractor,
-        max_trajectory_steps=MAX_SKILL_HORIZON,
-    )
-    abstract_plan_generator: AbstractPlanGenerator = (
-        RelationalHeuristicSearchAbstractPlanGenerator(
-            env_models.types,
-            env_models.predicates,
-            env_models.operators,
-            HEURISTIC_NAME,
-            seed=SEED,
-            precomputed_ground_operators=env_models.ground_operators,
-        )
-    )
-    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
-        env_models.operators,
-        precomputed_ground_operators=env_models.ground_operators,
-    )
-    planner = SesamePlanner(
-        abstract_plan_generator,
-        trajectory_sampler,
-        MAX_ABSTRACT_PLANS,
-        SAMPLES_PER_STEP,
-        abstract_successor_fn,
-        env_models.state_abstractor,
         seed=SEED,
+        max_abstract_plans=MAX_ABSTRACT_PLANS,
+        samples_per_step=SAMPLES_PER_STEP,
+        max_skill_horizon=MAX_SKILL_HORIZON,
+        timeout=PLANNING_TIMEOUT,
     )
-
-    plan, bpg = planner.run(problem, timeout=PLANNING_TIMEOUT)
     if plan is None:
         raise RuntimeError("Planner found no plan for the resampling instance.")
     return plan.states[-1], bpg, constant_state
-
-
-def _bake_constants_into_states(bundle_path: Path, constant_state: object) -> None:
-    """Merge the constant (static) objects into each pickled state in place.
-
-    The exported bundle's ``states`` map is what the visualizer renders. Each
-    planner state holds only dynamic objects, so we copy in the static objects
-    here. This touches only the rendered states, not the graph topology that
-    ``export`` already wrote.
-    """
-    with open(bundle_path, "rb") as f:
-        bundle = pickle.load(f)
-    baked = {}
-    for node_id, state in bundle["states"].items():
-        merged = state.copy()
-        merged.data.update(constant_state.data)  # type: ignore[attr-defined]
-        baked[node_id] = merged
-    bundle["states"] = baked
-    with open(bundle_path, "wb") as f:
-        pickle.dump(bundle, f)
 
 
 def main() -> None:
@@ -193,8 +130,7 @@ def main() -> None:
 
     out_path = Path(__file__).parent / "data" / "obstruction2d_o0_resampling.pkl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    bpg.export(out_path, final_state=final_state)
-    _bake_constants_into_states(out_path, constant_state)
+    bpg.export(out_path, final_state=final_state, constant_state=constant_state)
     print(f"Wrote visualizer bundle to {out_path}")
 
     renderer_path = Path(__file__).parent / "renderer.py"

--- a/kinder-bilevel-planning/lab/part1_stacking/run.py
+++ b/kinder-bilevel-planning/lab/part1_stacking/run.py
@@ -8,31 +8,16 @@ barrier between them. The two-step plan
 
 is the same as before, but now the motion-planned controllers must route the
 robot -- and the carried block -- up and over the barrier (a straight path
-collides). Run from the repo root:
+collides). Run from the lab/ directory:
 
-    python -m part1_stacking.run      (from the lab/ directory)
+    python -m part1_stacking.run
 """
 
-import pickle
 from pathlib import Path
 
 import kinder
 import numpy as np
-from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
-    AbstractPlanGenerator,
-)
-from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
-    RelationalHeuristicSearchAbstractPlanGenerator,
-)
-from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
-from bilevel_planning.structs import PlanningProblem
-from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
-    ParameterizedControllerTrajectorySampler,
-)
-from bilevel_planning.utils import (
-    RelationalAbstractSuccessorGenerator,
-    RelationalControllerGenerator,
-)
+from bilevel_planning.sesame import run_sesame
 from part1_stacking.models import create_stacking_models
 
 ENV_NAME = "kinder/Obstruction2D-o2-v0"
@@ -41,7 +26,6 @@ SEED = 0
 MAX_ABSTRACT_PLANS = 1
 SAMPLES_PER_STEP = 5
 MAX_SKILL_HORIZON = 200
-HEURISTIC_NAME = "hff"
 PLANNING_TIMEOUT = 120.0
 
 # Hand-designed geometry (world x in [0, 1.618]; blocks rest on the table top at
@@ -90,61 +74,18 @@ def build_bilevel_planning_graph() -> tuple:
         initial_state.get_object_from_name("target_surface"), "x", TARGET_SURFACE_X
     )
 
-    goal = env_models.goal_deriver(initial_state)
-    problem = PlanningProblem(
-        env_models.state_space,
-        env_models.action_space,
+    plan, bpg = run_sesame(
+        env_models,
         initial_state,
-        env_models.transition_fn,
-        goal,
-    )
-    trajectory_sampler = ParameterizedControllerTrajectorySampler(
-        controller_generator=RelationalControllerGenerator(env_models.skills),
-        transition_function=env_models.transition_fn,
-        state_abstractor=env_models.state_abstractor,
-        max_trajectory_steps=MAX_SKILL_HORIZON,
-    )
-    abstract_plan_generator: AbstractPlanGenerator = (
-        RelationalHeuristicSearchAbstractPlanGenerator(
-            env_models.types,
-            env_models.predicates,
-            env_models.operators,
-            HEURISTIC_NAME,
-            seed=SEED,
-            precomputed_ground_operators=env_models.ground_operators,
-        )
-    )
-    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
-        env_models.operators,
-        precomputed_ground_operators=env_models.ground_operators,
-    )
-    planner = SesamePlanner(
-        abstract_plan_generator,
-        trajectory_sampler,
-        MAX_ABSTRACT_PLANS,
-        SAMPLES_PER_STEP,
-        abstract_successor_fn,
-        env_models.state_abstractor,
         seed=SEED,
+        max_abstract_plans=MAX_ABSTRACT_PLANS,
+        samples_per_step=SAMPLES_PER_STEP,
+        max_skill_horizon=MAX_SKILL_HORIZON,
+        timeout=PLANNING_TIMEOUT,
     )
-    plan, bpg = planner.run(problem, timeout=PLANNING_TIMEOUT)
     if plan is None:
         raise RuntimeError("Planner found no plan for the stacking instance.")
     return plan.states[-1], bpg, constant_state
-
-
-def _bake_constants_into_states(bundle_path: Path, constant_state) -> None:
-    """Merge the constant (static) objects into each pickled state in place."""
-    with open(bundle_path, "rb") as f:
-        bundle = pickle.load(f)
-    baked = {}
-    for node_id, state in bundle["states"].items():
-        merged = state.copy()
-        merged.data.update(constant_state.data)  # type: ignore[attr-defined]
-        baked[node_id] = merged
-    bundle["states"] = baked
-    with open(bundle_path, "wb") as f:
-        pickle.dump(bundle, f)
 
 
 def main() -> None:
@@ -152,8 +93,7 @@ def main() -> None:
     final_state, bpg, constant_state = build_bilevel_planning_graph()
     out_path = Path(__file__).parent / "data" / "stacking.pkl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    bpg.export(out_path, final_state=final_state)
-    _bake_constants_into_states(out_path, constant_state)
+    bpg.export(out_path, final_state=final_state, constant_state=constant_state)
     renderer_path = Path(__file__).parent.parent / "renderer.py"
     print(f"Wrote visualizer bundle to {out_path}")
     print(

--- a/kinder-bilevel-planning/lab/part2_pyramid/run.py
+++ b/kinder-bilevel-planning/lab/part2_pyramid/run.py
@@ -6,26 +6,11 @@ target block all start on the table, none adjacent. Run from the lab/ directory:
     python -m part2_pyramid.run
 """
 
-import pickle
 from pathlib import Path
 
 import kinder
 import numpy as np
-from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
-    AbstractPlanGenerator,
-)
-from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
-    RelationalHeuristicSearchAbstractPlanGenerator,
-)
-from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
-from bilevel_planning.structs import PlanningProblem
-from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
-    ParameterizedControllerTrajectorySampler,
-)
-from bilevel_planning.utils import (
-    RelationalAbstractSuccessorGenerator,
-    RelationalControllerGenerator,
-)
+from bilevel_planning.sesame import run_sesame
 from part2_pyramid.models import create_pyramid_models
 
 ENV_NAME = "kinder/Obstruction2D-o2-v0"
@@ -34,7 +19,6 @@ SEED = 0
 MAX_ABSTRACT_PLANS = 5
 SAMPLES_PER_STEP = 5
 MAX_SKILL_HORIZON = 200
-HEURISTIC_NAME = "hff"
 PLANNING_TIMEOUT = 60.0
 
 # All three blocks on the table, none adjacent.
@@ -76,60 +60,18 @@ def build_bilevel_planning_graph() -> tuple:
         initial_state.get_object_from_name("target_surface"), "x", TARGET_SURFACE_X
     )
 
-    problem = PlanningProblem(
-        env_models.state_space,
-        env_models.action_space,
+    plan, bpg = run_sesame(
+        env_models,
         initial_state,
-        env_models.transition_fn,
-        env_models.goal_deriver(initial_state),
-    )
-    trajectory_sampler = ParameterizedControllerTrajectorySampler(
-        controller_generator=RelationalControllerGenerator(env_models.skills),
-        transition_function=env_models.transition_fn,
-        state_abstractor=env_models.state_abstractor,
-        max_trajectory_steps=MAX_SKILL_HORIZON,
-    )
-    abstract_plan_generator: AbstractPlanGenerator = (
-        RelationalHeuristicSearchAbstractPlanGenerator(
-            env_models.types,
-            env_models.predicates,
-            env_models.operators,
-            HEURISTIC_NAME,
-            seed=SEED,
-            precomputed_ground_operators=env_models.ground_operators,
-        )
-    )
-    abstract_successor_fn = RelationalAbstractSuccessorGenerator(
-        env_models.operators,
-        precomputed_ground_operators=env_models.ground_operators,
-    )
-    planner = SesamePlanner(
-        abstract_plan_generator,
-        trajectory_sampler,
-        MAX_ABSTRACT_PLANS,
-        SAMPLES_PER_STEP,
-        abstract_successor_fn,
-        env_models.state_abstractor,
         seed=SEED,
+        max_abstract_plans=MAX_ABSTRACT_PLANS,
+        samples_per_step=SAMPLES_PER_STEP,
+        max_skill_horizon=MAX_SKILL_HORIZON,
+        timeout=PLANNING_TIMEOUT,
     )
-    plan, bpg = planner.run(problem, timeout=PLANNING_TIMEOUT)
     if plan is None:
         raise RuntimeError("Planner found no plan for the pyramid instance.")
     return plan.states[-1], bpg, constant_state
-
-
-def _bake_constants_into_states(bundle_path: Path, constant_state) -> None:
-    """Merge the constant (static) objects into each pickled state in place."""
-    with open(bundle_path, "rb") as f:
-        bundle = pickle.load(f)
-    baked = {}
-    for node_id, state in bundle["states"].items():
-        merged = state.copy()
-        merged.data.update(constant_state.data)  # type: ignore[attr-defined]
-        baked[node_id] = merged
-    bundle["states"] = baked
-    with open(bundle_path, "wb") as f:
-        pickle.dump(bundle, f)
 
 
 def main() -> None:
@@ -137,8 +79,7 @@ def main() -> None:
     final_state, bpg, constant_state = build_bilevel_planning_graph()
     out_path = Path(__file__).parent / "data" / "pyramid.pkl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    bpg.export(out_path, final_state=final_state)
-    _bake_constants_into_states(out_path, constant_state)
+    bpg.export(out_path, final_state=final_state, constant_state=constant_state)
     renderer_path = Path(__file__).parent.parent / "renderer.py"
     print(f"Wrote visualizer bundle to {out_path}")
     print(

--- a/kinder-bilevel-planning/pyproject.toml
+++ b/kinder-bilevel-planning/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
    "relational_structs>=0.0.1",
    "tomsgeoms2d>=0.0.1",
    "pybullet_helpers>=0.0.1",
-   "bilevel_planning>=0.1.3",
+   "bilevel_planning>=0.1.4",
 ]
 
 [project.optional-dependencies]

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/agent.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/agent.py
@@ -3,24 +3,8 @@
 from collections.abc import Hashable
 from typing import Any, TypeVar
 
-from bilevel_planning.abstract_plan_generators.abstract_plan_generator import (
-    AbstractPlanGenerator,
-)
-from bilevel_planning.abstract_plan_generators.heuristic_search_plan_generator import (
-    RelationalHeuristicSearchAbstractPlanGenerator,
-)
-from bilevel_planning.bilevel_planners.sesame_planner import SesamePlanner
-from bilevel_planning.structs import (
-    PlanningProblem,
-    SesameModels,
-)
-from bilevel_planning.trajectory_samplers.parameterized_controller_sampler import (
-    ParameterizedControllerTrajectorySampler,
-)
-from bilevel_planning.utils import (
-    RelationalAbstractSuccessorGenerator,
-    RelationalControllerGenerator,
-)
+from bilevel_planning.sesame import run_sesame
+from bilevel_planning.structs import SesameModels
 from prpl_utils.planning_agent import PlanningAgent
 
 _O = TypeVar("_O", bound=Hashable)
@@ -97,57 +81,17 @@ class BilevelPlanningAgent(PlanningAgent[_O, _U, _X]):
         return list(zip(self._planned_states[:-1], self._planned_actions))
 
     def _run_planning(self) -> tuple[list[_X], list[_U]]:
-        # Create planning problem.
         initial_state = self._env_models.observation_to_state(self._last_observation)
-        goal = self._env_models.goal_deriver(initial_state)
-        problem = PlanningProblem(
-            self._env_models.state_space,
-            self._env_models.action_space,
+        plan, _ = run_sesame(
+            self._env_models,
             initial_state,
-            self._env_models.transition_fn,
-            goal,
-        )
-
-        # Create the sampler.
-        trajectory_sampler = ParameterizedControllerTrajectorySampler(
-            controller_generator=RelationalControllerGenerator(self._env_models.skills),
-            transition_function=self._env_models.transition_fn,
-            state_abstractor=self._env_models.state_abstractor,
-            max_trajectory_steps=self._max_skill_horizon,
-        )
-
-        # Create the abstract plan generator.
-        abstract_plan_generator: AbstractPlanGenerator = (
-            RelationalHeuristicSearchAbstractPlanGenerator(
-                self._env_models.types,
-                self._env_models.predicates,
-                self._env_models.operators,
-                self._heuristic_name,
-                seed=self._seed,
-                precomputed_ground_operators=self._env_models.ground_operators,
-            )
-        )
-
-        # Create the abstract successor function (not really used).
-        abstract_successor_fn = RelationalAbstractSuccessorGenerator(
-            self._env_models.operators,
-            precomputed_ground_operators=self._env_models.ground_operators,
-        )
-
-        # Finish the planner.
-        planner = SesamePlanner(
-            abstract_plan_generator,
-            trajectory_sampler,
-            self._max_abstract_plans,
-            self._samples_per_step,
-            abstract_successor_fn,
-            self._env_models.state_abstractor,
             seed=self._seed,
+            max_abstract_plans=self._max_abstract_plans,
+            samples_per_step=self._samples_per_step,
+            max_skill_horizon=self._max_skill_horizon,
+            heuristic_name=self._heuristic_name,
+            timeout=self._planning_timeout,
         )
-
-        # Run the planner.
-        plan, _ = planner.run(problem, timeout=self._planning_timeout)
         if plan is None:
             raise AgentFailure("No plan found")
-
         return plan.states, plan.actions


### PR DESCRIPTION
## Summary

Adopts `bilevel_planning.run_sesame` (released in `bilevel_planning` 0.1.4, prpl-mono #519/#520) across kinder-bilevel-planning, removing the duplicated SESAME planner-construction boilerplate.

- **`pyproject.toml`** — bump `bilevel_planning>=0.1.4`.
- **`agent.py`** — `BilevelPlanningAgent._run_planning` now delegates to `run_sesame` (was ~50 lines of inline sampler/plan-generator/successor/planner construction).
- **lab `run.py` (part1, part2)** and **`examples/*/generate_bundle.py` (×4)** — build the graph via `run_sesame`, and the examples now use `export(constant_state=...)` instead of a hand-written `_bake_constants_into_states` post-processing pass.

Net: **+78 / −509** lines. No behavior change — the agent's planning, the lab solves, and the example bundles are the same; the constant objects are now stored once in the bundle and merged at render time by the visualizer backend (the new 0.1.4 `export`).

## Validation
- `mypy .` clean (73 files), pylint clean on the changed files.
- The basic example runs end-to-end; the bundle carries `constant_state` once and the per-step states stay dynamic-only.

Note: this is scoped to the run_sesame migration only — unrelated example tweaks are intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
