### PR TITLE
Add Franka FR3 pick-and-place parameterized skills

### DIFF
--- a/kinder-ds-policies/experiments/collect_demos_ds.py
+++ b/kinder-ds-policies/experiments/collect_demos_ds.py
@@ -101,6 +101,14 @@ def collect_single_demo(
     obs, _ = env.reset(seed=seed)
     observations.append(obs)
 
+    # Some scripted policies keep moving after the environment's goal is
+    # already satisfied (e.g. a positional region check that fires while the
+    # object is still gripped, before the place skill releases and retracts).
+    # When the policy exposes is_finished(), run until it completes so the demo
+    # captures the full motion; otherwise stop at the environment's first
+    # termination, as before.
+    policy_is_finished = getattr(policy, "is_finished", None)
+
     for _ in range(max_steps):
         try:
             action = policy(obs)
@@ -112,11 +120,16 @@ def collect_single_demo(
         actions.append(action)
         rewards.append(float(rew))
 
-        if done:
-            terminated = True
-            break
+        # Record the environment's latest termination status either way.
+        terminated = bool(done)
         if trunc:
             truncated = True
+            break
+
+        if policy_is_finished is not None:
+            if policy_is_finished():
+                break
+        elif done:
             break
 
     return observations, actions, rewards, terminated, truncated

--- a/kinder-ds-policies/experiments/collect_demos_ds.py
+++ b/kinder-ds-policies/experiments/collect_demos_ds.py
@@ -133,7 +133,7 @@ def _main(cfg: DictConfig) -> None:
 
     # Create the environment.
     kinder.register_all_environments()
-    env = kinder.make(**cfg.env.make_kwargs, render_mode="rgb_array", use_gui=False)
+    env = kinder.make(**cfg.env.make_kwargs, render_mode="rgb_array")
     env_id = cfg.env.make_kwargs["id"]
 
     # Create the domain-specific policy.

--- a/kinder-ds-policies/experiments/conf/env/franka_pickplace3d-o1.yaml
+++ b/kinder-ds-policies/experiments/conf/env/franka_pickplace3d-o1.yaml
@@ -1,0 +1,9 @@
+# Used to refer to the family of environments, e.g., with different numbers of objects.
+env_name: "franka_pickplace3d"
+
+# Passed into kinder.make() to create the environment.
+make_kwargs:
+  id: "kinder/FrankaPickPlace3D-o1-v0"
+
+# Passed into create_domain_specific_policy() to create the policy.
+policy_kwargs: {}

--- a/kinder-ds-policies/src/kinder_ds_policies/policies/dynamic3d/__init__.py
+++ b/kinder-ds-policies/src/kinder_ds_policies/policies/dynamic3d/__init__.py
@@ -1,0 +1,1 @@
+"""Domain-specific policies for dynamic3d environments."""

--- a/kinder-ds-policies/src/kinder_ds_policies/policies/dynamic3d/franka_pickplace3d.py
+++ b/kinder-ds-policies/src/kinder_ds_policies/policies/dynamic3d/franka_pickplace3d.py
@@ -50,6 +50,7 @@ class FrankaPickPlace3DScriptedPolicy(StatefulPolicy):
         self._skill_sequence: list[tuple[str, tuple[Object, ...]]] = []
         self._skill_index = 0
         self._initialized = False
+        self._finished = False
 
     def reset(self) -> None:
         """Reset the policy state for a new episode."""
@@ -57,6 +58,17 @@ class FrankaPickPlace3DScriptedPolicy(StatefulPolicy):
         self._skill_sequence = []
         self._skill_index = 0
         self._initialized = False
+        self._finished = False
+
+    def is_finished(self) -> bool:
+        """Whether the scripted skill sequence has fully executed.
+
+        The environment's goal is a positional region check that fires while the cube is
+        still gripped during the place descent, before release. Demo collection uses
+        this to keep stepping until the place skill has also opened the gripper and
+        retracted, so the demo captures the full placement.
+        """
+        return self._finished
 
     def _build_skill_sequence(self, state: ObjectCentricState) -> None:
         """Build the skill sequence based on the initial state."""
@@ -112,8 +124,8 @@ class FrankaPickPlace3DScriptedPolicy(StatefulPolicy):
         while self._current_controller.terminated():
             self._skill_index += 1
             if not self._start_next_skill(state):
-                # All skills complete - return zero action (hold still) until
-                # the environment detects the goal.
+                # All skills complete - return zero action (hold still).
+                self._finished = True
                 shape = self._action_space.shape
                 assert shape is not None
                 return np.zeros(shape, dtype=np.float32)

--- a/kinder-ds-policies/src/kinder_ds_policies/policies/dynamic3d/franka_pickplace3d.py
+++ b/kinder-ds-policies/src/kinder_ds_policies/policies/dynamic3d/franka_pickplace3d.py
@@ -1,0 +1,148 @@
+"""Domain-specific policy for the FrankaPickPlace3D environment.
+
+This policy runs a scripted sequence of the pick and place parameterized skills from
+kinder-models: for each cube, pick it and place it in the goal region on the desk. The
+logic mirrors the test in kinder-models/tests/dynamic3d/franka_pickplace.
+"""
+
+from typing import Any
+
+import numpy as np
+from kinder.envs.dynamic3d.object_types import (
+    MujocoFR3RobotObjectType,
+    MujocoMovableObjectType,
+)
+from kinder.envs.dynamic3d.robots.fr3_robot_env import FR3RobotActionSpace
+from kinder_models.dynamic3d.franka_pickplace.parameterized_skills import (
+    create_lifted_controllers,
+)
+from numpy.typing import NDArray
+from relational_structs import Object, ObjectCentricState
+from relational_structs.spaces import ObjectCentricBoxSpace
+
+from kinder_ds_policies.policies.base import PolicyFailure, StatefulPolicy
+
+__all__ = ["create_domain_specific_policy"]
+
+
+class FrankaPickPlace3DScriptedPolicy(StatefulPolicy):
+    """A stateful scripted policy for FrankaPickPlace3D.
+
+    This policy maintains state between calls to track which controller is currently
+    executing and the overall progress through the task.
+    """
+
+    def __init__(
+        self,
+        observation_space: ObjectCentricBoxSpace,
+        action_space: FR3RobotActionSpace,
+        seed: int = 123,
+    ) -> None:
+        self._observation_space = observation_space
+        self._action_space = action_space
+        self._rng = np.random.default_rng(seed)
+
+        # Create controllers; the shared FR3 IK solver is built internally.
+        self._controllers = create_lifted_controllers(self._action_space)
+
+        # State tracking.
+        self._current_controller: Any = None
+        self._skill_sequence: list[tuple[str, tuple[Object, ...]]] = []
+        self._skill_index = 0
+        self._initialized = False
+
+    def reset(self) -> None:
+        """Reset the policy state for a new episode."""
+        self._current_controller = None
+        self._skill_sequence = []
+        self._skill_index = 0
+        self._initialized = False
+
+    def _build_skill_sequence(self, state: ObjectCentricState) -> None:
+        """Build the skill sequence based on the initial state."""
+        robots = state.get_objects(MujocoFR3RobotObjectType)
+        assert len(robots) == 1, f"Expected 1 robot, got {len(robots)}"
+        robot = list(robots)[0]
+        desk = state.get_object_from_name("desk_1")
+
+        # Pick and place each cube in the goal region on the desk.
+        self._skill_sequence = []
+        cubes = sorted(
+            (o for o in state.get_objects(MujocoMovableObjectType)),
+            key=lambda o: o.name,
+        )
+        for cube in cubes:
+            self._skill_sequence.append(("pick", (robot, cube)))
+            self._skill_sequence.append(("place", (robot, cube, desk)))
+
+    def _start_next_skill(self, state: ObjectCentricState) -> bool:
+        """Start the next skill in the sequence.
+
+        Returns True if a skill was started, False if the sequence is complete.
+        """
+        if self._skill_index >= len(self._skill_sequence):
+            return False
+
+        skill_name, objects = self._skill_sequence[self._skill_index]
+        lifted_controller = self._controllers[skill_name]
+        self._current_controller = lifted_controller.ground(objects)
+        try:
+            params = self._current_controller.sample_parameters(state, self._rng)
+            self._current_controller.reset(state, params)
+        except Exception as e:
+            raise PolicyFailure(f"Controller reset failed: {e}") from e
+        return True
+
+    def __call__(self, observation: NDArray[np.float32]) -> NDArray[np.float32]:
+        """Compute action using the scripted controller sequence."""
+        state = self._observation_space.devectorize(observation)
+
+        # Initialize on first call.
+        if not self._initialized:
+            self._build_skill_sequence(state)
+            if not self._start_next_skill(state):
+                raise PolicyFailure("No skills to execute.")
+            self._initialized = True
+
+        # Observe the result of the last action.
+        assert self._current_controller is not None
+        self._current_controller.observe(state)
+
+        # Check if the current controller is done; move to the next skill.
+        while self._current_controller.terminated():
+            self._skill_index += 1
+            if not self._start_next_skill(state):
+                # All skills complete - return zero action (hold still) until
+                # the environment detects the goal.
+                shape = self._action_space.shape
+                assert shape is not None
+                return np.zeros(shape, dtype=np.float32)
+
+        try:
+            action = self._current_controller.step()
+        except Exception as e:
+            raise PolicyFailure(f"Controller step failed: {e}") from e
+        return np.asarray(action, dtype=np.float32)
+
+
+def create_domain_specific_policy(
+    observation_space: ObjectCentricBoxSpace,
+    action_space: FR3RobotActionSpace,
+    seed: int = 123,
+) -> FrankaPickPlace3DScriptedPolicy:
+    """Create a domain-specific policy for FrankaPickPlace3D.
+
+    Args:
+        observation_space: The observation space used to devectorize
+            observations.
+        action_space: The action space (required for controller creation).
+        seed: Random seed for the skill parameter samplers.
+
+    Returns:
+        A stateful policy that maps observations to actions.
+    """
+    return FrankaPickPlace3DScriptedPolicy(
+        observation_space=observation_space,
+        action_space=action_space,
+        seed=seed,
+    )

--- a/kinder-models/src/kinder_models/dynamic3d/fr3_ik_solver.py
+++ b/kinder-models/src/kinder_models/dynamic3d/fr3_ik_solver.py
@@ -1,0 +1,169 @@
+"""Inverse kinematics solver for the Franka FR3 arm.
+
+This module provides an inverse kinematics solver that uses the MuJoCo physics engine on
+the FR3's own MJCF model (``franka_fr3/fr3.xml`` from the kindergarden package), so the
+kinematics exactly match the simulated robot — no cross-model approximation is needed.
+The solver implements a damped least squares approach with nullspace optimization toward
+the home configuration.
+
+Adapted from TidybotIKSolver in ik_solver.py.
+"""
+
+import re
+from pathlib import Path
+
+import kinder
+import mujoco
+import numpy as np
+from kinder.envs.dynamic3d.robots.fr3_robot_env import FR3RobotEnv
+
+# Distance from the flange attachment site to the pinch point between the
+# Robotiq 2F-85 finger pads, along the approach axis. Measured in the MJCF at
+# the home configuration (pad centers sit ~0.112 m beyond the flange; the
+# pinch point is slightly past the pad centers, toward the tips).
+FR3_TCP_OFFSET = 0.125
+
+
+class FR3IKSolver:
+    """Inverse kinematics solver for the Franka FR3 arm.
+
+    Targets are expressed in the arm base (mount) frame, at the pinch point of the
+    Robotiq 2F-85 gripper. Only the 7 arm joints are solved for; the gripper joints are
+    held at zero.
+    """
+
+    def __init__(
+        self,
+        ee_offset: float = 0.0,
+        damping_coeff: float = 1e-12,
+        max_angle_change: float = np.deg2rad(45),
+    ) -> None:
+        # Load the FR3 model (arm + gripper). The MJCF's meshdir assumes the
+        # kindergarden scene-merging rewrite, so point it at the real assets
+        # directory for standalone loading.
+        models_dir = Path(kinder.__file__).parent / "envs" / "dynamic3d" / "models"
+        xml = (models_dir / "franka_fr3" / "fr3.xml").read_text(encoding="utf-8")
+        xml = re.sub(r'meshdir="[^"]*"', f'meshdir="{models_dir / "assets"}"', xml)
+        self.model = mujoco.MjModel.from_xml_string(xml)  # pylint: disable=no-member
+        self.data = mujoco.MjData(self.model)  # pylint: disable=no-member
+        self.model.body_gravcomp[:] = 1.0
+
+        # The 7 arm joints must come first so we can slice qpos and the
+        # Jacobian by [:7].
+        arm_joint_names = [self.model.joint(i).name for i in range(7)]
+        assert arm_joint_names == [f"fr3_joint{i}" for i in range(1, 8)]
+
+        # Cache references
+        self.qpos0 = FR3RobotEnv.HOME_QPOS.copy()
+        self.site_id = self.model.site("attachment_site").id
+        self.site_pos = self.data.site(self.site_id).xpos
+        self.site_mat = self.data.site(self.site_id).xmat
+
+        # Extend the site from the flange to the gripper pinch point.
+        self.model.site(self.site_id).pos[2] += FR3_TCP_OFFSET + ee_offset
+
+        # Preallocate arrays
+        self.err = np.empty(6)
+        self.err_pos, self.err_rot = self.err[:3], self.err[3:]
+        self.site_quat = np.empty(4)
+        self.site_quat_inv = np.empty(4)
+        self.err_quat = np.empty(4)
+        self.jac = np.empty((6, self.model.nv))
+        self.jac_pos, self.jac_rot = self.jac[:3], self.jac[3:]
+        self.damping = damping_coeff * np.eye(6)
+        self.eye = np.eye(7)
+        self.max_angle_change = max_angle_change
+
+    def get_site_pose(self, qpos: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Compute the pinch-point pose for the given 7 arm joint positions.
+
+        Returns (position, quaternion) in the arm base frame, with the quaternion in (x,
+        y, z, w) order.
+        """
+        self.data.qpos[:7] = qpos
+        self.data.qpos[7:] = 0.0
+        mujoco.mj_kinematics(self.model, self.data)  # pylint: disable=no-member
+        mujoco.mju_mat2Quat(self.site_quat, self.site_mat)  # pylint: disable=no-member
+        return self.site_pos.copy(), self.site_quat[[1, 2, 3, 0]].copy()
+
+    def solve(
+        self,
+        pos: np.ndarray,
+        quat: np.ndarray,
+        curr_qpos: np.ndarray,
+        max_iters: int = 50,
+        err_thresh: float = 1e-4,
+    ) -> np.ndarray:
+        """Solve inverse kinematics to achieve the desired pinch-point pose.
+
+        Args:
+            pos: Target position (x, y, z) in the arm base frame, in meters
+            quat: Target orientation as quaternion (x, y, z, w)
+            curr_qpos: Current 7 arm joint positions
+            max_iters: Maximum number of iterations (default: 50)
+            err_thresh: Error threshold for convergence (default: 1e-4)
+
+        Returns:
+            The 7 arm joint positions that achieve the target pose
+        """
+        quat = quat[[3, 0, 1, 2]]  # (x, y, z, w) -> (w, x, y, z)
+
+        # Set arm to initial joint configuration; keep the gripper at zero.
+        self.data.qpos[:7] = curr_qpos
+        self.data.qpos[7:] = 0.0
+
+        for _ in range(max_iters):
+            # Update site pose
+            mujoco.mj_kinematics(self.model, self.data)  # pylint: disable=no-member
+            mujoco.mj_comPos(self.model, self.data)  # pylint: disable=no-member
+
+            # Translational error
+            self.err_pos[:] = pos - self.site_pos
+
+            # Rotational error
+            mujoco.mju_mat2Quat(  # pylint: disable=no-member
+                self.site_quat, self.site_mat
+            )
+            mujoco.mju_negQuat(  # pylint: disable=no-member
+                self.site_quat_inv, self.site_quat
+            )
+            mujoco.mju_mulQuat(  # pylint: disable=no-member
+                self.err_quat, quat, self.site_quat_inv
+            )
+            mujoco.mju_quat2Vel(  # pylint: disable=no-member
+                self.err_rot, self.err_quat, 1.0
+            )
+
+            # Check if target pose reached
+            if np.linalg.norm(self.err) < err_thresh:
+                break
+
+            # Calculate update, restricted to the 7 arm dofs
+            mujoco.mj_jacSite(  # pylint: disable=no-member
+                self.model, self.data, self.jac_pos, self.jac_rot, self.site_id
+            )
+            jac_arm = self.jac[:, :7]
+            update = jac_arm.T @ np.linalg.solve(
+                jac_arm @ jac_arm.T + self.damping, self.err
+            )
+            qpos0_err = (
+                np.mod(self.qpos0 - self.data.qpos[:7] + np.pi, 2 * np.pi) - np.pi
+            )
+            update += (
+                self.eye
+                - (
+                    jac_arm.T
+                    @ np.linalg.pinv(jac_arm @ jac_arm.T + self.damping)
+                    @ jac_arm
+                )
+            ) @ qpos0_err
+
+            # Enforce max angle change
+            update_max = np.abs(update).max()
+            if update_max > self.max_angle_change:
+                update *= self.max_angle_change / update_max
+
+            # Apply update
+            self.data.qpos[:7] += update
+
+        return self.data.qpos[:7].copy()

--- a/kinder-models/src/kinder_models/dynamic3d/franka_pickplace/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/franka_pickplace/parameterized_skills.py
@@ -55,6 +55,11 @@ PLACE_HEIGHT_OFFSET = 0.02
 GRIPPER_CLOSE_STEPS = 15
 GRIPPER_OPEN_STEPS = 10
 
+# Gripper close command in [0, 1]. A full close (1.0) squeezes the 2F-85 pads
+# far past contact on a 5 cm cube, rolling it in the grip; 0.6 is just beyond
+# contact. Ramped over the grip phase (see _GripPhase) for a gentle squeeze.
+GRIPPER_CLOSE_COMMAND = 0.6
+
 # Proportional gain for tracking profile targets; deltas are clipped to the
 # action space bounds by the caller-provided action space.
 ARM_KP = 2.0
@@ -89,13 +94,29 @@ class _MovePhase:
 
 
 class _GripPhase:
-    """Hold an arm configuration while commanding the gripper."""
+    """Hold an arm configuration while ramping the gripper command.
 
-    def __init__(self, hold_conf: np.ndarray, gripper: float, num_steps: int) -> None:
+    The command is interpolated linearly from gripper_start to gripper_end over
+    num_steps so the fingers close (or open) gently instead of snapping to the target.
+    """
+
+    def __init__(
+        self,
+        hold_conf: np.ndarray,
+        gripper_start: float,
+        gripper_end: float,
+        num_steps: int,
+    ) -> None:
         self.hold_conf = hold_conf
-        self.gripper = gripper
+        self.gripper_start = gripper_start
+        self.gripper_end = gripper_end
         self.num_steps = num_steps
         self.step_idx = 0
+
+    def current_command(self) -> float:
+        """The ramped gripper command for the current step."""
+        frac = min(1.0, (self.step_idx + 1) / self.num_steps)
+        return self.gripper_start + (self.gripper_end - self.gripper_start) * frac
 
 
 class _FrankaArmController(GroundParameterizedController[ObjectCentricState, Array]):
@@ -154,8 +175,9 @@ class _FrankaArmController(GroundParameterizedController[ObjectCentricState, Arr
             if phase.step_idx >= phase.num_steps:
                 self._phase_idx += 1
                 continue
+            gripper = phase.current_command()
             phase.step_idx += 1
-            return self._make_action(curr, phase.hold_conf, phase.gripper)
+            return self._make_action(curr, phase.hold_conf, gripper)
         # All phases done: hold the final configuration.
         last_phase = self._phases[-1]
         hold = (
@@ -170,7 +192,10 @@ class _FrankaArmController(GroundParameterizedController[ObjectCentricState, Arr
 
     def _final_gripper(self) -> float:
         assert self._phases is not None
-        return self._phases[-1].gripper
+        last_phase = self._phases[-1]
+        if isinstance(last_phase, _GripPhase):
+            return last_phase.gripper_end
+        return last_phase.gripper
 
     def _make_action(
         self, curr: np.ndarray, target: np.ndarray, gripper: float
@@ -256,8 +281,13 @@ class PickFrankaController(_FrankaArmController):
         return [
             _MovePhase(pre_grasp_conf, gripper=0.0),
             _MovePhase(grasp_conf, gripper=0.0),
-            _GripPhase(grasp_conf, gripper=1.0, num_steps=GRIPPER_CLOSE_STEPS),
-            _MovePhase(pre_grasp_conf, gripper=1.0),
+            _GripPhase(
+                grasp_conf,
+                gripper_start=0.0,
+                gripper_end=GRIPPER_CLOSE_COMMAND,
+                num_steps=GRIPPER_CLOSE_STEPS,
+            ),
+            _MovePhase(pre_grasp_conf, gripper=GRIPPER_CLOSE_COMMAND),
         ]
 
 
@@ -318,9 +348,14 @@ class PlaceFrankaController(_FrankaArmController):
         place_conf = self._solve_ik(place_world, pre_place_conf)
 
         return [
-            _MovePhase(pre_place_conf, gripper=1.0),
-            _MovePhase(place_conf, gripper=1.0),
-            _GripPhase(place_conf, gripper=0.0, num_steps=GRIPPER_OPEN_STEPS),
+            _MovePhase(pre_place_conf, gripper=GRIPPER_CLOSE_COMMAND),
+            _MovePhase(place_conf, gripper=GRIPPER_CLOSE_COMMAND),
+            _GripPhase(
+                place_conf,
+                gripper_start=GRIPPER_CLOSE_COMMAND,
+                gripper_end=0.0,
+                num_steps=GRIPPER_OPEN_STEPS,
+            ),
             _MovePhase(pre_place_conf, gripper=0.0),
             _MovePhase(FR3RobotEnv.HOME_QPOS.copy(), gripper=0.0),
         ]

--- a/kinder-models/src/kinder_models/dynamic3d/franka_pickplace/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/franka_pickplace/parameterized_skills.py
@@ -1,0 +1,396 @@
+"""Parameterized skills for the Franka FR3 FrankaPickPlace3D environment.
+
+The FR3 is a fixed-base arm mounted on a desk, so unlike the TidyBot skills there is no
+base navigation: each skill is a sequence of arm/gripper phases. Waypoint configurations
+are computed at reset time with FR3IKSolver (exact MuJoCo kinematics) and executed with
+trapezoidal joint-space velocity profiles under proportional control.
+"""
+
+from typing import Any
+
+import numpy as np
+from bilevel_planning.structs import (
+    GroundParameterizedController,
+    LiftedParameterizedController,
+)
+from gymnasium.spaces import Box
+from kinder.envs.dynamic3d.object_types import (
+    MujocoFixtureObjectType,
+    MujocoFR3RobotObjectType,
+    MujocoMovableObjectType,
+)
+from kinder.envs.dynamic3d.robots.fr3_robot_env import (
+    FR3RobotActionSpace,
+    FR3RobotEnv,
+)
+from relational_structs import (
+    Array,
+    Object,
+    ObjectCentricState,
+    Variable,
+)
+
+from kinder_models.dynamic3d.fr3_ik_solver import FR3IKSolver
+from kinder_models.dynamic3d.utils import (
+    MAX_SAMPLER_ATTEMPTS,
+    _compute_per_joint_profile,
+)
+
+# Height (z) of the fixed base mount above the ground. Matches
+# robots.fr3.robot.mount_height in FrankaPickPlace3D task JSONs; the mount
+# pose in the state only carries (x, y, yaw).
+FR3_MOUNT_HEIGHT = 0.75
+
+# Vertical clearance of the pre-grasp/pre-place waypoints above the grasp and
+# place poses.
+APPROACH_HEIGHT = 0.12
+
+# Extra height above the resting cube height when releasing it.
+PLACE_HEIGHT_OFFSET = 0.02
+
+# Number of control steps to hold the gripper command while closing/opening.
+# pos_gripper reads back the commanded value for the FR3, so closure cannot be
+# detected from the state; instead the command is held long enough for the
+# fingers to settle.
+GRIPPER_CLOSE_STEPS = 15
+GRIPPER_OPEN_STEPS = 10
+
+# Proportional gain for tracking profile targets; deltas are clipped to the
+# action space bounds by the caller-provided action space.
+ARM_KP = 2.0
+
+# Grasp-point offset bounds relative to the target object center (x and y).
+PICK_OFFSET_BOUNDS = (-0.01, 0.01)
+
+# Placement region on the desk, desk-local (x_min, y_min, x_max, y_max).
+# Matches goal_region in FrankaPickPlace3D-o1.json.
+GOAL_REGION_DESK_LOCAL = (-0.05, 0.12, 0.15, 0.27)
+
+# Minimum distance between a sampled placement and any other movable object.
+PLACE_COLLISION_THRESHOLD = 0.08
+
+# Arm joint velocity and acceleration limits (rad/s, rad/s²) for the profile
+# executor. Conservative relative to the FR3 datasheet limits so that the
+# per-step position deltas stay well inside the action bounds at 10 Hz.
+_FR3_MAX_VEL = np.deg2rad(np.array([80.0, 80.0, 80.0, 80.0, 70.0, 70.0, 70.0]))
+_FR3_MAX_ACCEL = np.deg2rad(np.array([297.0, 150.0, 150.0, 150.0, 150.0, 150.0, 150.0]))
+
+
+class _MovePhase:
+    """Follow a trapezoidal joint-space profile to a target configuration."""
+
+    def __init__(self, target_conf: np.ndarray, gripper: float) -> None:
+        self.target_conf = target_conf
+        self.gripper = gripper
+        self.trajectory: np.ndarray | None = None
+        self.direction: np.ndarray = np.zeros(7)
+        self.start_conf: np.ndarray = np.zeros(7)
+        self.step_idx = 0
+
+
+class _GripPhase:
+    """Hold an arm configuration while commanding the gripper."""
+
+    def __init__(self, hold_conf: np.ndarray, gripper: float, num_steps: int) -> None:
+        self.hold_conf = hold_conf
+        self.gripper = gripper
+        self.num_steps = num_steps
+        self.step_idx = 0
+
+
+class _FrankaArmController(GroundParameterizedController[ObjectCentricState, Array]):
+    """Base class executing a phase sequence computed at reset time.
+
+    The object parameters always start with the robot; subclasses define the rest and
+    build the phase list in _create_phases().
+    """
+
+    def __init__(self, *args, ik_solver: FR3IKSolver | None = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._ik_solver = ik_solver
+        self._last_state: ObjectCentricState | None = None
+        self._current_params: np.ndarray | None = None
+        self._phases: list[_MovePhase | _GripPhase] | None = None
+        self._phase_idx = 0
+        # Pinch-point orientation in the base frame: same as at the home
+        # configuration, i.e. pointing straight down for a top-down grasp.
+        self._down_quat: np.ndarray | None = None
+
+    def reset(self, x: ObjectCentricState, params: Any) -> None:
+        if self._ik_solver is None:
+            self._ik_solver = FR3IKSolver()
+        self._last_state = x
+        self._current_params = np.asarray(params, dtype=np.float32)
+        _, self._down_quat = self._ik_solver.get_site_pose(FR3RobotEnv.HOME_QPOS)
+        self._phases = self._create_phases(x)
+        self._phase_idx = 0
+
+    def _create_phases(self, x: ObjectCentricState) -> list[_MovePhase | _GripPhase]:
+        raise NotImplementedError
+
+    def terminated(self) -> bool:
+        assert self._phases is not None
+        return self._phase_idx >= len(self._phases)
+
+    def step(self) -> Array:
+        assert self._phases is not None
+        curr = np.array(self._get_current_arm_conf())
+        while self._phase_idx < len(self._phases):
+            phase = self._phases[self._phase_idx]
+            if isinstance(phase, _MovePhase):
+                if phase.trajectory is None:
+                    phase.start_conf = curr.copy()
+                    phase.trajectory, phase.direction = _compute_per_joint_profile(
+                        curr, phase.target_conf, _FR3_MAX_VEL, _FR3_MAX_ACCEL
+                    )
+                if phase.step_idx >= len(phase.trajectory):
+                    self._phase_idx += 1
+                    continue
+                s = float(phase.trajectory[phase.step_idx])
+                target = phase.start_conf + phase.direction * s
+                phase.step_idx += 1
+                return self._make_action(curr, target, phase.gripper)
+            assert isinstance(phase, _GripPhase)
+            if phase.step_idx >= phase.num_steps:
+                self._phase_idx += 1
+                continue
+            phase.step_idx += 1
+            return self._make_action(curr, phase.hold_conf, phase.gripper)
+        # All phases done: hold the final configuration.
+        last_phase = self._phases[-1]
+        hold = (
+            last_phase.target_conf
+            if isinstance(last_phase, _MovePhase)
+            else last_phase.hold_conf
+        )
+        return self._make_action(curr, hold, self._final_gripper())
+
+    def observe(self, x: ObjectCentricState) -> None:
+        self._last_state = x
+
+    def _final_gripper(self) -> float:
+        assert self._phases is not None
+        return self._phases[-1].gripper
+
+    def _make_action(
+        self, curr: np.ndarray, target: np.ndarray, gripper: float
+    ) -> Array:
+        action = np.zeros(8, dtype=np.float32)
+        # Delta joint targets, clipped to the FR3 action bounds.
+        action[:7] = np.clip(ARM_KP * (target - curr), -0.1, 0.1)
+        action[7] = gripper
+        return action
+
+    def _get_current_arm_conf(self) -> list[float]:
+        x = self._last_state
+        assert x is not None
+        robot = self.objects[0]
+        return [x.get(robot, f"pos_arm_joint{i}") for i in range(1, 8)]
+
+    def _world_to_base(self, pos_world: np.ndarray) -> np.ndarray:
+        """Transform a world position into the arm base (mount) frame."""
+        x = self._last_state
+        assert x is not None
+        robot = self.objects[0]
+        mount = np.array(
+            [
+                x.get(robot, "pos_base_x"),
+                x.get(robot, "pos_base_y"),
+                FR3_MOUNT_HEIGHT,
+            ]
+        )
+        yaw = x.get(robot, "pos_base_rot")
+        delta = pos_world - mount
+        cos_yaw, sin_yaw = np.cos(-yaw), np.sin(-yaw)
+        return np.array(
+            [
+                cos_yaw * delta[0] - sin_yaw * delta[1],
+                sin_yaw * delta[0] + cos_yaw * delta[1],
+                delta[2],
+            ]
+        )
+
+    def _solve_ik(self, pos_world: np.ndarray, init_conf: np.ndarray) -> np.ndarray:
+        assert self._ik_solver is not None and self._down_quat is not None
+        target_base = self._world_to_base(pos_world)
+        conf = self._ik_solver.solve(target_base, self._down_quat, init_conf)
+        reached, _ = self._ik_solver.get_site_pose(conf)
+        assert (
+            np.linalg.norm(reached - target_base) < 1e-3
+        ), f"IK failed to reach {pos_world}"
+        return conf
+
+
+class PickFrankaController(_FrankaArmController):
+    """Top-down pick: approach above the target, descend, close, lift.
+
+    The object parameters are:
+        robot: The robot itself.
+        object: The target object.
+
+    The continuous parameters are an (x, y) grasp-point offset relative to the
+    target object center.
+    """
+
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        del x  # any offset within bounds is valid
+        return rng.uniform(*PICK_OFFSET_BOUNDS, size=2)
+
+    def _create_phases(self, x: ObjectCentricState) -> list[_MovePhase | _GripPhase]:
+        assert self._current_params is not None
+        offset_x, offset_y = self._current_params
+        target = self.objects[1]
+        grasp_world = np.array(
+            [
+                x.get(target, "x") + offset_x,
+                x.get(target, "y") + offset_y,
+                x.get(target, "z"),
+            ]
+        )
+        pre_grasp_world = grasp_world + np.array([0.0, 0.0, APPROACH_HEIGHT])
+
+        curr = np.array(self._get_current_arm_conf())
+        pre_grasp_conf = self._solve_ik(pre_grasp_world, curr)
+        grasp_conf = self._solve_ik(grasp_world, pre_grasp_conf)
+
+        return [
+            _MovePhase(pre_grasp_conf, gripper=0.0),
+            _MovePhase(grasp_conf, gripper=0.0),
+            _GripPhase(grasp_conf, gripper=1.0, num_steps=GRIPPER_CLOSE_STEPS),
+            _MovePhase(pre_grasp_conf, gripper=1.0),
+        ]
+
+
+class PlaceFrankaController(_FrankaArmController):
+    """Place a held object on the desk: transfer, descend, open, retract home.
+
+    The object parameters are:
+        robot: The robot itself.
+        object: The held object.
+        surface: The desk fixture to place on.
+
+    The continuous parameters are the desk-local (x, y) placement position.
+    """
+
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        x_min, y_min, x_max, y_max = GOAL_REGION_DESK_LOCAL
+        surface = self.objects[2]
+        held = self.objects[1]
+        for _ in range(MAX_SAMPLER_ATTEMPTS):
+            place_x = rng.uniform(x_min, x_max)
+            place_y = rng.uniform(y_min, y_max)
+            place_world = np.array(
+                [
+                    x.get(surface, "x") + place_x,
+                    x.get(surface, "y") + place_y,
+                ]
+            )
+            collision = False
+            for other in x.get_objects(MujocoMovableObjectType):
+                if other.name == held.name:
+                    continue
+                other_xy = np.array([x.get(other, "x"), x.get(other, "y")])
+                if np.linalg.norm(place_world - other_xy) < PLACE_COLLISION_THRESHOLD:
+                    collision = True
+                    break
+            if not collision:
+                return np.array([place_x, place_y])
+        raise ValueError("No valid parameters found")
+
+    def _create_phases(self, x: ObjectCentricState) -> list[_MovePhase | _GripPhase]:
+        assert self._current_params is not None
+        place_x, place_y = self._current_params
+        held = self.objects[1]
+        surface = self.objects[2]
+        # Release with the held object slightly above its resting height.
+        place_z = FR3_MOUNT_HEIGHT + x.get(held, "bb_z") / 2 + PLACE_HEIGHT_OFFSET
+        place_world = np.array(
+            [
+                x.get(surface, "x") + place_x,
+                x.get(surface, "y") + place_y,
+                place_z,
+            ]
+        )
+        pre_place_world = place_world + np.array([0.0, 0.0, APPROACH_HEIGHT])
+
+        curr = np.array(self._get_current_arm_conf())
+        pre_place_conf = self._solve_ik(pre_place_world, curr)
+        place_conf = self._solve_ik(place_world, pre_place_conf)
+
+        return [
+            _MovePhase(pre_place_conf, gripper=1.0),
+            _MovePhase(place_conf, gripper=1.0),
+            _GripPhase(place_conf, gripper=0.0, num_steps=GRIPPER_OPEN_STEPS),
+            _MovePhase(pre_place_conf, gripper=0.0),
+            _MovePhase(FR3RobotEnv.HOME_QPOS.copy(), gripper=0.0),
+        ]
+
+
+def create_lifted_controllers(
+    action_space: FR3RobotActionSpace,
+    init_constant_state: ObjectCentricState | None = None,
+    ik_solver: FR3IKSolver | None = None,
+) -> dict[str, LiftedParameterizedController]:
+    """Create lifted parameterized controllers for the FrankaPickPlace3D env."""
+    del action_space, init_constant_state  # not used
+
+    if ik_solver is None:
+        ik_solver = FR3IKSolver()
+
+    # Create wrapper classes that capture the shared IK solver.
+    class PickController(PickFrankaController):
+        """Pick controller with a pre-configured IK solver."""
+
+        def __init__(self, objects: list[Object]) -> None:
+            super().__init__(ik_solver=ik_solver, objects=objects)
+
+    class PlaceController(PlaceFrankaController):
+        """Place controller with a pre-configured IK solver."""
+
+        def __init__(self, objects: list[Object]) -> None:
+            super().__init__(ik_solver=ik_solver, objects=objects)
+
+    # Pick controller.
+    robot = Variable("?robot", MujocoFR3RobotObjectType)
+    target = Variable("?target", MujocoMovableObjectType)
+
+    # Parameter space: (x, y) grasp-point offset.
+    pick_params_space = Box(
+        low=np.array([PICK_OFFSET_BOUNDS[0]] * 2, dtype=np.float32),
+        high=np.array([PICK_OFFSET_BOUNDS[1]] * 2, dtype=np.float32),
+        dtype=np.float32,
+    )
+
+    lifted_pick_controller: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot, target],
+            PickController,
+            params_space=pick_params_space,
+        )
+    )
+
+    # Place controller.
+    robot = Variable("?robot", MujocoFR3RobotObjectType)
+    target = Variable("?target", MujocoMovableObjectType)
+    surface = Variable("?surface", MujocoFixtureObjectType)
+
+    # Parameter space: desk-local (x, y) placement position.
+    x_min, y_min, x_max, y_max = GOAL_REGION_DESK_LOCAL
+    place_params_space = Box(
+        low=np.array([x_min, y_min], dtype=np.float32),
+        high=np.array([x_max, y_max], dtype=np.float32),
+        dtype=np.float32,
+    )
+
+    lifted_place_controller: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot, target, surface],
+            PlaceController,
+            params_space=place_params_space,
+        )
+    )
+
+    return {
+        "pick": lifted_pick_controller,
+        "place": lifted_place_controller,
+    }

--- a/kinder-models/tests/dynamic3d/franka_pickplace/test_franka_pickplace_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/franka_pickplace/test_franka_pickplace_parameterized_skills.py
@@ -1,0 +1,153 @@
+"""Tests for the Franka FR3 pick-and-place parameterized skills."""
+
+import pickle
+import time
+from pathlib import Path
+
+import kinder
+import numpy as np
+from conftest import MAKE_VIDEOS, SAVE_DEMOS
+from gymnasium.wrappers import RecordVideo
+from kinder.envs.dynamic3d.object_types import MujocoFR3RobotObjectType
+from relational_structs import ObjectCentricState
+from relational_structs.spaces import ObjectCentricBoxSpace
+
+from kinder_models.dynamic3d.franka_pickplace.parameterized_skills import (
+    create_lifted_controllers,
+)
+
+kinder.register_all_environments()
+
+
+def _save_demo(
+    env_id: str,
+    seed: int,
+    observations: list,
+    actions: list,
+    rewards: list,
+    terminated: bool,
+    truncated: bool,
+    demos_dir: str = "./demos",
+) -> Path:
+    """Save a demo pickle in the standard kindergarden demo format."""
+    env_short_name = env_id.removeprefix("kinder/").removesuffix("-v0")
+    timestamp = int(time.time())
+    save_dir = Path(demos_dir) / env_short_name / str(seed)
+    save_dir.mkdir(parents=True, exist_ok=True)
+    save_path = save_dir / f"{timestamp}.p"
+    demo = {
+        "env_id": env_id,
+        "timestamp": timestamp,
+        "seed": seed,
+        "observations": observations,
+        "actions": actions,
+        "rewards": rewards,
+        "terminated": terminated,
+        "truncated": truncated,
+    }
+    with open(save_path, "wb") as f:
+        pickle.dump(demo, f)
+    print(f"\nSaved demo to {save_path}")
+    return save_path
+
+
+def _get_robot_from_state(state: ObjectCentricState):
+    """Helper to get robot object from state by type."""
+    robots = state.get_objects(MujocoFR3RobotObjectType)
+    assert len(robots) == 1, f"Expected 1 robot, got {len(robots)}"
+    return list(robots)[0]
+
+
+def test_franka_pick_place_skill():
+    """Pick and place one cube into the goal region on the desk."""
+    env_id = "kinder/FrankaPickPlace3D-o1-v0"
+    seed = 123
+    env = kinder.make(env_id, render_mode="rgb_array")
+    if MAKE_VIDEOS:
+        env = RecordVideo(
+            env, "unit_test_videos", name_prefix="FrankaPickPlace3D-o1-real"
+        )
+
+    # Reset the environment and get the initial state.
+    obs, _ = env.reset(seed=seed)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+
+    demo_observations = [obs]
+    demo_actions: list = []
+    demo_rewards: list = []
+    demo_terminated = False
+    demo_truncated = False
+
+    controllers = create_lifted_controllers(env.action_space)
+
+    # Create the pick ground controller.
+    lifted_controller = controllers["pick"]
+    robot = _get_robot_from_state(state)
+    cube = state.get_object_from_name("cube1")
+    controller = lifted_controller.ground((robot, cube))
+    params = controller.sample_parameters(state, np.random.default_rng(seed))
+
+    # Reset and execute the controller until it terminates.
+    controller.reset(state, params)
+    for _ in range(400):
+        action = controller.step()
+        obs, reward, terminated, truncated, _ = env.step(action)
+        demo_observations.append(obs)
+        demo_actions.append(action)
+        demo_rewards.append(reward)
+        demo_terminated = terminated
+        demo_truncated = truncated
+        next_state = env.observation_space.devectorize(obs)
+        controller.observe(next_state)
+        state = next_state
+        if controller.terminated():
+            break
+    else:
+        assert False, "Pick controller did not terminate"
+
+    # The cube must have been lifted off the desk.
+    cube = state.get_object_from_name("cube1")
+    assert state.get(cube, "z") > 0.85, "Cube was not lifted"
+
+    # Create the place ground controller.
+    lifted_controller = controllers["place"]
+    robot = _get_robot_from_state(state)
+    cube = state.get_object_from_name("cube1")
+    desk = state.get_object_from_name("desk_1")
+    controller = lifted_controller.ground((robot, cube, desk))
+    params = controller.sample_parameters(state, np.random.default_rng(seed))
+
+    # Reset and execute the controller until it terminates.
+    controller.reset(state, params)
+    for _ in range(400):
+        action = controller.step()
+        obs, reward, terminated, truncated, _ = env.step(action)
+        demo_observations.append(obs)
+        demo_actions.append(action)
+        demo_rewards.append(reward)
+        demo_terminated = terminated
+        demo_truncated = truncated
+        next_state = env.observation_space.devectorize(obs)
+        controller.observe(next_state)
+        state = next_state
+        if controller.terminated():
+            break
+    else:
+        assert False, "Place controller did not terminate"
+
+    # The goal (cube in the goal region) must have been reached.
+    assert demo_terminated, "Environment did not terminate with the goal reached"
+
+    env.close()
+
+    if SAVE_DEMOS:
+        _save_demo(
+            env_id=env_id,
+            seed=seed,
+            observations=demo_observations,
+            actions=demo_actions,
+            rewards=demo_rewards,
+            terminated=demo_terminated,
+            truncated=demo_truncated,
+        )

--- a/kinder-models/tests/dynamic3d/test_fr3_ik.py
+++ b/kinder-models/tests/dynamic3d/test_fr3_ik.py
@@ -1,0 +1,89 @@
+"""Tests for the Franka FR3 inverse kinematics solver (FR3IKSolver)."""
+
+import mujoco
+import numpy as np
+from kinder.envs.dynamic3d.robots.fr3_robot_env import FR3RobotEnv
+
+from kinder_models.dynamic3d.fr3_ik_solver import FR3IKSolver
+
+
+def _rotation_from_quat_xyzw(quat: np.ndarray) -> np.ndarray:
+    """Convert an (x, y, z, w) quaternion to a 3x3 rotation matrix."""
+    mat = np.empty(9)
+    mujoco.mju_quat2Mat(mat, quat[[3, 0, 1, 2]])  # pylint: disable=no-member
+    return mat.reshape(3, 3)
+
+
+def test_fr3_fk_home_pose():
+    """FK at the home configuration matches the measured MJCF geometry.
+
+    The TCP (2F-85 pinch point) sits in front of the mount with the approach axis
+    pointing straight down, which is what the top-down pick-and-place skills rely on.
+    """
+    ik = FR3IKSolver()
+    pos, quat = ik.get_site_pose(FR3RobotEnv.HOME_QPOS)
+    # Flange at (0.5545, 0, 0.6245) in the base frame, minus the 0.125 m TCP
+    # extension along the downward approach axis.
+    assert np.allclose(pos, [0.5545, 0.0, 0.4995], atol=1e-2)
+    approach_axis = _rotation_from_quat_xyzw(quat)[:, 2]
+    assert np.allclose(approach_axis, [0.0, 0.0, -1.0], atol=1e-6)
+
+
+def test_fr3_ik_solver_basic():
+    """Solving for the home pose from the home configuration is a fixed point."""
+    ik = FR3IKSolver()
+    target_pos, target_quat = ik.get_site_pose(FR3RobotEnv.HOME_QPOS)
+    result = ik.solve(target_pos, target_quat, FR3RobotEnv.HOME_QPOS)
+    assert result.shape == (7,)
+    assert np.all(np.isfinite(result))
+    assert np.allclose(result, FR3RobotEnv.HOME_QPOS, atol=1e-3)
+
+
+def test_fr3_ik_fk_roundtrip():
+    """IK followed by FK reproduces top-down targets across the desk workspace.
+
+    Targets are in the arm base frame and bracket the poses the pick-and-place
+    skills request: grasp/pre-grasp near the cube region and place/pre-place
+    near the goal region of FrankaPickPlace3D-o1.
+    """
+    ik = FR3IKSolver()
+    home = FR3RobotEnv.HOME_QPOS
+    _, down_quat = ik.get_site_pose(home)
+    targets = [
+        (0.56, -0.03, 0.03),  # grasp height near the cube init region
+        (0.56, -0.03, 0.15),  # pre-grasp above it
+        (0.40, 0.18, 0.05),  # place height in the goal region
+        (0.40, 0.18, 0.17),  # pre-place above it
+        (0.45, -0.20, 0.10),  # opposite side of the desk
+    ]
+    for target in targets:
+        target_pos = np.array(target)
+        qpos = ik.solve(target_pos, down_quat, home)
+        assert qpos.shape == (7,)
+        assert np.all(np.isfinite(qpos))
+        fk_pos, fk_quat = ik.get_site_pose(qpos)
+        assert np.allclose(
+            fk_pos, target_pos, atol=1e-3
+        ), f"Position mismatch at {target}: {fk_pos}"
+        quat_dist = min(
+            float(np.linalg.norm(fk_quat - down_quat)),
+            float(np.linalg.norm(fk_quat + down_quat)),
+        )
+        assert quat_dist < 1e-2, f"Orientation mismatch at {target}: {fk_quat}"
+
+
+def test_fr3_ik_unreachable_target():
+    """An unreachable target yields a large FK error rather than a failure signal.
+
+    The solver is best-effort; callers are responsible for verifying the solution with
+    FK, as the pick-and-place skills do.
+    """
+    ik = FR3IKSolver()
+    home = FR3RobotEnv.HOME_QPOS
+    _, down_quat = ik.get_site_pose(home)
+    # Well beyond the FR3's ~0.855 m reach.
+    target_pos = np.array([1.5, 0.0, 0.1])
+    qpos = ik.solve(target_pos, down_quat, home)
+    assert np.all(np.isfinite(qpos))
+    fk_pos, _ = ik.get_site_pose(qpos)
+    assert np.linalg.norm(fk_pos - target_pos) > 0.3


### PR DESCRIPTION
## Summary

Adds pick and place parameterized skills for `kinder/FrankaPickPlace3D-o1-v0`, the desk-mounted Franka FR3 task introduced in kindergarden PR [Princeton-Robot-Planning-and-Learning/kindergarden#115](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/115).

> [!NOTE]
> **Draft: red CI is expected.** These skills import `FR3RobotEnv` / `MujocoFR3RobotObjectType`, which only exist on the unmerged kindergarden branch. CI installs `kindergarden` from PyPI and will fail until kindergarden #115 merges and a release ships. Verified green locally against an editable install of that branch (mypy, pylint, and the full kinder-models test suite).

## What's added

- `src/kinder_models/dynamic3d/fr3_ik_solver.py` — `FR3IKSolver`: damped-least-squares IK with nullspace bias toward `HOME_QPOS`, running on the FR3's own MJCF (`franka_fr3/fr3.xml`) so kinematics exactly match the simulated robot. Mirrors `TidybotIKSolver`; no PyBullet dependency. TCP = flange `attachment_site` extended 0.125 m to the Robotiq 2F-85 pinch point.
- `src/kinder_models/dynamic3d/franka_pickplace/parameterized_skills.py` — `PickFrankaController` (approach, descend, close, lift) and `PlaceFrankaController` (transfer, descend, open, retract home), plus `create_lifted_controllers()` returning `{"pick", "place"}`. The FR3 is fixed-base, so unlike the TidyBot shelf skills there is no base-navigation phase; waypoint configurations are solved by IK at reset time and executed with trapezoidal joint-space profiles under proportional control.
- `tests/dynamic3d/franka_pickplace/test_franka_pickplace_parameterized_skills.py` — end-to-end: pick then place one cube, asserting the cube is lifted off the desk and the env's goal predicate fires. Supports `--make-videos` / `--save-demos` like the shelf tests.

## Design notes

- **MuJoCo-native IK instead of a PyBullet Panda stand-in**: exact FR3 kinematics (IK residuals ~1e-6), one less simulator in the loop.
- **Known limitation**: no collision-aware motion planning between waypoints — fine for one cube on an open desk, needs a real planner for cluttered variants.
- `pos_gripper` reads back the commanded value (not measured finger width), so grasp closure is handled by holding the gripper command for a fixed number of steps.

## Testing

- New test passes: pick lifts the cube (z > 0.85), place lands it in the goal region, env terminates on the goal predicate.
- Full local `./run_ci_checks.sh` green with the kindergarden branch installed: mypy 0 issues, pylint clean, 53/53 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
