### PR TITLE
kinder-models: add state abstractions for Tossing3D

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -14,10 +14,12 @@ from bilevel_planning.structs import (
 )
 from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
 from kinder.envs.dynamic3d.object_types import (
+    MujocoFixtureObjectType,
     MujocoMovableObjectType,
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
 )
+from prpl_utils.utils import get_signed_angle_distance
 from relational_structs import (
     GroundAtom,
     Object,
@@ -43,8 +45,7 @@ NearBin = Predicate("NearBin", [MujocoTidyBotRobotObjectType, MujocoMovableObjec
 # literal in the file scores real successes as failures.
 GOAL_REGION_NAME = "blocks_goal_region"
 
-# Every rigid body in this domain is a movable, so the manipulable cubes, the bin and
-# the barrier are told apart by name, the way sweep3D tells its wiper from its cubes.
+# Names by which the scene's movables are told apart -- see state_abstractor().
 CUBE_NAME_PREFIX = "cube"
 BIN_NAME_PREFIX = "bin"
 BARRIER_NAME = "cuboid_barrier"
@@ -76,7 +77,18 @@ class Tossing3DStateAbstractor:
         self._sim = sim
 
     def state_abstractor(self, state: ObjectCentricState) -> RelationalAbstractState:
-        """Get the abstract state for the current state."""
+        """Get the abstract state for the current state.
+
+        Two things a caller should know. First, NearBin is not achievable through
+        MoveToTargetGroundController's *sampler*, which hardcodes a 0.5 m grasping
+        standoff; establishing it takes an explicit standoff parameter in the throwable
+        band, so an env model that grounds that skill with its own sampler will never
+        satisfy NearBin. Second, this is not a pure function of its argument: object
+        poses come from `state`, but the goal region is read from the live simulator, so
+        calling it on a stored or hypothetical state evaluates InGoalRegion against
+        today's region. Both are inert for Tossing3D as it stands and are recorded so
+        they do not have to be rediscovered.
+        """
         atoms: set[GroundAtom] = set()
 
         # Sync the pybullet simulator.
@@ -84,7 +96,14 @@ class Tossing3DStateAbstractor:
 
         # Extract the relevant objects.
         robot = state.get_object_from_name(self._robot_name)
+        fixtures = state.get_objects(MujocoFixtureObjectType)
         movables = state.get_objects(MujocoMovableObjectType)
+        all_mujoco_objects = set(fixtures) | set(movables)
+        # The bin and the barrier are movables too, so the cubes -- the only objects
+        # here that are actually manipulated -- are picked out by name, the way sweep3D
+        # picks its wiper out from its cubes. OnGround and InGoalRegion are restricted
+        # to them deliberately: the bin and the barrier are scene furniture, and
+        # asserting where they rest would say nothing a planner can act on.
         cubes = [o for o in movables if o.name.startswith(CUBE_NAME_PREFIX)]
         bins = [o for o in movables if o.name.startswith(BIN_NAME_PREFIX)]
         barriers = [o for o in movables if o.name == BARRIER_NAME]
@@ -128,24 +147,44 @@ class Tossing3DStateAbstractor:
                 if state.get(cube, "x") < state.get(barrier, "x"):
                     atoms.add(GroundAtom(Reachable, [cube, barrier]))
 
-        # NearBin. This is an exact characterisation of the base pose that
-        # MoveToTargetGroundController produces for a bin at zero yaw with zero
-        # rotation offset, namely (bin_x - target_distance, bin_y): the robot is on the
-        # bin's axis, at a standoff a throw can be thrown from. Both conjuncts are
-        # needed. A test on distance alone is satisfied by a whole ring of base poses,
-        # most of which face away from the bin, so it would report that the robot is
-        # ready to throw after any motion that happened to end at the right radius --
-        # for instance a move to a cube that sits off to one side. The lateral conjunct
-        # rules those out. The tolerance is the controller's own WAYPOINT_TOL, i.e.
-        # exactly how far off its own waypoint that controller is willing to stop.
+        # NearBin: the base is standing where a throw can actually be thrown from. All
+        # three conjuncts are load-bearing, and a throw needs all three to be true.
+        #
+        #   dx -- the standoff, signed rather than absolute, because the robot must be
+        #     on the near side of the bin. An absolute value would also accept a base
+        #     past the bin (and so past the barrier), a pose that is unreachable today
+        #     only because WORLD_X_BOUNDS caps base planning short of it.
+        #   dy -- the base is on the bin's axis, not merely at the right radius. A
+        #     radius test alone is satisfied by a whole ring of positions.
+        #   heading -- the base is pointing at the bin. Position does not imply this:
+        #     nothing stops the base sitting at the right (x, y) while turned away, and
+        #     a throw is released along the base's own heading, so a predicate that
+        #     omitted this would call the robot ready to throw when it is not.
+        #
+        # All three tolerances are MoveToTargetGroundController's own WAYPOINT_TOL --
+        # including the heading one, since _robot_is_close_to_pose() applies that same
+        # constant to x, y and theta alike. NearBin therefore admits precisely the poses
+        # that controller is willing to stop at, rather than a tolerance invented here.
         low, high = THROW_STANDOFF_BOUNDS
+        base_x = state.get(robot, "pos_base_x")
+        base_y = state.get(robot, "pos_base_y")
         for target_bin in bins:
-            dx = abs(state.get(robot, "pos_base_x") - state.get(target_bin, "x"))
-            dy = abs(state.get(robot, "pos_base_y") - state.get(target_bin, "y"))
-            if dy <= WAYPOINT_TOL and low - WAYPOINT_TOL <= dx <= high + WAYPOINT_TOL:
+            dx = state.get(target_bin, "x") - base_x
+            dy = abs(state.get(target_bin, "y") - base_y)
+            heading_error = abs(
+                get_signed_angle_distance(
+                    np.arctan2(state.get(target_bin, "y") - base_y, dx),
+                    state.get(robot, "pos_base_rot"),
+                )
+            )
+            if (
+                dy <= WAYPOINT_TOL
+                and low - WAYPOINT_TOL <= dx <= high + WAYPOINT_TOL
+                and heading_error <= WAYPOINT_TOL
+            ):
                 atoms.add(GroundAtom(NearBin, [robot, target_bin]))
 
-        objects = {robot} | set(movables)
+        objects = {robot} | all_mujoco_objects
         return RelationalAbstractState(atoms, objects)
 
     def goal_deriver(self, state: ObjectCentricState) -> RelationalAbstractGoal:

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -1,0 +1,181 @@
+"""State abstractions for the Tossing3D environment.
+
+Tossing3D is the one dynamic3d domain whose goal cannot be reached by manipulation
+alone: a 5 m barrier separates the robot from the bin, so a cube that is placed past the
+barrier can never be retrieved. The abstractions below are written to make that
+irreversibility visible to a planner -- Reachable is a one-way door that Toss deletes.
+"""
+
+import numpy as np
+from bilevel_planning.structs import (
+    RelationalAbstractGoal,
+    RelationalAbstractState,
+)
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoMovableObjectType,
+    MujocoObjectType,
+    MujocoTidyBotRobotObjectType,
+)
+from relational_structs import (
+    GroundAtom,
+    Object,
+    ObjectCentricState,
+    Predicate,
+)
+
+from kinder_models.dynamic3d.utils import WAYPOINT_TOL, PyBulletSim
+
+# Predicates.
+InGoalRegion = Predicate("InGoalRegion", [MujocoMovableObjectType])
+OnGround = Predicate("OnGround", [MujocoObjectType])
+Holding = Predicate("Holding", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType])
+HandEmpty = Predicate("HandEmpty", [MujocoTidyBotRobotObjectType])
+Reachable = Predicate("Reachable", [MujocoMovableObjectType, MujocoMovableObjectType])
+NearBin = Predicate("NearBin", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType])
+
+# The name of the region the task config asks the cubes to end up in. InGoalRegion is
+# checked against this region rather than against a hardcoded box, so that it agrees
+# with ObjectCentricTidyBot3DEnv._check_goals() by construction. The task JSON's own
+# "ranges" entry is not the region: the environment inflates it by the ground
+# placement threshold before building the region, so a predicate written against the
+# literal in the file scores real successes as failures.
+GOAL_REGION_NAME = "blocks_goal_region"
+
+# Every rigid body in this domain is a movable, so the manipulable cubes, the bin and
+# the barrier are told apart by name, the way sweep3D tells its wiper from its cubes.
+CUBE_NAME_PREFIX = "cube"
+BIN_NAME_PREFIX = "bin"
+BARRIER_NAME = "cuboid_barrier"
+
+# Thresholds shared with shelf/state_abstractions.py, whose HandEmpty, OnGround and
+# Holding classify the same TidyBot state that this domain reads.
+HANDEMPTY_TOL = 1e-3
+GRASP_THRESHOLD = 0.1
+HOLDING_HEIGHT = 0.1
+ON_GROUND_TOL = 0.05
+EE_TO_OBJECT_TOL = 0.05
+
+# The range of standoffs, in metres, that a throw is thrown from. Unlike the grasping
+# standoff, which MoveToTargetGroundController pins at 0.5 m, a throw standoff has no
+# single right value: the further back the robot stands the flatter the throw has to
+# be, and both ends of this band land a cube in the goal region.
+THROW_STANDOFF_BOUNDS = (1.20, 1.65)
+
+
+class Tossing3DStateAbstractor:
+    """State abstractor for the Tossing3D environment."""
+
+    def __init__(self, sim: ObjectCentricTidyBot3DEnv) -> None:
+        """Initialize the state abstractor."""
+        initial_state, _ = sim.reset()  # just need to access the objects
+        self._pybullet_sim = PyBulletSim(initial_state, rendering=False)
+        self._robot_name = sim.robot_name
+        self._sim = sim
+
+    def state_abstractor(self, state: ObjectCentricState) -> RelationalAbstractState:
+        """Get the abstract state for the current state."""
+        atoms: set[GroundAtom] = set()
+
+        # Sync the pybullet simulator.
+        self._pybullet_sim.set_state(state)
+
+        # Extract the relevant objects.
+        robot = state.get_object_from_name(self._robot_name)
+        movables = state.get_objects(MujocoMovableObjectType)
+        cubes = [o for o in movables if o.name.startswith(CUBE_NAME_PREFIX)]
+        bins = [o for o in movables if o.name.startswith(BIN_NAME_PREFIX)]
+        barriers = [o for o in movables if o.name == BARRIER_NAME]
+
+        # HandEmpty.
+        gripper_val = state.get(robot, "pos_gripper")
+        if np.isclose(gripper_val, 0.0, atol=HANDEMPTY_TOL):
+            atoms.add(GroundAtom(HandEmpty, [robot]))
+
+        for cube in cubes:
+            # OnGround. Flatness is part of the condition because the pick controller
+            # builds its grasp pose from the object's orientation, so a cube that came
+            # to rest on a corner is not a cube that grasp is modelled on.
+            z = state.get(cube, "z")
+            bb_z = state.get(cube, "bb_z")
+            if (
+                np.isclose(z - bb_z / 2, 0.0, atol=ON_GROUND_TOL)
+                and np.isclose(state.get(cube, "qx"), 0.0, atol=ON_GROUND_TOL)
+                and np.isclose(state.get(cube, "qy"), 0.0, atol=ON_GROUND_TOL)
+            ):
+                atoms.add(GroundAtom(OnGround, [cube]))
+
+            # Holding. Checking the ee pose and the target pose.
+            if gripper_val > GRASP_THRESHOLD and z > HOLDING_HEIGHT:
+                ee_pose = self._pybullet_sim.get_ee_pose()
+                if (
+                    abs(ee_pose.position[0] - state.get(cube, "x")) < EE_TO_OBJECT_TOL
+                    and abs(ee_pose.position[1] - state.get(cube, "y"))
+                    < EE_TO_OBJECT_TOL
+                    and abs(ee_pose.position[2] - z) < EE_TO_OBJECT_TOL
+                ):
+                    atoms.add(GroundAtom(Holding, [robot, cube]))
+
+            # InGoalRegion.
+            if self._check_in_goal_region(state, cube):
+                atoms.add(GroundAtom(InGoalRegion, [cube]))
+
+            # Reachable. Compared against the barrier's own live x rather than a
+            # constant, because the barrier's pose is sampled per episode.
+            for barrier in barriers:
+                if state.get(cube, "x") < state.get(barrier, "x"):
+                    atoms.add(GroundAtom(Reachable, [cube, barrier]))
+
+        # NearBin. This is an exact characterisation of the base pose that
+        # MoveToTargetGroundController produces for a bin at zero yaw with zero
+        # rotation offset, namely (bin_x - target_distance, bin_y): the robot is on the
+        # bin's axis, at a standoff a throw can be thrown from. A plain distance test is
+        # not enough, because after picking a cube the base sits about 1.76 m from the
+        # bin -- inside the standoff band -- while facing roughly 40 degrees away from
+        # it, and a throw from there misses. The tolerance is the controller's own
+        # WAYPOINT_TOL, i.e. exactly how far off its own waypoint it will stop.
+        low, high = THROW_STANDOFF_BOUNDS
+        for target_bin in bins:
+            dx = abs(state.get(robot, "pos_base_x") - state.get(target_bin, "x"))
+            dy = abs(state.get(robot, "pos_base_y") - state.get(target_bin, "y"))
+            if dy <= WAYPOINT_TOL and low - WAYPOINT_TOL <= dx <= high + WAYPOINT_TOL:
+                atoms.add(GroundAtom(NearBin, [robot, target_bin]))
+
+        objects = {robot} | set(movables)
+        return RelationalAbstractState(atoms, objects)
+
+    def goal_deriver(self, state: ObjectCentricState) -> RelationalAbstractGoal:
+        """The goal is to toss every cube into the goal region."""
+        movables = state.get_objects(MujocoMovableObjectType)
+        atoms = {
+            GroundAtom(InGoalRegion, [o])
+            for o in movables
+            if o.name.startswith(CUBE_NAME_PREFIX)
+        }
+        return RelationalAbstractGoal(atoms, self.state_abstractor)
+
+    def _check_in_goal_region(self, state: ObjectCentricState, cube: Object) -> bool:
+        """Check whether a cube's centre lies in the goal region.
+
+        The region is queried per state rather than cached. For a region on the ground
+        the bounding box is state-independent today, so caching would be correct, but
+        querying cannot go stale if that ever changes, and it is the same call
+        _check_goals() makes -- which is what makes this predicate and the environment's
+        own success criterion the same test rather than two tests that happen to agree.
+        The cost is negligible next to a MuJoCo step.
+        """
+        ground_fixture = self._sim._ground_fixture  # pylint: disable=protected-access
+        assert ground_fixture is not None, "Ground fixture not initialized"
+        position = np.array(
+            [
+                state.get(cube, "x"),
+                state.get(cube, "y"),
+                state.get(cube, "z"),
+            ],
+            dtype=np.float32,
+        )
+        return ground_fixture.check_in_region(
+            position,
+            GOAL_REGION_NAME,
+            self._sim._robot_env,  # pylint: disable=protected-access
+        )

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -1,9 +1,10 @@
 """State abstractions for the Tossing3D environment.
 
 Tossing3D is the one dynamic3d domain whose goal cannot be reached by manipulation
-alone: a 5 m barrier separates the robot from the bin, so a cube that is placed past the
-barrier can never be retrieved. The abstractions below are written to make that
-irreversibility visible to a planner -- Reachable is a one-way door that Toss deletes.
+alone: a barrier spanning the width of the scene separates the robot from the bin, and
+the base cannot pass it, so a cube on the far side can never be retrieved. Reachable
+below exists to make that irreversibility expressible -- an operator model that omits it
+can emit a retrieve-and-retry plan the dynamics will never execute.
 """
 
 import numpy as np
