### PR TITLE
kinder-models: disconnect PyBulletSim's PyBullet client when the sim is garbage collected

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -432,27 +432,9 @@ class PyBulletSim:
         else:
             self._physics_client_id = p.connect(p.DIRECT)
 
-        # Disconnect when this object is garbage collected. Callers that ground a
-        # fresh controller per skill execution create one sim each, and without this
-        # every one of those clients stays open for the life of the process.
-        #
-        #   weakref.finalize(self, p.disconnect, self._physics_client_id)
-        #                     ^     ^             ^
-        #                     |     |             a plain int
-        #                     |     a module-level function
-        #                     the object being watched
-        #
-        # Both arguments are deliberately self-free. Registering a bound method
-        # (weakref.finalize(self, self.close)) would keep self reachable, so the sim
-        # would never be collected, the callback would never fire, and the leak would
-        # look fixed while continuing. See close() for what does and does not run.
-        #
-        # This mirrors tempfile.TemporaryDirectory in the standard library, which
-        # registers a classmethod plus the path by value for the same reason. It uses
-        # a classmethod because its cleanup is several statements; ours is one call,
-        # so the module-level p.disconnect suffices. If more cleanup is ever needed,
-        # move it to a @staticmethod taking the client id and call that from both
-        # here and close() -- do not reach for self.
+        # Disconnect on collection -- callers ground a fresh controller, and so a
+        # fresh sim, per skill execution. The callback must not reference self, or
+        # the sim stays reachable and is never collected. See close().
         self._finalizer = weakref.finalize(self, p.disconnect, self._physics_client_id)
 
         # Create the robot, assuming that it is a kinova gen3.
@@ -614,19 +596,8 @@ class PyBulletSim:
     def close(self) -> None:
         """Close the PyBullet simulator. Safe to call more than once.
 
-        What runs when, given the finalizer registered in __init__:
-
-            sim.close()          -> this body, then p.disconnect(id)
-            sim goes out of scope -> p.disconnect(id) ONLY; this body does not run
-            close() then collected -> nothing the second time
-
-        Note the middle line: garbage collection invokes the registered callback,
-        not this method, so anything added to this body will silently not happen on
-        collection. Register it in __init__ instead -- and keep it off self, or the
-        sim stays reachable and is never collected at all.
-
-        Do not disconnect physics_client_id by hand instead of calling this:
-        PyBullet reuses client ids, so a finalizer left holding a recycled id would
-        disconnect an unrelated simulator.
+        Collection runs the finalizer, not this method, so put any further cleanup in
+        __init__'s callback. Do not call p.disconnect by hand: ids get reused, so a
+        stale finalizer would disconnect an unrelated sim.
         """
         self._finalizer()

--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -1,6 +1,7 @@
 """Utils for tidybot environments."""
 
 import math
+import weakref
 from typing import Iterable
 
 import numpy as np
@@ -431,6 +432,12 @@ class PyBulletSim:
         else:
             self._physics_client_id = p.connect(p.DIRECT)
 
