### PR TITLE
lab: document a no-PyBullet slim install; drop dead kindergarden extras

### DIFF
--- a/kinder-bilevel-planning/lab/SETUP.md
+++ b/kinder-bilevel-planning/lab/SETUP.md
@@ -39,6 +39,25 @@ uv pip install -e "./kinder-models[develop]" -e "./kinder-bilevel-planning[devel
 (This installs just the two packages the lab uses and their dependencies — not the
 other baselines.)
 
+### Slim install (no PyBullet — smaller and faster)
+
+The command above pulls every simulation backend, including PyBullet and MuJoCo.
+The lab only uses the 2D (Obstruction2D) environments, which need neither. To
+install just those, install the packages without their dependencies and then the
+lab's 2D requirements file:
+
+```bash
+uv venv --python=3.10
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+uv pip install --no-deps kindergarden \
+    -e ./kinder-models -e ./kinder-bilevel-planning
+uv pip install -r kinder-bilevel-planning/lab/requirements/lab2d.txt
+```
+
+This produces the same working lab with a much lighter install — useful on
+machines (or hosted notebooks like Colab) where the full backend stack is slow or
+unnecessary.
+
 ## 4. Go to the lab and verify
 
 ```bash

--- a/kinder-bilevel-planning/lab/requirements/lab2d.txt
+++ b/kinder-bilevel-planning/lab/requirements/lab2d.txt
@@ -1,0 +1,34 @@
+# 2D-only dependency set for the bilevel-planning lab: no PyBullet, MuJoCo,
+# pygame, or pymunk. This is the union of the non-backend dependencies of
+# kindergarden, kinder_models, and kinder_bilevel_planning, plus pytest for the
+# exercises.
+#
+# The three lab packages pull every backend by default. To install the lab
+# without PyBullet, install them with --no-deps and then this file (pip resolves
+# the transitive dependencies of the entries below normally):
+#
+#     uv pip install --no-deps kindergarden \
+#         -e ./kinder-models -e ./kinder-bilevel-planning
+#     uv pip install -r kinder-bilevel-planning/lab/requirements/lab2d.txt
+#
+gymnasium
+matplotlib
+numpy
+Pillow
+dill
+shapely>=2.1.2
+scipy>=1.14.0
+relational_structs>=0.0.1
+prpl_utils>=0.0.7
+tomsgeoms2d>=0.0.1
+spatialmath-python
+h5py
+flask-socketio
+opencv-python>=4.9.0
+pandas
+pandas-stubs
+hydra-core
+hydra-joblib-launcher
+omegaconf
+bilevel_planning>=0.1.3
+pytest>=7.2.2

--- a/kinder-bilevel-planning/notebooks/bilevel_planning.ipynb
+++ b/kinder-bilevel-planning/notebooks/bilevel_planning.ipynb
@@ -7,7 +7,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## Installation\n\n```bash\npip install kindergarden[kinematic2d]\ngit clone https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git\ncd kinder-baselines\npip install -e kinder-models\npip install -e kinder-bilevel-planning\n```",
+   "source": "## Installation\n\n```bash\npip install kindergarden\ngit clone https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git\ncd kinder-baselines\npip install -e kinder-models\npip install -e kinder-bilevel-planning\n```",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/kinder-bilevel-planning/pyproject.toml
+++ b/kinder-bilevel-planning/pyproject.toml
@@ -34,7 +34,10 @@ develop = [
     "nbmake",
     "pylint>=2.14.5",
     "pytest-pylint>=0.18.0",
-    "pytest>=7.2.2",
+    # pytest 9.1 dropped the `path` arg from the pytest_collect_file hookspec,
+    # which pytest-pylint 0.21.0 still uses -- it crashes the lint job. Temporary
+    # cap; see https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/issues/111
+    "pytest>=7.2.2,<9.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/kinder-trajopt/notebooks/model_predictive_control.ipynb
+++ b/kinder-trajopt/notebooks/model_predictive_control.ipynb
@@ -21,7 +21,7 @@
    "cell_type": "markdown",
    "id": "5xuaxmf2wki",
    "metadata": {},
-   "source": "## Installation\n\n```bash\npip install kindergarden[kinematic2d]\ngit clone https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git\ncd kinder-baselines\npip install -e kinder-mbrl\npip install -e kinder-trajopt\n```"
+   "source": "## Installation\n\n```bash\npip install kindergarden\ngit clone https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines.git\ncd kinder-baselines\npip install -e kinder-mbrl\npip install -e kinder-trajopt\n```"
   },
   {
    "cell_type": "code",

--- a/kinder-trajopt/pyproject.toml
+++ b/kinder-trajopt/pyproject.toml
@@ -28,7 +28,10 @@ develop = [
     "mypy",
     "pylint>=2.14.5",
     "pytest-pylint>=0.18.0",
-    "pytest>=7.2.2",
+    # pytest 9.1 dropped the `path` arg from the pytest_collect_file hookspec,
+    # which pytest-pylint 0.21.0 still uses -- it crashes the lint job. Temporary
+    # cap; see https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/issues/111
+    "pytest>=7.2.2,<9.1",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## What

Make the bilevel-planning lab installable without PyBullet/MuJoCo, and stop
referencing the `kindergarden[kinematic2d]` extra (removed in
Princeton-Robot-Planning-and-Learning/kindergarden#110).

## Why

The lab only uses the 2D Obstruction2D environments. The default install pulls
the full simulation backend stack (PyBullet, MuJoCo, ...), which is slow/unwanted
on machines and hosted notebooks like Colab.

## Changes

- `kinder-bilevel-planning/lab/requirements/lab2d.txt`: the 2D-only dependency
  closure across `kindergarden`, `kinder_models`, and `kinder_bilevel_planning`
  (+ pytest).
- `kinder-bilevel-planning/lab/SETUP.md`: document the slim install
  (`--no-deps` + `lab2d.txt`).
- `bilevel_planning` and `model_predictive_control` notebooks: install plain
  `kindergarden` instead of the removed `[kinematic2d]` extra.

## Validation

A fresh venv built the documented slim way installs no PyBullet/MuJoCo/pygame,
and `pytest part1_stacking` runs (failing only on the intended lab TODOs).

## Note

CI lint on this repo may hit a pre-existing, unrelated failure (pytest 9.1 vs
`pytest-pylint`), tracked in
Princeton-Robot-Planning-and-Learning/kindergarden#111. Not introduced by this PR
(no `.py` changes here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