@@ -56,10 +57,11 @@ HOLDING_HEIGHT = 0.1
 ON_GROUND_TOL = 0.05
 EE_TO_OBJECT_TOL = 0.05
 
-# The range of standoffs, in metres, that a throw is thrown from. Unlike the grasping
-# standoff, which MoveToTargetGroundController pins at 0.5 m, a throw standoff has no
-# single right value: the further back the robot stands the flatter the throw has to
-# be, and both ends of this band land a cube in the goal region.
+# The band of base standoffs, in metres, that NearBin treats as throwable-from. Unlike
+# the grasping standoff, which MoveToTargetGroundController pins at 0.5 m, a throw
+# standoff has no single right value, so this is a band rather than a number. It is
+# wider than the 1.35 m the test uses and is the interval a toss sampler would draw
+# from; narrowing it makes NearBin stricter, never unsound.
 THROW_STANDOFF_BOUNDS = (1.20, 1.65)
 
 
@@ -129,11 +131,13 @@ class Tossing3DStateAbstractor:
         # NearBin. This is an exact characterisation of the base pose that
         # MoveToTargetGroundController produces for a bin at zero yaw with zero
         # rotation offset, namely (bin_x - target_distance, bin_y): the robot is on the
-        # bin's axis, at a standoff a throw can be thrown from. A plain distance test is
-        # not enough, because after picking a cube the base sits about 1.76 m from the
-        # bin -- inside the standoff band -- while facing roughly 40 degrees away from
-        # it, and a throw from there misses. The tolerance is the controller's own
-        # WAYPOINT_TOL, i.e. exactly how far off its own waypoint it will stop.
+        # bin's axis, at a standoff a throw can be thrown from. Both conjuncts are
+        # needed. A test on distance alone is satisfied by a whole ring of base poses,
+        # most of which face away from the bin, so it would report that the robot is
+        # ready to throw after any motion that happened to end at the right radius --
+        # for instance a move to a cube that sits off to one side. The lateral conjunct
+        # rules those out. The tolerance is the controller's own WAYPOINT_TOL, i.e.
+        # exactly how far off its own waypoint that controller is willing to stop.
         low, high = THROW_STANDOFF_BOUNDS
         for target_bin in bins:
             dx = abs(state.get(robot, "pos_base_x") - state.get(target_bin, "x"))

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -1,10 +1,12 @@
 """State abstractions for the Tossing3D environment.
 
-Tossing3D is the one dynamic3d domain whose goal cannot be reached by manipulation
-alone: a barrier spanning the width of the scene separates the robot from the bin, and
-the base cannot pass it, so a cube on the far side can never be retrieved. Reachable
-below exists to make that irreversibility expressible -- an operator model that omits it
-can emit a retrieve-and-retry plan the dynamics will never execute.
+Tossing3D's goal region sits on the far side of a barrier that spans the scene in y:
+cuboid_barrier is 5 m wide and the task config places it at x ~ 1.3, while the goal
+region is x in [1.85, 2.15]. Nothing in this package models that barrier -- base motion
+planning runs with an empty obstacle set -- so it is MuJoCo contact alone that keeps the
+base on the near side. Reachable below records which side of it a cube is on, so an
+operator model can express that a toss is irreversible rather than emitting a plan that
+retrieves the cube and retries, which the dynamics will never execute.
 """
 
 import numpy as np