+        # Disconnect when this object is garbage collected, since callers that create
+        # one sim per skill execution would otherwise exhaust PyBullet's client pool.
+        # The callback must take the client id by value and never close over self, or
+        # the sim would stay reachable and never be collected.
+        self._finalizer = weakref.finalize(self, p.disconnect, self._physics_client_id)
+
         # Create the robot, assuming that it is a kinova gen3.
         self._robot = create_pybullet_robot(
             "kinova-gen3",
@@ -588,5 +595,11 @@ class PyBulletSim:
         return self._joint_distance_fn(conf1, conf2)
 
     def close(self) -> None:
-        """Close the PyBullet simulator."""
-        p.disconnect(self._physics_client_id)
+        """Close the PyBullet simulator.
+
+        Safe to call more than once, and called automatically when this object is
+        garbage collected. Do not disconnect physics_client_id by hand instead:
+        PyBullet reuses client ids, so a finalizer left holding a recycled id would
+        disconnect an unrelated simulator.
+        """
+        self._finalizer()

--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -432,10 +432,27 @@ class PyBulletSim:
         else:
             self._physics_client_id = p.connect(p.DIRECT)
 
-        # Disconnect when this object is garbage collected, since callers that create
-        # one sim per skill execution would otherwise exhaust PyBullet's client pool.
-        # The callback must take the client id by value and never close over self, or
-        # the sim would stay reachable and never be collected.
+        # Disconnect when this object is garbage collected. Callers that ground a
+        # fresh controller per skill execution create one sim each, and without this
+        # every one of those clients stays open for the life of the process.
+        #
+        #   weakref.finalize(self, p.disconnect, self._physics_client_id)
+        #                     ^     ^             ^
+        #                     |     |             a plain int
+        #                     |     a module-level function
+        #                     the object being watched
+        #
+        # Both arguments are deliberately self-free. Registering a bound method
+        # (weakref.finalize(self, self.close)) would keep self reachable, so the sim
+        # would never be collected, the callback would never fire, and the leak would
+        # look fixed while continuing. See close() for what does and does not run.
+        #
+        # This mirrors tempfile.TemporaryDirectory in the standard library, which
+        # registers a classmethod plus the path by value for the same reason. It uses
+        # a classmethod because its cleanup is several statements; ours is one call,
+        # so the module-level p.disconnect suffices. If more cleanup is ever needed,
+        # move it to a @staticmethod taking the client id and call that from both
+        # here and close() -- do not reach for self.
         self._finalizer = weakref.finalize(self, p.disconnect, self._physics_client_id)
 
         # Create the robot, assuming that it is a kinova gen3.
@@ -595,10 +612,20 @@ class PyBulletSim:
         return self._joint_distance_fn(conf1, conf2)
 
     def close(self) -> None:
-        """Close the PyBullet simulator.
+        """Close the PyBullet simulator. Safe to call more than once.
 
-        Safe to call more than once, and called automatically when this object is
-        garbage collected. Do not disconnect physics_client_id by hand instead:
+        What runs when, given the finalizer registered in __init__:
+
+            sim.close()          -> this body, then p.disconnect(id)
+            sim goes out of scope -> p.disconnect(id) ONLY; this body does not run
+            close() then collected -> nothing the second time
+
+        Note the middle line: garbage collection invokes the registered callback,
+        not this method, so anything added to this body will silently not happen on
+        collection. Register it in __init__ instead -- and keep it off self, or the
+        sim stays reachable and is never collected at all.
+
+        Do not disconnect physics_client_id by hand instead of calling this:
         PyBullet reuses client ids, so a finalizer left holding a recycled id would
         disconnect an unrelated simulator.
         """

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1,9 +1,11 @@
 """Tests for ground parameterized skills."""
 
+import gc
 from pathlib import Path
 
 import kinder
 import numpy as np
+import pybullet as p
 from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
 from kinder.envs.dynamic3d.envs import TidyBot3DEnv
@@ -29,12 +31,25 @@ kinder.register_all_environments()
 
 _TEST_TASKS = Path(__file__).parent.parent.parent / "test_tasks"
 
+# PyBullet keeps a fixed-size table of physics clients, so every possible client id
+# can be queried directly.
+_MAX_PYBULLET_CLIENTS = 1024
+
 
 def _get_robot_from_state(state: ObjectCentricState):
     """Helper to get robot object from state by type."""
     robots = state.get_objects(MujocoTidyBotRobotObjectType)
     assert len(robots) == 1, f"Expected 1 robot, got {len(robots)}"
     return list(robots)[0]
+
+
+def _count_connected_pybullet_clients() -> int:
+    """Helper to count the PyBullet physics clients that are currently connected."""
+    return sum(
+        1
+        for client_id in range(_MAX_PYBULLET_CLIENTS)
+        if p.getConnectionInfo(physicsClientId=client_id)["isConnected"]
+    )
 
 
 def _create_robot_state(
@@ -224,6 +239,79 @@ def test_move_to_target_arm_configuration():
             break
     else:
         assert False, "Controller did not terminate"
+
+    env.close()
+
+
+def test_repeated_grounding_does_not_leak_pybullet_clients():
+    """Test that repeatedly grounding a controller does not leak PyBullet clients.
+
+    The motion-planning controllers create a PyBulletSim the first time they are reset,
+    and LiftedParameterizedController.ground() returns a new controller every call, so a
+    planner or data-collection loop creates one PyBulletSim per skill execution. Those
+    clients must be released when the controller is dropped.
+    """
+
+    # Create the environment.
+    num_cubes = 1
+    env = TidyBot3DEnv(
+        task_config_path=str(_TEST_TASKS / f"tidybot-ground-o{num_cubes}.json"),
+        render_mode="rgb_array",
+    )
+
+    # Reset the environment and get the initial state.
+    obs, _ = env.reset(seed=124)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+
+    # Create the controller.
+    controllers = create_lifted_controllers(env.action_space)
+    lifted_controller = controllers["move_arm_to_conf"]
+    robot = _get_robot_from_state(state)
+    object_parameters = (robot,)
+
+    # Alternate between two configurations so that every execution moves the arm.
+    target_confs = [
+        np.zeros(7),
+        np.deg2rad([0.0, -20.0, 180.0, -146.0, 0.0, -50.0, 90.0]),  # retract
+    ]
+    num_executions = 4
+    steps_per_execution = []
+
+    # Ground a fresh controller for each execution and drop it afterwards.
+    clients_before = _count_connected_pybullet_clients()
+    for execution_idx in range(num_executions):
+        controller = lifted_controller.ground(object_parameters)
+        params = target_confs[execution_idx % len(target_confs)]
+
+        # Reset and execute the controller until it terminates.
+        controller.reset(state, params)
+        for num_steps in range(1, 201):
+            action = controller.step()
+            obs, _, _, _, _ = env.step(action)
+            next_state = env.observation_space.devectorize(obs)
+            controller.observe(next_state)
+            state = next_state
+            if controller.terminated():
+                steps_per_execution.append(num_steps)
+                break
+        else:
+            assert False, "Controller did not terminate"
+
+        # Drop the controller and collect so that the client count is deterministic.
+        del controller
+        gc.collect()
+
+    # Check that the executions above did real work, rather than terminating
+    # immediately and making the client count below vacuously correct.
+    assert len(steps_per_execution) == num_executions
+    assert min(steps_per_execution) > 1
+
+    clients_after = _count_connected_pybullet_clients()
+    assert clients_after == clients_before, (
+        f"Leaked {clients_after - clients_before} PyBullet clients over "
+        f"{num_executions} skill executions"
+    )
 
     env.close()
 

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -31,8 +31,11 @@ kinder.register_all_environments()
 
 _TEST_TASKS = Path(__file__).parent.parent.parent / "test_tasks"
 
-# PyBullet keeps a fixed-size table of physics clients, so every possible client id
-# can be queried directly.
+# Size of PyBullet's fixed table of physics client slots. This is a scan bound, not a
+# limit the test imposes: ids are handed out by first-free-slot scan, so a client can
+# land on any id, including one left over from an earlier test in the same process.
+# Scanning fewer slots would silently undercount and let a leak pass. The full scan
+# costs about 0.2 ms. pybullet does not expose the value, so it is repeated here.
 _MAX_PYBULLET_CLIENTS = 1024
 
 
@@ -45,11 +48,12 @@ def _get_robot_from_state(state: ObjectCentricState):
 
 def _count_connected_pybullet_clients() -> int:
     """Helper to count the PyBullet physics clients that are currently connected."""
-    return sum(
-        1
-        for client_id in range(_MAX_PYBULLET_CLIENTS)
-        if p.getConnectionInfo(physicsClientId=client_id)["isConnected"]
-    )
+    num_connected = 0
+    for client_id in range(_MAX_PYBULLET_CLIENTS):
+        connection_info = p.getConnectionInfo(physicsClientId=client_id)
+        if connection_info["isConnected"]:
+            num_connected += 1
+    return num_connected
 
 
 def _create_robot_state(
@@ -298,8 +302,16 @@ def test_repeated_grounding_does_not_leak_pybullet_clients():
         else:
             assert False, "Controller did not terminate"
 
-        # Drop the controller and collect so that the client count is deterministic.
+        # Drop the last reference to the controller, which drops its PyBulletSim,
+        # which runs the sim's weakref.finalize and disconnects the client.
         del controller
+        # gc.collect() runs a full collection pass immediately, rather than whenever
+        # CPython would next get round to it. It is belt-and-braces here: the sim is
+        # freed by reference counting alone, which is immediate and does not need the
+        # collector (verified by running this loop with gc disabled). It would only
+        # start to matter if a future change put the sim in a reference cycle, which
+        # refcounting cannot break. Calling it keeps the count below deterministic
+        # either way.
         gc.collect()
 
     # Check that the executions above did real work, rather than terminating


### PR DESCRIPTION
**TL;DR** — `PyBulletSim` opens a PyBullet client in its constructor and only releases it in `close()`, which has **zero callers** in either [kinder-baselines](https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines) or [kindergarden](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden). Since `ground()` returns a fresh controller per call and each builds a sim lazily, **one skill execution leaks one client and ~150 MB, without bound** — measured at +150.0 MB/execution, R² = 0.999974, live clients exactly `iter + 1` on 40/40 iterations, no plateau. It reproduces in this repo's own `test_pick_toss`. Fixed by registering a `weakref.finalize` that disconnects the client when the sim is collected: **2 files, +103/−2**, with a regression test that fails on `main` and passes with the fix.

<img width="1425" height="1230" alt="image" src="https://github.com/user-attachments/assets/517deff5-1417-49e3-838c-3eeaf080d0aa" />


Reported in #88.

## Question / goal

Why does any loop that repeatedly executes `dynamic3d/tossing` skills grow in memory until it is OOM-killed, and what is the smallest change that fixes it?

## Hypothesis

`PyBulletSim.__init__` connects a client that only `close()` releases; `close()` is never called and there is no finalizer, so one client leaks per skill execution. If so, live client count and RSS should grow linearly and without bound, and explicitly disconnecting should flatten both.

## Guidance given

The fix was constrained to be **the minimum that closes the leak** while following this repo's existing conventions — no refactors, no new public API, nothing that is "while we're here". Assertions had to be on live client count rather than RSS, since the count is exact and deterministic while RSS is allocator-dependent. The regression test had to be written first and observed failing before the fix existed.

## Methods

`PyBulletSim.__init__` opens a `DIRECT` client (`dynamic3d/utils.py:432`; GUI branch at `:428`) and only releases it in `close()` (`:590`). `close()` has **zero callers** anywhere in [kinder-baselines](https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines) or [kindergarden](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden), and the class defines no finalizer. (The two `sim.close()` calls that a grep turns up in kindergarden are on `ObjectCentricTransport3DEnv` and `ObjectCentricPrplLab3DEnv`; kindergarden does not import `kinder_models` at all, so it cannot reach this class.)

The tossing controllers build a sim lazily in `reset()` (`tossing/parameterized_skills.py:208`, `:335`, `:489`), and `LiftedParameterizedController.ground()` returns a fresh controller on every call:

```python
# bilevel_planning/structs.py:138-145
return self.controller_cls(objects)
```

So one skill execution → one controller → one client → never disconnected.

Four arms were measured, 40 skill executions each, one process per arm, sampling live clients via `p.getConnectionInfo` and RSS from `/proc/self/status`. All four ran inside an 8 GB memory-capped cgroup, since the leak is unbounded by construction.

## Results

| arm | live clients, first → last | RSS growth | RSS slope |
| --- | --- | --- | --- |
| unpatched, fresh controller per execution | 1 → 40 | +5845.0 MB | +150.0 MB/exec, R² = 0.999974 |
| **patched (this PR)** | **0 → 0** | −24.2 MB | +0.1 MB/exec |
| control: one controller reused | 1 → 1 | +0.1 MB | +0.0 MB/exec |
| control: explicit `close()` each execution | 0 → 0 | −17.0 MB | +0.2 MB/exec |

All four arms executed the same 620 environment steps and every iteration reached `terminated()`, so this is not an early-exit artifact. The explicit-`close()` control recovers the full ~150 MB per execution, which is what identifies the un-disconnected client as the whole of the growth.

**It reproduces in this repo's own test suite.** Calling `tests/dynamic3d/tossing/test_tossing_parameterized_skills.py::test_pick_toss` three times in one process:

```
before:                          rss=260.5 MB   live_clients=0
after test_pick_toss() call 1/3: rss=1085.7 MB  live_clients=4
after test_pick_toss() call 2/3: rss=1699.1 MB  live_clients=8
after test_pick_toss() call 3/3: rss=2296.5 MB  live_clients=12
```

That test calls `env.close()`, which releases nothing — the clients belong to the controllers, not the env.

**The change** is two files:

- **`dynamic3d/utils.py`** (+15/−2) — register a `weakref.finalize` that disconnects the client when the sim is collected, and route `close()` through it.
- **`tests/dynamic3d/tossing/.../test_tossing_parameterized_skills.py`** (+88) — a regression test asserting the live client count does not grow across repeated groundings.

Two details are load-bearing and easy to get wrong:

- **The callback takes the client id by value and never closes over `self`.** A bound method such as `weakref.finalize(self, self.close)` would hold a strong reference, the sim would never become unreachable, and the finalizer would never run — the leak would *appear* fixed and would not be. Verified by confirming the sim is collected by refcounting alone with `gc` disabled. This is the same shape `tempfile.TemporaryDirectory` uses in the standard library, which registers a classmethod plus the path by value for exactly this reason; a classmethod is unnecessary here because the cleanup is a single module-level call.
- **Note that garbage collection runs the registered callback, not `close()` itself.** `close()`'s docstring spells out what runs in each case, so that anything added to it later is not silently skipped on collection. A `__del__` calling `close()` would invoke the method, but the CPython docs favour finalizers, and `kindergarden`'s own `mujoco_utils.py:993` is the cautionary example — its unguarded `__del__` raises `AttributeError` on a partially-constructed object.
- **`close()` delegates to the finalizer** rather than calling `p.disconnect` directly. `p.disconnect` on an already-disconnected id raises rather than no-oping, and PyBullet recycles client ids by first-free-slot scan over `MAX_PHYSICS_CLIENTS`, so a stale finalizer holding a recycled id could silently disconnect an unrelated simulator. Routing both paths through the finalize object makes them mutually exclusive, since it marks itself dead on first call. `close()`'s docstring records this.

**Validation:**

- The regression test fails on `main` — `AssertionError: Leaked 4 PyBullet clients over 4 skill executions` — and passes with the fix. It reaches the client-count assertion only after asserting 4/4 executions terminated in more than one step, so it cannot pass vacuously.
- `pytest tests/dynamic3d` — **32 passed**, including `test_pick_toss` and `test_pick_ground_toss`.
- `pylint --rcfile=.pylintrc` on the changed files — **10.00/10**. `black --check` clean.
- `gc.collect()` is **not** load-bearing: with `gc` disabled, refcounting alone frees the sim, so a real planner loop releases promptly.

One side effect not claimed above: because the finalizer is registered immediately after `p.connect`, a failure inside `create_pybullet_robot` (`utils.py:451`) now also releases the client. Previously a construction failure leaked it.

## Recommendation

Merge. A finalizer rather than an explicit `close()` call because the controller is dropped by the planner, so there is no lifecycle hook on which to hang one — adding it would mean introducing a controller teardown protocol and threading it through every caller.

**Deliberately out of scope:**

- `dynamic3d/shelf` (`:740`) and `dynamic3d/sweep3D` (`:1067`) accept an optional `pybullet_sim` that `dynamic3d/tossing` does not. Adding it here would reduce how often a client is created but would **not** fix the leak, since nothing disconnects an injected sim either.
- Context-manager support (`__enter__`/`__exit__`) was considered and dropped: none of the 21 `PyBulletSim(...)` construction sites in these two repos uses `with`, so it would be an unused API in a bug-fix change.