@@ -34,6 +36,10 @@ InGoalRegion = Predicate("InGoalRegion", [MujocoMovableObjectType])
 OnGround = Predicate("OnGround", [MujocoObjectType])
 Holding = Predicate("Holding", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType])
 HandEmpty = Predicate("HandEmpty", [MujocoTidyBotRobotObjectType])
+# Reachable reads as "the first object is on the robot's side of the second". Both slots
+# are MujocoMovableObjectType because upstream has no barrier type, so a planner will
+# also ground it as (cube_0, bin_0) or (bin_0, cuboid_barrier) -- pairs state_abstractor
+# never emits, since it only ever pairs a cube with BARRIER_NAME.
 Reachable = Predicate("Reachable", [MujocoMovableObjectType, MujocoMovableObjectType])
 NearBin = Predicate("NearBin", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType])
 
@@ -50,8 +56,10 @@ CUBE_NAME_PREFIX = "cube"
 BIN_NAME_PREFIX = "bin"
 BARRIER_NAME = "cuboid_barrier"
 
-# Thresholds shared with shelf/state_abstractions.py, whose HandEmpty, OnGround and
-# Holding classify the same TidyBot state that this domain reads.
+# Duplicated from shelf/state_abstractions.py, whose HandEmpty, OnGround and Holding
+# classify the same TidyBot state this domain reads. They are literals there, declared
+# inside state_abstractor() rather than at module scope, so nothing keeps the two sets
+# in sync; hoisting them into dynamic3d/utils.py would, but that touches shelf.
 HANDEMPTY_TOL = 1e-3
 GRASP_THRESHOLD = 0.1
 HOLDING_HEIGHT = 0.1
@@ -60,10 +68,19 @@ EE_TO_OBJECT_TOL = 0.05
 
 # The band of base standoffs, in metres, that NearBin treats as throwable-from. Unlike
 # the grasping standoff, which MoveToTargetGroundController pins at 0.5 m, a throw
-# standoff has no single right value, so this is a band rather than a number. It is
-# wider than the 1.35 m the test uses and is the interval a toss sampler would draw
-# from; narrowing it makes NearBin stricter, never unsound.
+# standoff has no single right value, so this is a band rather than a number. It
+# brackets the 1.35 m the test uses with room either side, and is the interval a toss
+# sampler would draw from; narrowing it makes NearBin stricter, never unsound.
 THROW_STANDOFF_BOUNDS = (1.20, 1.65)
+
+# NearBin's own slack, deliberately wider than MoveToTargetGroundController's
+# WAYPOINT_TOL. That controller stops when np.isclose(..., atol=WAYPOINT_TOL) holds,
+# which is atol + rtol * |b| and so strictly wider than a <= test; and its own sampler
+# spends half of WAYPOINT_TOL on the planned off-axis offset before the controller adds
+# its termination slack on top. A pose the controller accepts can therefore sit just
+# outside a strict WAYPOINT_TOL test and make NearBin false immediately after the skill
+# that established it.
+NEAR_BIN_TOL = 2 * WAYPOINT_TOL
 
 
 class Tossing3DStateAbstractor:
@@ -77,18 +94,10 @@ class Tossing3DStateAbstractor:
         self._sim = sim
 
     def state_abstractor(self, state: ObjectCentricState) -> RelationalAbstractState:
-        """Get the abstract state for the current state.
-
-        Two things a caller should know. First, NearBin is not achievable through
-        MoveToTargetGroundController's *sampler*, which hardcodes a 0.5 m grasping
-        standoff; establishing it takes an explicit standoff parameter in the throwable
-        band, so an env model that grounds that skill with its own sampler will never
-        satisfy NearBin. Second, this is not a pure function of its argument: object
-        poses come from `state`, but the goal region is read from the live simulator, so
-        calling it on a stored or hypothetical state evaluates InGoalRegion against
-        today's region. Both are inert for Tossing3D as it stands and are recorded so
-        they do not have to be rediscovered.
-        """
+        """Get the abstract state for the current state."""
+        # Not a pure function of its argument: object poses come from `state`, but the
+        # goal region is read from the live simulator, so calling this on a stored or
+        # hypothetical state evaluates InGoalRegion against today's region.
         atoms: set[GroundAtom] = set()
 
         # Sync the pybullet simulator.
@@ -101,10 +110,11 @@ class Tossing3DStateAbstractor:
         all_mujoco_objects = set(fixtures) | set(movables)
         # The bin and the barrier are movables too, so the cubes -- the only objects
         # here that are actually manipulated -- are picked out by name, the way sweep3D
-        # picks its wiper out from its cubes. OnGround and InGoalRegion are restricted
-        # to them deliberately: the bin and the barrier are scene furniture, and
-        # asserting where they rest would say nothing a planner can act on.
-        cubes = [o for o in movables if o.name.startswith(CUBE_NAME_PREFIX)]
+        # picks its wiper out from its cubes. Every per-object predicate below
+        # (OnGround, Holding, InGoalRegion, Reachable) is restricted to them
+        # deliberately: the bin and the barrier are scene furniture, and asserting where
+        # they rest would say nothing a planner can act on.
+        cubes = self._get_cubes(state)
         bins = [o for o in movables if o.name.startswith(BIN_NAME_PREFIX)]
         barriers = [o for o in movables if o.name == BARRIER_NAME]
 
@@ -116,7 +126,11 @@ class Tossing3DStateAbstractor:
         for cube in cubes:
             # OnGround. Flatness is part of the condition because the pick controller
             # builds its grasp pose from the object's orientation, so a cube that came
-            # to rest on a corner is not a cube that grasp is modelled on.
+            # to rest on a corner is not a cube that grasp is modelled on. The cost is
+            # that OnGround is not predictable after a toss: a cube that lands flat in
+            # the goal region gets OnGround and InGoalRegion, one that lands tilted gets
+            # only InGoalRegion, and no fixed effect set covers both under the
+            # final_abstract_state == ns refinement gate.
             z = state.get(cube, "z")
             bb_z = state.get(cube, "bb_z")
             if (
@@ -137,12 +151,21 @@ class Tossing3DStateAbstractor:
                 ):
                     atoms.add(GroundAtom(Holding, [robot, cube]))
 
-            # InGoalRegion.
+            # InGoalRegion. Note for the env model that will consume this: the cube is
+            # only in the region once it has come to rest, and TossController
+            # terminates when its trapezoidal profile is exhausted, which is while the
+            # cube may still be in flight. Under the refinement gate's
+            # final_abstract_state == ns, a toss operator that adds InGoalRegion needs
+            # the cube settled before the state is abstracted -- and the same goes for
+            # HandEmpty, which wants pos_gripper back within 1e-3 of 0 after release.
             if self._check_in_goal_region(state, cube):
                 atoms.add(GroundAtom(InGoalRegion, [cube]))
 
             # Reachable. Compared against the barrier's own live x rather than a
-            # constant, because the barrier's pose is sampled per episode.
+            # constant, because the barrier's placement comes from a task-config region
+            # rather than from code. Today that region is 1 mm wide (barrier_init_region,
+            # yaw pinned to 0), so the value barely moves; reading it keeps this correct
+            # if the config ever widens it.
             for barrier in barriers:
                 if state.get(cube, "x") < state.get(barrier, "x"):
                     atoms.add(GroundAtom(Reachable, [cube, barrier]))
@@ -161,26 +184,30 @@ class Tossing3DStateAbstractor:
         #     a throw is released along the base's own heading, so a predicate that
         #     omitted this would call the robot ready to throw when it is not.
         #
-        # All three tolerances are MoveToTargetGroundController's own WAYPOINT_TOL --
-        # including the heading one, since _robot_is_close_to_pose() applies that same
-        # constant to x, y and theta alike. NearBin therefore admits precisely the poses
-        # that controller is willing to stop at, rather than a tolerance invented here.
+        # All three slacks are NEAR_BIN_TOL, derived from
+        # MoveToTargetGroundController's own WAYPOINT_TOL -- including the heading one,
+        # since _robot_is_close_to_pose() applies that same constant to x, y and theta
+        # alike -- rather than a tolerance invented here. That makes NearBin's slack the
+        # controller's slack; it does not make the two sets equal. The controller will
+        # also stop at poses NearBin rejects: any standoff outside the band, and any
+        # target_rot that swings the base off the bin's x axis (target_rot = pi/2 puts
+        # it beside the bin, dx = 0).
         low, high = THROW_STANDOFF_BOUNDS
         base_x = state.get(robot, "pos_base_x")
         base_y = state.get(robot, "pos_base_y")
         for target_bin in bins:
             dx = state.get(target_bin, "x") - base_x
-            dy = abs(state.get(target_bin, "y") - base_y)
+            dy = state.get(target_bin, "y") - base_y
             heading_error = abs(
                 get_signed_angle_distance(
-                    np.arctan2(state.get(target_bin, "y") - base_y, dx),
+                    np.arctan2(dy, dx),
                     state.get(robot, "pos_base_rot"),
                 )
             )
             if (
-                dy <= WAYPOINT_TOL
-                and low - WAYPOINT_TOL <= dx <= high + WAYPOINT_TOL
-                and heading_error <= WAYPOINT_TOL
+                abs(dy) <= NEAR_BIN_TOL
+                and low - NEAR_BIN_TOL <= dx <= high + NEAR_BIN_TOL
+                and heading_error <= NEAR_BIN_TOL
             ):
                 atoms.add(GroundAtom(NearBin, [robot, target_bin]))
 
@@ -189,24 +216,20 @@ class Tossing3DStateAbstractor:
 
     def goal_deriver(self, state: ObjectCentricState) -> RelationalAbstractGoal:
         """The goal is to toss every cube into the goal region."""
-        movables = state.get_objects(MujocoMovableObjectType)
-        atoms = {
-            GroundAtom(InGoalRegion, [o])
-            for o in movables
-            if o.name.startswith(CUBE_NAME_PREFIX)
-        }
+        atoms = {GroundAtom(InGoalRegion, [o]) for o in self._get_cubes(state)}
         return RelationalAbstractGoal(atoms, self.state_abstractor)
 
-    def _check_in_goal_region(self, state: ObjectCentricState, cube: Object) -> bool:
-        """Check whether a cube's centre lies in the goal region.
+    def _get_cubes(self, state: ObjectCentricState) -> list[Object]:
+        """Get the cubes, told apart from the bin and the barrier by name."""
+        movables = state.get_objects(MujocoMovableObjectType)
+        return [o for o in movables if o.name.startswith(CUBE_NAME_PREFIX)]
 
-        The region is queried per state rather than cached. For a region on the ground
-        the bounding box is state-independent today, so caching would be correct, but
-        querying cannot go stale if that ever changes, and it is the same call
-        _check_goals() makes -- which is what makes this predicate and the environment's
-        own success criterion the same test rather than two tests that happen to agree.
-        The cost is negligible next to a MuJoCo step.
-        """
+    def _check_in_goal_region(self, state: ObjectCentricState, cube: Object) -> bool:
+        """Check whether a cube's centre lies in the goal region."""
+        # The region is queried per state rather than cached, because this is the same
+        # call _check_goals() makes -- which is what makes this predicate and the
+        # environment's own success criterion the same test rather than two tests that
+        # happen to agree.
         ground_fixture = self._sim._ground_fixture  # pylint: disable=protected-access
         assert ground_fixture is not None, "Ground fixture not initialized"
         position = np.array(

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -51,13 +51,6 @@ def test_tossing3d_state_abstraction():
         f"(Reachable cube_0 cuboid_barrier)]"
     )
 
-    # The robot starts far from the bin, so it is not yet in a pose it can throw from,
-    # and nothing is held.
-    assert not any(
-        atom.predicate.name in ("NearBin", "Holding", "InGoalRegion")
-        for atom in abstract_state.atoms
-    )
-
     # The goal is for the cube to land in the goal region, which is exactly the
     # environment's own success criterion.
     cube = state.get_object_from_name("cube_0")

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -1,0 +1,65 @@
+"""Tests for tossing state_abstractions.py."""
+
+import kinder
+from conftest import MAKE_VIDEOS  # pylint: disable=import-error
+from gymnasium.wrappers import RecordVideo
+from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
+from relational_structs import GroundAtom, ObjectCentricState
+
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    InGoalRegion,
+    Tossing3DStateAbstractor,
+)
+
+
+def _get_robot_from_state(state: ObjectCentricState):
+    """Helper to get robot object from state by type."""
+    robots = state.get_objects(MujocoTidyBotRobotObjectType)
+    assert len(robots) == 1, f"Expected 1 robot, got {len(robots)}"
+    return list(robots)[0]
+
+
+def test_tossing3d_state_abstraction():
+    """Tests for Tossing3DStateAbstractor()."""
+    kinder.register_all_environments()
+    num_objects = 1
+    env = kinder.make(f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array")
+    if MAKE_VIDEOS:
+        env = RecordVideo(
+            env,
+            "unit_test_videos",
+            name_prefix="Tossing3D-state-abstraction",
+        )
+    sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
+    abstractor = Tossing3DStateAbstractor(sim)
+
+    # Check the state abstraction in the initial state. The robot's hand should be
+    # empty, the cube should be on the ground on the robot's side of the barrier, and
+    # the cube should not yet be in the goal region.
+    obs, _ = env.reset(seed=125)
+    state = env.observation_space.devectorize(obs)
+    assert isinstance(state, ObjectCentricState)
+    abstract_state = abstractor.state_abstractor(state)
+    robot = _get_robot_from_state(state)
+    assert str(sorted(abstract_state.atoms)) == (
+        f"[(HandEmpty {robot.name}), "
+        f"(OnGround cube_0), "
+        f"(Reachable cube_0 cuboid_barrier)]"
+    )
+
+    # The robot starts far from the bin, so it is not yet in a pose it can throw from,
+    # and nothing is held.
+    assert not any(
+        atom.predicate.name in ("NearBin", "Holding", "InGoalRegion")
+        for atom in abstract_state.atoms
+    )
+
+    # The goal is for the cube to land in the goal region, which is exactly the
+    # environment's own success criterion.
+    cube = state.get_object_from_name("cube_0")
+    goal = abstractor.goal_deriver(state)
+    assert goal.atoms == {GroundAtom(InGoalRegion, [cube])}
+    assert not goal.check_state(state)
+    assert not sim._check_goals()  # pylint: disable=protected-access
+
+    env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -1,11 +1,15 @@
 """Tests for tossing state_abstractions.py."""
 
 import kinder
+import numpy as np
 from conftest import MAKE_VIDEOS  # pylint: disable=import-error
 from gymnasium.wrappers import RecordVideo
 from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
 from relational_structs import GroundAtom, ObjectCentricState
 
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    create_lifted_controllers,
+)
 from kinder_models.dynamic3d.tossing.state_abstractions import (
     InGoalRegion,
     Tossing3DStateAbstractor,
@@ -61,5 +65,35 @@ def test_tossing3d_state_abstraction():
     assert goal.atoms == {GroundAtom(InGoalRegion, [cube])}
     assert not goal.check_state(state)
     assert not sim._check_goals()  # pylint: disable=protected-access
+
+    # Drive the base to a throw standoff from the bin. NearBin is the one predicate
+    # here with no upstream precedent, so it is checked against the controller that is
+    # supposed to establish it rather than only against the initial state.
+    controllers = create_lifted_controllers(env.action_space)
+    lifted_controller = controllers["move_to_target"]
+    target_bin = state.get_object_from_name("bin_0")
+    controller = lifted_controller.ground((robot, target_bin))
+    throw_standoff = 1.35
+    controller.reset(state, np.array([throw_standoff, 0.0]))
+    for _ in range(300):
+        action = controller.step()
+        obs, _, _, _, _ = env.step(action)
+        next_state = env.observation_space.devectorize(obs)
+        controller.observe(next_state)
+        state = next_state
+        if controller.terminated():
+            break
+    else:
+        assert False, "Controller did not terminate"
+
+    # The robot is now standing where it can throw from, and nothing else has changed:
+    # the cube is untouched and still on the robot's side of the barrier.
+    abstract_state = abstractor.state_abstractor(state)
+    assert str(sorted(abstract_state.atoms)) == (
+        f"[(HandEmpty {robot.name}), "
+        f"(NearBin {robot.name} bin_0), "
+        f"(OnGround cube_0), "
+        f"(Reachable cube_0 cuboid_barrier)]"
+    )
 
     env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -29,6 +29,7 @@ def test_tossing3d_state_abstraction():
     num_objects = 1
     env = kinder.make(f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array")
     if MAKE_VIDEOS:
+        env.unwrapped._object_centric_env.set_render_camera("task_view")  # type: ignore # pylint: disable=protected-access
         env = RecordVideo(
             env,
             "unit_test_videos",
@@ -59,13 +60,26 @@ def test_tossing3d_state_abstraction():
     assert not goal.check_state(state)
     assert not sim._check_goals()  # pylint: disable=protected-access
 
+    # InGoalRegion is checked against the environment's own region object, which is the
+    # task JSON's "ranges" entry inflated by the ground placement threshold (0.05 m) in
+    # every direction. Putting the cube just outside the literal 2.10 but inside the
+    # inflated 2.15 is what tells the two apart: a predicate written against the file
+    # would score this real success as a failure.
+    landed_state = state.copy()
+    landed_state.set(cube, "x", 2.14)
+    landed_state.set(cube, "y", 0.0)
+    landed_state.set(cube, "z", 0.025)
+    landed_atoms = abstractor.state_abstractor(landed_state).atoms
+    assert GroundAtom(InGoalRegion, [cube]) in landed_atoms
+
     # Drive the base to a throw standoff from the bin. NearBin is the one predicate
     # here with no upstream precedent, so it is checked against the controller that is
     # supposed to establish it rather than only against the initial state.
     controllers = create_lifted_controllers(env.action_space)
     lifted_controller = controllers["move_to_target"]
     target_bin = state.get_object_from_name("bin_0")
-    controller = lifted_controller.ground((robot, target_bin))
+    object_parameters = (robot, target_bin)
+    controller = lifted_controller.ground(object_parameters)
     throw_standoff = 1.35
     controller.reset(state, np.array([throw_standoff, 0.0]))
     for _ in range(300):


### PR DESCRIPTION
**TL;DR** `dynamic3d/tossing/` was the only one of four `dynamic3d` domains without a `state_abstractions.py`. This adds one — six predicates, a `Tossing3DStateAbstractor` shaped like `sweep3D`'s, and a simulator-backed test. Purely additive. Tossing suite **12/12** against a real simulator.

## Question / goal

Give `Tossing3D` the symbolic layer its three sibling domains already have, so a bilevel planner can be pointed at it the way it is pointed at `base_motion`, `shelf` and `sweep3D`.

## Background

`kinder_models/dynamic3d/` holds four domains. `base_motion/`, `shelf/` and `sweep3D/` each ship a `state_abstractions.py` — module-level `Predicate` symbols, a `state_abstractor(state)` that assigns all of them, and a goal deriver. `tossing/` ships only `parameterized_skills.py`, so its controllers exist but nothing turns them into a planning problem.

`Tossing3D` differs from its siblings in one way the abstractions have to express. A cuboid barrier spans the scene between the robot and the bin. Nothing in this package models it — base motion planning runs with an empty obstacle set, so it is MuJoCo contact alone that keeps the base on the near side — but a cube tossed past it can never be retrieved. Tossing is therefore irreversible, and an operator model that does not say so will emit a retrieve-and-retry plan the dynamics can never execute.

`InGoalRegion` is the domain's success criterion, and `ObjectCentricTidyBot3DEnv._check_goals()` already computes it. The predicate defers to that same `check_in_region` call rather than re-deriving a box, so the two cannot drift apart.

## Hypothesis

None — implementation task, not an experiment.

## Guidance given

Copy `sweep3D/state_abstractions.py`'s shape; do not reinvent `HandEmpty`/`OnGround`/`Holding`, which `shelf` already defines over the same TidyBot state; keep the diff purely additive.

## Methods

Six predicates. Three come from `shelf`, thresholds included — duplicated rather than shared, because `shelf` declares them as literals inside its own `state_abstractor`: `HandEmpty`, `OnGround`, `Holding`. Three are new:

- **`InGoalRegion(cube)`** — unary, since there is no region object in the `ObjectCentricState` to bind a second variable to. Queried per state against the live simulator, which is what makes it and `_check_goals()` one test rather than two that happen to agree.
- **`Reachable(cube, barrier)`** — the cube is on the robot's side, compared against the barrier's own live `x`. This is the one-way door.
- **`NearBin(robot, bin)`** — a signed standoff in the throwable band, on the bin's axis, and pointing at the bin. All three conjuncts are needed: distance alone admits a ring of poses, and position alone admits any heading, while a throw is released along the base's heading.

All three `NearBin` slacks are `NEAR_BIN_TOL = 2 * WAYPOINT_TOL`, derived from `MoveToTargetGroundController`'s own tolerance rather than invented here (sized in Results). That makes `NearBin`'s slack the controller's slack; it does not make the two sets equal, and the controller will still stop at poses `NearBin` rejects.

Every rigid body in this domain is a `MujocoMovableObjectType` — bin and barrier included — so cubes are told apart by name, as `sweep3D` tells its wiper from its cubes.

The test resets `Tossing3D-o1` at seed 125, asserts the initial abstract state is exactly the measured set, that the goal deriver yields exactly `InGoalRegion(cube_0)`, and that the derived goal and `_check_goals()` agree. It then drives the base to a 1.35 m standoff with `move_to_target` and asserts `NearBin` appears with the rest unchanged. `InGoalRegion`'s true branch is exercised by placing the cube at x = 2.14 — outside the task JSON's literal 2.10 but inside the region the environment actually builds by inflating it, which is the whole reason the predicate reads the region object rather than the file.

## Results

**12/12** in the `dynamic3d/tossing` suite (11 pre-existing, 1 new), ~25 s, against a real simulator.

- Initial abstract state at seed 125 is `[(HandEmpty robot), (OnGround cube_0), (Reachable cube_0 cuboid_barrier)]` — **3/3** asserted atoms present and **0/3** of `NearBin`/`Holding`/`InGoalRegion`, which is right. After `move_to_target(bin_0, 1.35, 0.0)` it is those three plus `(NearBin robot bin_0)`, **4/4**.
- **`NEAR_BIN_TOL`'s headroom is measured, not assumed.** At controller termination the residuals are `|dy|` = 0.0013 and heading error 0.00005–0.0019 rad across seeds 123/124/125 — roughly 30x inside a strict `WAYPOINT_TOL` of 0.04. So the widening is never observed to bite, and a strict test would have passed on every seed tried. What it covers is the worst case the controller's termination condition actually permits: 0.02 planned off-axis from #90's sampler plus 0.04 of `np.isclose` slack is 0.06, which exceeds `WAYPOINT_TOL` and fits inside `NEAR_BIN_TOL` of 0.08. Headroom against a guaranteed bound, not a fix for an observed failure.
- black / isort / docformatter / mypy clean, pylint 10.00/10, over **2/2** files.

## Recommendation

Merge after review. Two gaps worth naming rather than hiding. `Holding`'s forward-kinematics conjunct is not exercised here — reaching it means running the full pick-and-toss sequence, which #91 does. And `NearBin` cannot be established through `MoveToTargetGroundController`'s own sampler, which pins a 0.5 m grasping standoff; it needs the explicit throw standoff that #90's `move_to_throw_pose` samples. That is recorded where an env model built on these predicates will hit it.
