### PR TITLE
Tossing3D: a throw-pose controller and a composed toss, so a planner can throw

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -38,7 +38,6 @@ from kinder_models.dynamic3d.utils import (
     GRASP_CLOSE_THRESHOLD,
     GRIPPER_CLOSED_THRESHOLD,
     GRIPPER_OPEN_THRESHOLD,
-    MOVE_TO_TARGET_DISTANCE_BOUNDS,
     MOVE_TO_TARGET_ROT_BOUNDS,
     WAYPOINT_TOL,
     WORLD_X_BOUNDS,
@@ -56,6 +55,17 @@ from kinder_models.dynamic3d.utils import (
 # the same configurations the pick-and-toss tests drive the arm through by hand.
 TOSS_WINDUP_ARM_CONF = np.deg2rad([0.0, 50.0, 180.0, -110.0, 0.0, -100.0, 90.0])
 TOSS_RELEASE_ARM_CONF = np.deg2rad([0.0, 20.0, 180.0, -35.0, 0.0, 25.0, 90.0])
+
+# The base-to-target standoffs, in metres, that MoveToThrowPoseController draws from.
+# This is deliberately NOT MOVE_TO_TARGET_DISTANCE_BOUNDS: that interval, (0.5, 0.6), is
+# the range that gives a stable *grasp*, and a robot standing 0.55 m from the bin is
+# standing on top of it, not somewhere a throw is thrown from. The interval brackets
+# 1.35 m, the standoff both pick-and-toss tests drive to, and sits strictly inside
+# state_abstractions.THROW_STANDOFF_BOUNDS = (1.20, 1.65), the band NearBin treats as
+# throwable-from -- so every draw satisfies NearBin. That containment is the real
+# constraint and is asserted in test_move_to_throw_pose_samples_a_throwable_standoff;
+# it is not imported here because state_abstractions imports this module.
+TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45)
 
 
 class MoveToTargetGroundController(
@@ -193,8 +203,10 @@ class MoveToThrowPoseController(MoveToTargetGroundController):
         target_rot: float (radians)
 
     This differs from MoveToTargetGroundController in two ways. Its sampler draws a
-    standoff instead of returning the single constant distance that gives a stable
-    grasp, since a throw has no one right distance to be at. And it excludes the held
+    standoff from TOSS_TARGET_DISTANCE_BOUNDS instead of returning the single constant
+    distance that gives a stable grasp, since a throw has no one right distance to be
+    at -- and, more to the point, is thrown from much further away than a grasp is
+    taken from. And it excludes the held
     object from base collision checking by default, because the robot is carrying that
     object while it drives, so checking the base against it would reject every plan.
     That exclusion is a no-op today: run_base_motion_planning currently leaves its
@@ -205,7 +217,7 @@ class MoveToThrowPoseController(MoveToTargetGroundController):
     """
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
-        distance = rng.uniform(*MOVE_TO_TARGET_DISTANCE_BOUNDS)  # type: ignore
+        distance = rng.uniform(*TOSS_TARGET_DISTANCE_BOUNDS)  # type: ignore
         rot = rng.uniform(*MOVE_TO_TARGET_ROT_BOUNDS)
         return np.array([distance, rot])
 

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -25,6 +25,7 @@ from pybullet_helpers.motion_planning import (
 )
 from relational_structs import (
     Array,
+    Object,
     ObjectCentricState,
     Variable,
 )
@@ -37,6 +38,8 @@ from kinder_models.dynamic3d.utils import (
     GRASP_CLOSE_THRESHOLD,
     GRIPPER_CLOSED_THRESHOLD,
     GRIPPER_OPEN_THRESHOLD,
+    MOVE_TO_TARGET_DISTANCE_BOUNDS,
+    MOVE_TO_TARGET_ROT_BOUNDS,
     WAYPOINT_TOL,
     WORLD_X_BOUNDS,
     WORLD_Y_BOUNDS,
@@ -47,6 +50,12 @@ from kinder_models.dynamic3d.utils import (
     get_target_robot_pose_from_parameters,
     run_base_motion_planning,
 )
+
+# The two demonstrated arm configurations that make up a toss, in the order the toss
+# executes them: wind the arm up and back, then swing it forward and release. These are
+# the same configurations the pick-and-toss tests drive the arm through by hand.
+TOSS_WINDUP_ARM_CONF = np.deg2rad([0.0, 50.0, 180.0, -110.0, 0.0, -100.0, 90.0])
+TOSS_RELEASE_ARM_CONF = np.deg2rad([0.0, 20.0, 180.0, -35.0, 0.0, 25.0, 90.0])
 
 
 class MoveToTargetGroundController(
@@ -168,6 +177,49 @@ class MoveToTargetGroundController(
                 0.0,
                 atol=atol,
             )
+        )
+
+
+class MoveToThrowPoseController(MoveToTargetGroundController):
+    """Controller for motion planning to a base pose to throw a held object from.
+
+    The object parameters are:
+        robot: The robot itself.
+        object: The target object to throw at.
+        held: The object the robot is currently holding.
+
+    The continuous parameters are the same as MoveToTargetGroundController's:
+        target_distance: float
+        target_rot: float (radians)
+
+    This differs from MoveToTargetGroundController in two ways. Its sampler draws a
+    standoff instead of returning the single constant distance that gives a stable
+    grasp, since a throw has no one right distance to be at. And it disables collision
+    checking against the held object by default, because the robot is holding that
+    object while it drives, so planning the base against it makes every plan fail.
+    """
+
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        distance = rng.uniform(*MOVE_TO_TARGET_DISTANCE_BOUNDS)  # type: ignore
+        rot = rng.uniform(*MOVE_TO_TARGET_ROT_BOUNDS)
+        return np.array([distance, rot])
+
+    def reset(
+        self,
+        x: ObjectCentricState,
+        params: Any,
+        extend_xy_magnitude: float = 0.025,
+        extend_rot_magnitude: float = np.pi / 8,
+        disable_collision_objects: list[str] | None = None,
+    ) -> None:
+        if disable_collision_objects is None:
+            disable_collision_objects = [self.objects[2].name]
+        super().reset(
+            x,
+            params,
+            extend_xy_magnitude=extend_xy_magnitude,
+            extend_rot_magnitude=extend_rot_magnitude,
+            disable_collision_objects=disable_collision_objects,
         )
 
 
@@ -453,6 +505,95 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         return dist < 6 * 1e-2
 
 
+class _WindupArmController(MoveArmToConfController):
+    """A MoveArmToConfController that can be handed an existing PyBullet sim."""
+
+    def __init__(
+        self, *args, pybullet_sim: PyBulletSim | None = None, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._pybullet_sim: PyBulletSim | None = pybullet_sim
+
+
+class _ReleaseTossController(TossController):
+    """A TossController that can be handed an existing PyBullet sim."""
+
+    def __init__(
+        self, *args, pybullet_sim: PyBulletSim | None = None, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._pybullet_sim: PyBulletSim | None = pybullet_sim
+
+
+class TossFromWindupController(
+    GroundParameterizedController[ObjectCentricState, Array]
+):
+    """Controller for winding the arm up and then tossing the held object.
+
+    The object parameters are:
+        robot: The robot itself.
+
+    The continuous parameters are a (2, 7) array of arm configurations:
+        params[0]: the windup conf, reached with MoveArmToConfController.
+        params[1]: the release conf, swung to and released at by TossController.
+
+    A toss is those two arm motions back to back, and this runs them as one controller
+    rather than as two skills. Splitting them would need a predicate over the windup
+    conf to chain the two operators, and both sub-controllers terminate on a step count
+    rather than on the state, so running them from here emits the same actions in the
+    same order that running them separately does.
+    """
+
+    def __init__(
+        self, *args, pybullet_sim: PyBulletSim | None = None, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._windup_controller = _WindupArmController(
+            self.objects, pybullet_sim=pybullet_sim
+        )
+        self._toss_controller = _ReleaseTossController(
+            self.objects, pybullet_sim=pybullet_sim
+        )
+        self._last_state: ObjectCentricState | None = None
+        self._toss_params: np.ndarray | None = None
+        self._tossing: bool = False
+
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        # The demonstrated configurations, returned as constants. Which arm motion
+        # throws the held object where is not something this samples over.
+        del x, rng  # not used
+        return np.array([TOSS_WINDUP_ARM_CONF, TOSS_RELEASE_ARM_CONF])
+
+    def reset(self, x: ObjectCentricState, params: Any) -> None:
+        current_params = np.asarray(params, dtype=np.float32)
+        assert current_params.shape == (2, 7)
+        self._last_state = x
+        self._toss_params = current_params[1]
+        self._tossing = False
+        # Only the windup is planned now. The toss is planned when the windup ends,
+        # from the state the arm actually reached, which is what running the two
+        # controllers separately plans from too.
+        self._windup_controller.reset(x, current_params[0])
+
+    def terminated(self) -> bool:
+        return self._tossing and self._toss_controller.terminated()
+
+    def step(self) -> Array:
+        if not self._tossing and self._windup_controller.terminated():
+            assert self._last_state is not None
+            assert self._toss_params is not None
+            self._toss_controller.reset(self._last_state, self._toss_params)
+            self._tossing = True
+        if self._tossing:
+            return self._toss_controller.step()
+        return self._windup_controller.step()
+
+    def observe(self, x: ObjectCentricState) -> None:
+        self._last_state = x
+        self._windup_controller.observe(x)
+        self._toss_controller.observe(x)
+
+
 class MoveArmToEndEffectorController(
     GroundParameterizedController[ObjectCentricState, Array]
 ):
@@ -703,10 +844,18 @@ class OpenGripperController(GroundParameterizedController[ObjectCentricState, Ar
 def create_lifted_controllers(
     action_space: TidyBot3DRobotActionSpace,
     init_constant_state: ObjectCentricState | None = None,
+    pybullet_sim: PyBulletSim | None = None,
 ) -> dict[str, LiftedParameterizedController]:
     """Create lifted parameterized controllers for the TidyBot3D ground environment."""
 
     del action_space, init_constant_state  # not used
+
+    # Create wrapper class that captures pybullet_sim
+    class TossFromWindup(TossFromWindupController):
+        """Toss-from-windup controller with pre-configured PyBullet sim."""
+
+        def __init__(self, objects):
+            super().__init__(objects, pybullet_sim=pybullet_sim)
 
     # Controllers.
 
@@ -749,6 +898,28 @@ def create_lifted_controllers(
         TossController,
     )
 
+    # Move to throw pose controller.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    target = Variable("?target", MujocoObjectType)
+    held = Variable("?held", MujocoObjectType)
+
+    LiftedMoveToThrowPoseController: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot, target, held],
+            MoveToThrowPoseController,
+        )
+    )
+
+    # Toss from windup controller.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+
+    LiftedTossFromWindupController: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot],
+            TossFromWindup,
+        )
+    )
+
     # Move arm to end effector controller.
     robot = Variable("?robot", MujocoTidyBotRobotObjectType)
 
@@ -784,6 +955,8 @@ def create_lifted_controllers(
         "move_to_target_from_other_target": LiftedMoveToTargetFromOtherTargetController,
         "move_arm_to_conf": LiftedMoveArmToConfController,
         "toss": LiftedTossController,
+        "move_to_throw_pose": LiftedMoveToThrowPoseController,
+        "toss_from_windup": LiftedTossFromWindupController,
         "move_arm_to_end_effector": LiftedMoveArmToEndEffectorController,
         "close_gripper": LiftedCloseGripperController,
         "open_gripper": LiftedOpenGripperController,

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -38,7 +38,6 @@ from kinder_models.dynamic3d.utils import (
     GRASP_CLOSE_THRESHOLD,
     GRIPPER_CLOSED_THRESHOLD,
     GRIPPER_OPEN_THRESHOLD,
-    MOVE_TO_TARGET_ROT_BOUNDS,
     WAYPOINT_TOL,
     WORLD_X_BOUNDS,
     WORLD_Y_BOUNDS,
@@ -66,6 +65,21 @@ TOSS_RELEASE_ARM_CONF = np.deg2rad([0.0, 20.0, 180.0, -35.0, 0.0, 25.0, 90.0])
 # constraint and is asserted in test_move_to_throw_pose_samples_a_throwable_standoff;
 # it is not imported here because state_abstractions imports this module.
 TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45)
+
+# The rotations, in radians, that MoveToThrowPoseController draws from. Again not
+# MOVE_TO_TARGET_ROT_BOUNDS, which is (-pi/4, pi/4): that rotation swings the base
+# around the target on an arc, and NearBin requires the base to be on the bin's *axis*
+# (|dy| <= WAYPOINT_TOL) and not merely at the right radius. Since
+# get_target_robot_pose_from_parameters places the base target_distance * sin(rot)
+# off-axis, the widest usable rotation is the one that spends half the tolerance at the
+# furthest standoff; the other half is left to the controller, which stops as soon as it
+# is within WAYPOINT_TOL of the pose it planned. Derived rather than written as a
+# literal so that retuning the distance range or the tolerance cannot silently
+# invalidate it.
+_TOSS_MAX_TARGET_ROT = float(
+    np.arcsin(0.5 * WAYPOINT_TOL / TOSS_TARGET_DISTANCE_BOUNDS[1])
+)
+TOSS_TARGET_ROT_BOUNDS = (-_TOSS_MAX_TARGET_ROT, _TOSS_MAX_TARGET_ROT)
 
 
 class MoveToTargetGroundController(
@@ -218,7 +232,7 @@ class MoveToThrowPoseController(MoveToTargetGroundController):
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
         distance = rng.uniform(*TOSS_TARGET_DISTANCE_BOUNDS)  # type: ignore
-        rot = rng.uniform(*MOVE_TO_TARGET_ROT_BOUNDS)
+        rot = rng.uniform(*TOSS_TARGET_ROT_BOUNDS)
         return np.array([distance, rot])
 
     def reset(

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -8,6 +8,7 @@ from bilevel_planning.structs import (
     LiftedParameterizedController,
 )
 from kinder.envs.dynamic3d.object_types import (
+    MujocoMovableObjectType,
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
 )
@@ -185,7 +186,7 @@ class MoveToThrowPoseController(MoveToTargetGroundController):
     The object parameters are:
         robot: The robot itself.
         object: The target object to throw at.
-        held: The object the robot is currently holding.
+        held: The movable object the robot is currently holding.
 
     The continuous parameters are the same as MoveToTargetGroundController's:
         target_distance: float
@@ -900,7 +901,11 @@ def create_lifted_controllers(
     # Move to throw pose controller.
     robot = Variable("?robot", MujocoTidyBotRobotObjectType)
     target = Variable("?target", MujocoObjectType)
-    held = Variable("?held", MujocoObjectType)
+    # The held object is necessarily movable: the robot is carrying it. Typing it
+    # MujocoObjectType would let a planner ground it to a fixture, or to the same
+    # object as ?target, in which case the throw target is the object whose collisions
+    # get disabled.
+    held = Variable("?held", MujocoMovableObjectType)
 
     LiftedMoveToThrowPoseController: LiftedParameterizedController = (
         LiftedParameterizedController(

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -194,9 +194,14 @@ class MoveToThrowPoseController(MoveToTargetGroundController):
 
     This differs from MoveToTargetGroundController in two ways. Its sampler draws a
     standoff instead of returning the single constant distance that gives a stable
-    grasp, since a throw has no one right distance to be at. And it disables collision
-    checking against the held object by default, because the robot is holding that
-    object while it drives, so planning the base against it makes every plan fail.
+    grasp, since a throw has no one right distance to be at. And it excludes the held
+    object from base collision checking by default, because the robot is carrying that
+    object while it drives, so checking the base against it would reject every plan.
+    That exclusion is a no-op today: run_base_motion_planning currently leaves its
+    obstacle set empty (the two lines that would fill it are commented out in
+    dynamic3d/utils.py), so no base plan is collision checked at all. It is here so
+    that the held object is already excluded when that checking is switched back on,
+    which is also why the two pick-and-toss tests pass the same list by hand.
     """
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
@@ -538,10 +543,13 @@ class TossFromWindupController(
         params[1]: the release conf, swung to and released at by TossController.
 
     A toss is those two arm motions back to back, and this runs them as one controller
-    rather than as two skills. Splitting them would need a predicate over the windup
-    conf to chain the two operators, and both sub-controllers terminate on a step count
-    rather than on the state, so running them from here emits the same actions in the
-    same order that running them separately does.
+    rather than as two skills, because splitting them would need a predicate over the
+    windup conf to chain the two operators. Running them from here emits the same
+    actions, in the same order, that running them separately does, for two reasons: the
+    sub-controllers terminate on a step count over a precomputed profile rather than on
+    the state, which fixes both the action count and where the phase boundary falls;
+    and their actions, which are closed loop on the observed state, then agree because
+    the environment is deterministic given identical actions from an identical state.
     """
 
     def __init__(

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -62,20 +62,19 @@ TOSS_RELEASE_ARM_CONF = np.deg2rad([0.0, 20.0, 180.0, -35.0, 0.0, 25.0, 90.0])
 # 1.35 m, the standoff both pick-and-toss tests drive to, and sits strictly inside
 # state_abstractions.THROW_STANDOFF_BOUNDS = (1.20, 1.65), the band NearBin treats as
 # throwable-from -- so every draw satisfies NearBin. That containment is the real
-# constraint and is asserted in test_move_to_throw_pose_samples_a_throwable_standoff;
-# it is not imported here because state_abstractions imports this module.
+# constraint and is asserted in test_move_to_throw_pose_samples_a_throwable_standoff.
 TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45)
 
 # The rotations, in radians, that MoveToThrowPoseController draws from. Again not
 # MOVE_TO_TARGET_ROT_BOUNDS, which is (-pi/4, pi/4): that rotation swings the base
 # around the target on an arc, and NearBin requires the base to be on the bin's *axis*
-# (|dy| <= WAYPOINT_TOL) and not merely at the right radius. Since
-# get_target_robot_pose_from_parameters places the base target_distance * sin(rot)
-# off-axis, the widest usable rotation is the one that spends half the tolerance at the
-# furthest standoff; the other half is left to the controller, which stops as soon as it
-# is within WAYPOINT_TOL of the pose it planned. Derived rather than written as a
-# literal so that retuning the distance range or the tolerance cannot silently
-# invalidate it.
+# and not merely at the right radius. Since get_target_robot_pose_from_parameters
+# places the base target_distance * sin(bin_yaw + rot) off-axis, the widest usable
+# rotation is the one that spends half of WAYPOINT_TOL at the furthest standoff; the
+# other half is left to the controller, which stops as soon as it is within
+# WAYPOINT_TOL of the pose it planned, and NearBin's own slack (NEAR_BIN_TOL) covers
+# the sum. Derived rather than written as a literal so that retuning the distance
+# range or the tolerance cannot silently invalidate it.
 _TOSS_MAX_TARGET_ROT = float(
     np.arcsin(0.5 * WAYPOINT_TOL / TOSS_TARGET_DISTANCE_BOUNDS[1])
 )
@@ -220,9 +219,9 @@ class MoveToThrowPoseController(MoveToTargetGroundController):
     standoff from TOSS_TARGET_DISTANCE_BOUNDS instead of returning the single constant
     distance that gives a stable grasp, since a throw has no one right distance to be
     at -- and, more to the point, is thrown from much further away than a grasp is
-    taken from. And it excludes the held
-    object from base collision checking by default, because the robot is carrying that
-    object while it drives, so checking the base against it would reject every plan.
+    taken from. And it excludes the held object from base collision checking by
+    default, because the robot is carrying that object while it drives, so checking
+    the base against it would reject every plan.
     That exclusion is a no-op today: run_base_motion_planning currently leaves its
     obstacle set empty (the two lines that would fill it are commented out in
     dynamic3d/utils.py), so no base plan is collision checked at all. It is here so

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -25,7 +25,6 @@ from pybullet_helpers.motion_planning import (
 )
 from relational_structs import (
     Array,
-    Object,
     ObjectCentricState,
     Variable,
 )

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -23,6 +23,7 @@ from kinder_models.dynamic3d.utils import (
     MOVE_TO_TARGET_DISTANCE_BOUNDS,
     MOVE_TO_TARGET_ROT_BOUNDS,
     WAYPOINT_TOL,
+    PyBulletSim,
     get_overhead_object_se2_pose,
 )
 from kinder_models.dynamic3d.shelf.parameterized_skills import (
@@ -1408,13 +1409,15 @@ def test_toss_from_windup_matches_split_controllers():
         scene_bg=False,
     )
     assert isinstance(env.observation_space, ObjectCentricBoxSpace)
-    controllers = create_lifted_controllers(env.action_space)
 
     # The two demonstrated arm configurations, exactly as test_pick_toss uses them.
     windup_conf = np.deg2rad([0, 50, 180, -110, 0, -100, 90])  # pre toss
     toss_conf = np.deg2rad([0, 20, 180, -35, 0, 25, 90])  # toss
 
-    def _run_sequence(steps: list[tuple[str, np.ndarray]]) -> list[list[np.ndarray]]:
+    def _run_sequence(
+        steps: list[tuple[str, np.ndarray]],
+        controllers: dict,
+    ) -> list[list[np.ndarray]]:
         """Run controllers back to back from a fresh reset, recording every action.
 
         The actions are returned grouped by controller, so that a caller can tell how
@@ -1441,11 +1444,12 @@ def test_toss_from_windup_matches_split_controllers():
             actions_per_controller.append(actions)
         return actions_per_controller
 
+    controllers = create_lifted_controllers(env.action_space)
     split_phases = _run_sequence(
-        [("move_arm_to_conf", windup_conf), ("toss", toss_conf)]
+        [("move_arm_to_conf", windup_conf), ("toss", toss_conf)], controllers
     )
     composed_phases = _run_sequence(
-        [("toss_from_windup", np.array([windup_conf, toss_conf]))]
+        [("toss_from_windup", np.array([windup_conf, toss_conf]))], controllers
     )
 
     # Both halves did real work, so the comparison below is not vacuous. Measured
@@ -1456,12 +1460,42 @@ def test_toss_from_windup_matches_split_controllers():
     assert min(len(phase) for phase in split_phases) >= 5
 
     split_actions = [action for phase in split_phases for action in phase]
-    (composed_actions,) = composed_phases
+    assert len(composed_phases) == 1
+    composed_actions = composed_phases[0]
     assert len(composed_actions) == len(split_actions)
     for composed_action, split_action in zip(
         composed_actions, split_actions, strict=True
     ):
         assert np.array_equal(composed_action, split_action)
+
+    # Handing the factory a PyBullet sim to share must not change what comes out of
+    # it. Without this, the sim is the client every sub-controller plans in, so a
+    # mistake there would silently change the plans rather than fail loudly.
+    obs, _ = env.reset(seed=125)
+    initial_state = env.observation_space.devectorize(obs)
+    shared_sim = PyBulletSim(initial_state)
+    clients_before = _count_connected_pybullet_clients()
+    shared_controllers = create_lifted_controllers(
+        env.action_space, pybullet_sim=shared_sim
+    )
+    shared_phases = _run_sequence(
+        [("toss_from_windup", np.array([windup_conf, toss_conf]))], shared_controllers
+    )
+    assert len(shared_phases) == 1
+    shared_actions = shared_phases[0]
+    assert len(shared_actions) == len(split_actions)
+    for shared_action, split_action in zip(shared_actions, split_actions, strict=True):
+        assert np.array_equal(shared_action, split_action)
+
+    # The shared sim is still the caller's to reuse: no sub-controller disconnected it
+    # out from under the caller, and nothing was leaked. Note the count check alone is
+    # weak evidence of sharing, since PyBulletSim's finalizer releases a private client
+    # too once the controller is dropped; what shows the shared sim was actually planned
+    # in is that the actions above came out identical.
+    assert p.getConnectionInfo(physicsClientId=shared_sim.physics_client_id)[
+        "isConnected"
+    ]
+    assert _count_connected_pybullet_clients() == clients_before
 
     env.close()
 

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -21,14 +21,14 @@ from relational_structs.utils import create_state_from_dict
 from spatialmath import SE2
 
 from kinder_models.dynamic3d.shelf.parameterized_skills import (
-    create_lifted_controllers as shelf_create_lifted_controllers,
-)
+    create_lifted_controllers as shelf_create_lifted_controllers,)
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    TOSS_TARGET_DISTANCE_BOUNDS,
     create_lifted_controllers,
     get_target_robot_pose_from_parameters,
 )
+from kinder_models.dynamic3d.tossing.state_abstractions import THROW_STANDOFF_BOUNDS
 from kinder_models.dynamic3d.utils import (
-    MOVE_TO_TARGET_DISTANCE_BOUNDS,
     MOVE_TO_TARGET_ROT_BOUNDS,
     WAYPOINT_TOL,
     PyBulletSim,
@@ -1358,13 +1358,14 @@ def test_move_to_throw_pose_controller(monkeypatch):
     controller = lifted_controller.ground((robot, target, held))
 
     # MoveToTargetGroundController returns the constant [0.5, 0.0], so a planner can
-    # only ever try one base pose. This controller samples. Note that being inside the
-    # bounds is not on its own evidence of that: the constant it replaces is inside
-    # them too, so what distinguishes the two is that both components vary.
+    # only ever try one base pose. This controller samples, and it samples from a throw
+    # range rather than the grasping range -- 0.5 m is not a distance a toss is thrown
+    # from. Both components must also vary, since a constant would sit inside any
+    # interval that contains it.
     rng = np.random.default_rng(123)
     draws = np.array([controller.sample_parameters(state, rng) for _ in range(20)])
-    assert np.all(draws[:, 0] >= MOVE_TO_TARGET_DISTANCE_BOUNDS[0])
-    assert np.all(draws[:, 0] <= MOVE_TO_TARGET_DISTANCE_BOUNDS[1])
+    assert np.all(draws[:, 0] >= TOSS_TARGET_DISTANCE_BOUNDS[0])
+    assert np.all(draws[:, 0] <= TOSS_TARGET_DISTANCE_BOUNDS[1])
     assert np.all(draws[:, 1] >= MOVE_TO_TARGET_ROT_BOUNDS[0])
     assert np.all(draws[:, 1] <= MOVE_TO_TARGET_ROT_BOUNDS[1])
     assert draws[:, 0].min() < draws[:, 0].max()
@@ -1558,5 +1559,45 @@ def test_toss_from_windup_samples_the_demonstrated_confs():
     assert np.array_equal(params, other_params)
     assert np.allclose(params[0], np.deg2rad([0, 50, 180, -110, 0, -100, 90]))
     assert np.allclose(params[1], np.deg2rad([0, 20, 180, -35, 0, 25, 90]))
+
+    env.close()
+
+
+def test_move_to_throw_pose_samples_a_throwable_standoff():
+    """The sampled standoff must be one a throw can actually be thrown from.
+
+    MoveToThrowPoseController originally drew from MOVE_TO_TARGET_DISTANCE_BOUNDS,
+    which is the *grasping* range (0.5-0.6 m). NearBin -- the predicate that says the
+    base is standing somewhere a toss can be released from -- admits only
+    THROW_STANDOFF_BOUNDS (1.20-1.65 m). Those two intervals are disjoint, so no draw
+    from the sampler could ever satisfy NearBin, and any planner asked to reach NearBin
+    through this controller fails no matter how many samples it takes.
+
+    This asserts the containment directly rather than the two numbers, so widening
+    either interval keeps the test meaningful.
+    """
+    num_cubes = 1
+    env = kinder.make(
+        f"kinder/Tossing3D-o{num_cubes}-v0", render_mode="rgb_array", scene_bg=False
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+
+    controllers = create_lifted_controllers(env.action_space)
+    lifted_controller = controllers["move_to_throw_pose"]
+    robot = _get_robot_from_state(state)
+    target = state.get_object_from_name("bin_0")
+    held = state.get_object_from_name("cube_0")
+    controller = lifted_controller.ground((robot, target, held))
+
+    rng = np.random.default_rng(123)
+    draws = np.array([controller.sample_parameters(state, rng) for _ in range(50)])
+
+    low, high = THROW_STANDOFF_BOUNDS
+    assert np.all(draws[:, 0] >= low), draws[:, 0].min()
+    assert np.all(draws[:, 0] <= high), draws[:, 0].max()
+    # Still a sampler, not a constant.
+    assert draws[:, 0].min() < draws[:, 0].max()
 
     env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1386,15 +1386,19 @@ def test_move_to_throw_pose_controller():
     expected_pose = get_target_robot_pose_from_parameters(
         target_pose, params[0], params[1]
     )
-    assert np.isclose(state.get(robot, "pos_base_x"), expected_pose.x, atol=WAYPOINT_TOL)
-    assert np.isclose(state.get(robot, "pos_base_y"), expected_pose.y, atol=WAYPOINT_TOL)
+    assert np.isclose(
+        state.get(robot, "pos_base_x"), expected_pose.x, atol=WAYPOINT_TOL
+    )
+    assert np.isclose(
+        state.get(robot, "pos_base_y"), expected_pose.y, atol=WAYPOINT_TOL
+    )
 
     env.close()
 
 
 def test_toss_from_windup_matches_split_controllers():
-    """Test that the composed toss emits the same actions as the two-controller
-    sequence it replaces."""
+    """Test that the composed toss emits the same actions as the two-controller sequence
+    it replaces."""
 
     # Create the environment.
     num_cubes = 1
@@ -1450,7 +1454,8 @@ def test_toss_from_windup_matches_split_controllers():
 
 
 def test_toss_from_windup_samples_the_demonstrated_confs():
-    """Test that the composed toss samples the two demonstrated confs, deterministically."""
+    """Test that the composed toss samples the two demonstrated confs,
+    deterministically."""
 
     # Create the environment.
     num_cubes = 1

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -14,24 +14,26 @@ from kinder.envs.dynamic3d.object_types import (
     MujocoObjectTypeFeatures,
     MujocoTidyBotRobotObjectType,
 )
+from prpl_utils.utils import get_signed_angle_distance
 from relational_structs import Object, ObjectCentricState
 from relational_structs.spaces import ObjectCentricBoxSpace
 from relational_structs.utils import create_state_from_dict
 from spatialmath import SE2
 
-from kinder_models.dynamic3d.utils import (
-    MOVE_TO_TARGET_DISTANCE_BOUNDS,
-    MOVE_TO_TARGET_ROT_BOUNDS,
-    WAYPOINT_TOL,
-    PyBulletSim,
-    get_overhead_object_se2_pose,
-)
 from kinder_models.dynamic3d.shelf.parameterized_skills import (
     create_lifted_controllers as shelf_create_lifted_controllers,
 )
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     create_lifted_controllers,
     get_target_robot_pose_from_parameters,
+)
+from kinder_models.dynamic3d.utils import (
+    MOVE_TO_TARGET_DISTANCE_BOUNDS,
+    MOVE_TO_TARGET_ROT_BOUNDS,
+    WAYPOINT_TOL,
+    PyBulletSim,
+    get_overhead_object_se2_pose,
+    run_base_motion_planning,
 )
 
 kinder.register_all_environments()
@@ -1330,7 +1332,7 @@ def test_pick_ground_toss():
     env.close()
 
 
-def test_move_to_throw_pose_controller():
+def test_move_to_throw_pose_controller(monkeypatch):
     """Test the throw-pose controller in the tossing environment with 1 cube."""
 
     # Create the environment.
@@ -1355,21 +1357,42 @@ def test_move_to_throw_pose_controller():
     held = state.get_object_from_name("cube_0")
     controller = lifted_controller.ground((robot, target, held))
 
-    # MoveToTargetGroundController returns a constant standoff, so a planner can only
-    # ever try one base pose. This controller samples, so two rngs must disagree.
-    params = controller.sample_parameters(state, np.random.default_rng(123))
-    other_params = controller.sample_parameters(state, np.random.default_rng(456))
-    assert (
-        MOVE_TO_TARGET_DISTANCE_BOUNDS[0]
-        <= params[0]
-        <= MOVE_TO_TARGET_DISTANCE_BOUNDS[1]
+    # MoveToTargetGroundController returns the constant [0.5, 0.0], so a planner can
+    # only ever try one base pose. This controller samples. Note that being inside the
+    # bounds is not on its own evidence of that: the constant it replaces is inside
+    # them too, so what distinguishes the two is that both components vary.
+    rng = np.random.default_rng(123)
+    draws = np.array([controller.sample_parameters(state, rng) for _ in range(20)])
+    assert np.all(draws[:, 0] >= MOVE_TO_TARGET_DISTANCE_BOUNDS[0])
+    assert np.all(draws[:, 0] <= MOVE_TO_TARGET_DISTANCE_BOUNDS[1])
+    assert np.all(draws[:, 1] >= MOVE_TO_TARGET_ROT_BOUNDS[0])
+    assert np.all(draws[:, 1] <= MOVE_TO_TARGET_ROT_BOUNDS[1])
+    assert draws[:, 0].min() < draws[:, 0].max()
+    assert draws[:, 1].min() < draws[:, 1].max()
+    params = draws[0]
+
+    # Record what the controller asks the base planner to ignore. Asserting on the
+    # resulting plan would prove nothing: base collision checking is currently
+    # commented out in run_base_motion_planning (dynamic3d/utils.py), so every plan
+    # succeeds whether or not the held object is excluded. What this pins is that the
+    # controller passes the held object down, which is what will matter when that
+    # checking is switched back on.
+    recorded_disabled: list[list[str] | None] = []
+
+    def _recording_run_base_motion_planning(**kwargs):
+        recorded_disabled.append(kwargs.get("disable_collision_objects"))
+        return run_base_motion_planning(**kwargs)
+
+    monkeypatch.setattr(
+        "kinder_models.dynamic3d.tossing.parameterized_skills"
+        ".run_base_motion_planning",
+        _recording_run_base_motion_planning,
     )
-    assert MOVE_TO_TARGET_ROT_BOUNDS[0] <= params[1] <= MOVE_TO_TARGET_ROT_BOUNDS[1]
-    assert not np.allclose(params, other_params)
 
     # Reset and execute the controller until it terminates. The held object is not
     # passed as a collision object, so this must plan without one being given.
     controller.reset(state, params)
+    assert recorded_disabled == [["cube_0"]]
     for _ in range(400):
         action = controller.step()
         obs, _, _, _, _ = env.step(action)
@@ -1392,6 +1415,15 @@ def test_move_to_throw_pose_controller():
     )
     assert np.isclose(
         state.get(robot, "pos_base_y"), expected_pose.y, atol=WAYPOINT_TOL
+    )
+    # The heading matters as much as the position: the sampled rotation is half of what
+    # this controller newly varies, and a throw is released along the base's heading.
+    assert np.isclose(
+        get_signed_angle_distance(
+            state.get(robot, "pos_base_rot"), expected_pose.theta()
+        ),
+        0.0,
+        atol=WAYPOINT_TOL,
     )
 
     env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -24,12 +24,12 @@ from kinder_models.dynamic3d.shelf.parameterized_skills import (
     create_lifted_controllers as shelf_create_lifted_controllers,)
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     TOSS_TARGET_DISTANCE_BOUNDS,
+    TOSS_TARGET_ROT_BOUNDS,
     create_lifted_controllers,
     get_target_robot_pose_from_parameters,
 )
 from kinder_models.dynamic3d.tossing.state_abstractions import THROW_STANDOFF_BOUNDS
 from kinder_models.dynamic3d.utils import (
-    MOVE_TO_TARGET_ROT_BOUNDS,
     WAYPOINT_TOL,
     PyBulletSim,
     get_overhead_object_se2_pose,
@@ -1366,8 +1366,8 @@ def test_move_to_throw_pose_controller(monkeypatch):
     draws = np.array([controller.sample_parameters(state, rng) for _ in range(20)])
     assert np.all(draws[:, 0] >= TOSS_TARGET_DISTANCE_BOUNDS[0])
     assert np.all(draws[:, 0] <= TOSS_TARGET_DISTANCE_BOUNDS[1])
-    assert np.all(draws[:, 1] >= MOVE_TO_TARGET_ROT_BOUNDS[0])
-    assert np.all(draws[:, 1] <= MOVE_TO_TARGET_ROT_BOUNDS[1])
+    assert np.all(draws[:, 1] >= TOSS_TARGET_ROT_BOUNDS[0])
+    assert np.all(draws[:, 1] <= TOSS_TARGET_ROT_BOUNDS[1])
     assert draws[:, 0].min() < draws[:, 0].max()
     assert draws[:, 1].min() < draws[:, 1].max()
     params = draws[0]
@@ -1599,5 +1599,46 @@ def test_move_to_throw_pose_samples_a_throwable_standoff():
     assert np.all(draws[:, 0] <= high), draws[:, 0].max()
     # Still a sampler, not a constant.
     assert draws[:, 0].min() < draws[:, 0].max()
+
+    env.close()
+
+
+def test_move_to_throw_pose_samples_a_pose_on_the_bin_axis():
+    """Every sampled pose must be one NearBin accepts, in y as well as in x.
+
+    NearBin has three conjuncts, and the standoff is only one of them. It also
+    requires the base to be on the bin's axis -- |dy| <= WAYPOINT_TOL -- because a
+    radius test alone is satisfied by a whole ring of positions. The sampled rotation
+    is what moves the base off that axis: get_target_robot_pose_from_parameters places
+    the base at target_distance * sin(target_rot) off-axis, so drawing target_rot from
+    MOVE_TO_TARGET_ROT_BOUNDS = (-pi/4, pi/4) puts all but a few percent of draws
+    outside NearBin however good the standoff is.
+
+    The assertion is on the off-axis offset the parameters imply, not on the bounds
+    themselves, so it keeps its meaning if either interval is retuned.
+    """
+    num_cubes = 1
+    env = kinder.make(
+        f"kinder/Tossing3D-o{num_cubes}-v0", render_mode="rgb_array", scene_bg=False
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+
+    controllers = create_lifted_controllers(env.action_space)
+    lifted_controller = controllers["move_to_throw_pose"]
+    robot = _get_robot_from_state(state)
+    target = state.get_object_from_name("bin_0")
+    held = state.get_object_from_name("cube_0")
+    controller = lifted_controller.ground((robot, target, held))
+
+    rng = np.random.default_rng(123)
+    draws = np.array([controller.sample_parameters(state, rng) for _ in range(50)])
+
+    off_axis = np.abs(draws[:, 0] * np.sin(draws[:, 1]))
+    assert np.all(off_axis <= WAYPOINT_TOL), off_axis.max()
+    # Still a sampler, not a constant, in both components.
+    assert draws[:, 0].min() < draws[:, 0].max()
+    assert draws[:, 1].min() < draws[:, 1].max()
 
     env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -19,6 +19,12 @@ from relational_structs.spaces import ObjectCentricBoxSpace
 from relational_structs.utils import create_state_from_dict
 from spatialmath import SE2
 
+from kinder_models.dynamic3d.utils import (
+    MOVE_TO_TARGET_DISTANCE_BOUNDS,
+    MOVE_TO_TARGET_ROT_BOUNDS,
+    WAYPOINT_TOL,
+    get_overhead_object_se2_pose,
+)
 from kinder_models.dynamic3d.shelf.parameterized_skills import (
     create_lifted_controllers as shelf_create_lifted_controllers,
 )
@@ -1319,5 +1325,154 @@ def test_pick_ground_toss():
     print("cube_orientation", cube_orientation)
     print("robot base position", robot_base_position)
     print("distance", distance)
+
+    env.close()
+
+
+def test_move_to_throw_pose_controller():
+    """Test the throw-pose controller in the tossing environment with 1 cube."""
+
+    # Create the environment.
+    num_cubes = 1
+    env = kinder.make(
+        f"kinder/Tossing3D-o{num_cubes}-v0",
+        render_mode="rgb_array",
+        scene_bg=False,
+    )
+
+    # Reset the environment and get the initial state.
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+
+    # Ground the controller on (robot, target, held).
+    controllers = create_lifted_controllers(env.action_space)
+    lifted_controller = controllers["move_to_throw_pose"]
+    assert len(lifted_controller.variables) == 3
+    robot = _get_robot_from_state(state)
+    target = state.get_object_from_name("bin_0")
+    held = state.get_object_from_name("cube_0")
+    controller = lifted_controller.ground((robot, target, held))
+
+    # MoveToTargetGroundController returns a constant standoff, so a planner can only
+    # ever try one base pose. This controller samples, so two rngs must disagree.
+    params = controller.sample_parameters(state, np.random.default_rng(123))
+    other_params = controller.sample_parameters(state, np.random.default_rng(456))
+    assert (
+        MOVE_TO_TARGET_DISTANCE_BOUNDS[0]
+        <= params[0]
+        <= MOVE_TO_TARGET_DISTANCE_BOUNDS[1]
+    )
+    assert MOVE_TO_TARGET_ROT_BOUNDS[0] <= params[1] <= MOVE_TO_TARGET_ROT_BOUNDS[1]
+    assert not np.allclose(params, other_params)
+
+    # Reset and execute the controller until it terminates. The held object is not
+    # passed as a collision object, so this must plan without one being given.
+    controller.reset(state, params)
+    for _ in range(400):
+        action = controller.step()
+        obs, _, _, _, _ = env.step(action)
+        next_state = env.observation_space.devectorize(obs)
+        controller.observe(next_state)
+        state = next_state
+        if controller.terminated():
+            break
+    else:
+        assert False, "Controller did not terminate"
+
+    # The base ended up the sampled distance from the target, facing it.
+    robot = _get_robot_from_state(state)
+    target_pose = get_overhead_object_se2_pose(state, target)
+    expected_pose = get_target_robot_pose_from_parameters(
+        target_pose, params[0], params[1]
+    )
+    assert np.isclose(state.get(robot, "pos_base_x"), expected_pose.x, atol=WAYPOINT_TOL)
+    assert np.isclose(state.get(robot, "pos_base_y"), expected_pose.y, atol=WAYPOINT_TOL)
+
+    env.close()
+
+
+def test_toss_from_windup_matches_split_controllers():
+    """Test that the composed toss emits the same actions as the two-controller
+    sequence it replaces."""
+
+    # Create the environment.
+    num_cubes = 1
+    env = kinder.make(
+        f"kinder/Tossing3D-o{num_cubes}-v0",
+        render_mode="rgb_array",
+        scene_bg=False,
+    )
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    controllers = create_lifted_controllers(env.action_space)
+
+    # The two demonstrated arm configurations, exactly as test_pick_toss uses them.
+    windup_conf = np.deg2rad([0, 50, 180, -110, 0, -100, 90])  # pre toss
+    toss_conf = np.deg2rad([0, 20, 180, -35, 0, 25, 90])  # toss
+
+    def _run_sequence(steps: list[tuple[str, np.ndarray]]) -> list[np.ndarray]:
+        """Run controllers back to back from a fresh reset, recording every action."""
+        obs, _ = env.reset(seed=125)
+        state = env.observation_space.devectorize(obs)
+        actions: list[np.ndarray] = []
+        for controller_name, params in steps:
+            robot = _get_robot_from_state(state)
+            controller = controllers[controller_name].ground((robot,))
+            controller.reset(state, params)
+            for _ in range(400):
+                action = controller.step()
+                actions.append(np.array(action, dtype=np.float32, copy=True))
+                obs, _, _, _, _ = env.step(action)
+                state = env.observation_space.devectorize(obs)
+                controller.observe(state)
+                if controller.terminated():
+                    break
+            else:
+                assert False, "Controller did not terminate"
+        return actions
+
+    split_actions = _run_sequence(
+        [("move_arm_to_conf", windup_conf), ("toss", toss_conf)]
+    )
+    composed_actions = _run_sequence(
+        [("toss_from_windup", np.array([windup_conf, toss_conf]))]
+    )
+
+    # The sequence did real work, so the comparison below is not vacuous.
+    assert len(split_actions) > 2
+    assert len(composed_actions) == len(split_actions)
+    for composed_action, split_action in zip(
+        composed_actions, split_actions, strict=True
+    ):
+        assert np.array_equal(composed_action, split_action)
+
+    env.close()
+
+
+def test_toss_from_windup_samples_the_demonstrated_confs():
+    """Test that the composed toss samples the two demonstrated confs, deterministically."""
+
+    # Create the environment.
+    num_cubes = 1
+    env = kinder.make(
+        f"kinder/Tossing3D-o{num_cubes}-v0",
+        render_mode="rgb_array",
+        scene_bg=False,
+    )
+
+    # Reset the environment and get the initial state.
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+
+    controllers = create_lifted_controllers(env.action_space)
+    robot = _get_robot_from_state(state)
+    controller = controllers["toss_from_windup"].ground((robot,))
+
+    params = controller.sample_parameters(state, np.random.default_rng(123))
+    other_params = controller.sample_parameters(state, np.random.default_rng(456))
+    assert np.array_equal(params, other_params)
+    assert np.allclose(params[0], np.deg2rad([0, 50, 180, -110, 0, -100, 90]))
+    assert np.allclose(params[1], np.deg2rad([0, 20, 180, -35, 0, 25, 90]))
 
     env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1414,15 +1414,20 @@ def test_toss_from_windup_matches_split_controllers():
     windup_conf = np.deg2rad([0, 50, 180, -110, 0, -100, 90])  # pre toss
     toss_conf = np.deg2rad([0, 20, 180, -35, 0, 25, 90])  # toss
 
-    def _run_sequence(steps: list[tuple[str, np.ndarray]]) -> list[np.ndarray]:
-        """Run controllers back to back from a fresh reset, recording every action."""
+    def _run_sequence(steps: list[tuple[str, np.ndarray]]) -> list[list[np.ndarray]]:
+        """Run controllers back to back from a fresh reset, recording every action.
+
+        The actions are returned grouped by controller, so that a caller can tell how
+        much work each one did rather than only how much they did between them.
+        """
         obs, _ = env.reset(seed=125)
         state = env.observation_space.devectorize(obs)
-        actions: list[np.ndarray] = []
+        actions_per_controller: list[list[np.ndarray]] = []
         for controller_name, params in steps:
             robot = _get_robot_from_state(state)
             controller = controllers[controller_name].ground((robot,))
             controller.reset(state, params)
+            actions: list[np.ndarray] = []
             for _ in range(400):
                 action = controller.step()
                 actions.append(np.array(action, dtype=np.float32, copy=True))
@@ -1433,17 +1438,25 @@ def test_toss_from_windup_matches_split_controllers():
                     break
             else:
                 assert False, "Controller did not terminate"
-        return actions
+            actions_per_controller.append(actions)
+        return actions_per_controller
 
-    split_actions = _run_sequence(
+    split_phases = _run_sequence(
         [("move_arm_to_conf", windup_conf), ("toss", toss_conf)]
     )
-    composed_actions = _run_sequence(
+    composed_phases = _run_sequence(
         [("toss_from_windup", np.array([windup_conf, toss_conf]))]
     )
 
-    # The sequence did real work, so the comparison below is not vacuous.
-    assert len(split_actions) > 2
+    # Both halves did real work, so the comparison below is not vacuous. Measured
+    # locally: 16 windup actions then 18 toss actions, 34 in total. The exact counts
+    # are not asserted because they follow from a motion plan, but a phase that
+    # collapsed to a step or two would no longer be a windup or a toss.
+    assert len(split_phases) == 2
+    assert min(len(phase) for phase in split_phases) >= 5
+
+    split_actions = [action for phase in split_phases for action in phase]
+    (composed_actions,) = composed_phases
     assert len(composed_actions) == len(split_actions)
     for composed_action, split_action in zip(
         composed_actions, split_actions, strict=True

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -20,15 +20,16 @@ from relational_structs.spaces import ObjectCentricBoxSpace
 from relational_structs.utils import create_state_from_dict
 from spatialmath import SE2
 
-from kinder_models.dynamic3d.shelf.parameterized_skills import (
-    create_lifted_controllers as shelf_create_lifted_controllers,)
+import kinder_models.dynamic3d.tossing.parameterized_skills
+from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
-    TOSS_TARGET_DISTANCE_BOUNDS,
-    TOSS_TARGET_ROT_BOUNDS,
     create_lifted_controllers,
     get_target_robot_pose_from_parameters,
 )
-from kinder_models.dynamic3d.tossing.state_abstractions import THROW_STANDOFF_BOUNDS
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    NEAR_BIN_TOL,
+    THROW_STANDOFF_BOUNDS,
+)
 from kinder_models.dynamic3d.utils import (
     WAYPOINT_TOL,
     PyBulletSim,
@@ -1221,7 +1222,7 @@ def test_pick_ground_toss():
     state = env.observation_space.devectorize(obs)
 
     # Create the move-base controller.
-    controllers = shelf_create_lifted_controllers(env.action_space)
+    controllers = shelf_skills.create_lifted_controllers(env.action_space)
 
     # create the pick ground controller.
     lifted_controller = controllers["pick_shelf"]
@@ -1332,7 +1333,7 @@ def test_pick_ground_toss():
     env.close()
 
 
-def test_move_to_throw_pose_controller(monkeypatch):
+def test_move_to_throw_pose_controller():
     """Test the throw-pose controller in the tossing environment with 1 cube."""
 
     # Create the environment.
@@ -1342,6 +1343,11 @@ def test_move_to_throw_pose_controller(monkeypatch):
         render_mode="rgb_array",
         scene_bg=False,
     )
+    if MAKE_VIDEOS:
+        env.unwrapped._object_centric_env.set_render_camera("task_view")  # type: ignore # pylint: disable=protected-access
+        env = RecordVideo(
+            env, "unit_test_videos", name_prefix=f"TidyBot3D-throw-pose-o{num_cubes}"
+        )
 
     # Reset the environment and get the initial state.
     obs, _ = env.reset(seed=125)
@@ -1358,16 +1364,12 @@ def test_move_to_throw_pose_controller(monkeypatch):
     controller = lifted_controller.ground((robot, target, held))
 
     # MoveToTargetGroundController returns the constant [0.5, 0.0], so a planner can
-    # only ever try one base pose. This controller samples, and it samples from a throw
-    # range rather than the grasping range -- 0.5 m is not a distance a toss is thrown
-    # from. Both components must also vary, since a constant would sit inside any
-    # interval that contains it.
+    # only ever try one base pose. This controller samples, and both components must
+    # vary. Where the draws land is asserted in the two tests below, against the
+    # predicate they have to satisfy rather than against the sampler's own bounds --
+    # which the sampler draws from directly, so asserting them here could not fail.
     rng = np.random.default_rng(123)
     draws = np.array([controller.sample_parameters(state, rng) for _ in range(20)])
-    assert np.all(draws[:, 0] >= TOSS_TARGET_DISTANCE_BOUNDS[0])
-    assert np.all(draws[:, 0] <= TOSS_TARGET_DISTANCE_BOUNDS[1])
-    assert np.all(draws[:, 1] >= TOSS_TARGET_ROT_BOUNDS[0])
-    assert np.all(draws[:, 1] <= TOSS_TARGET_ROT_BOUNDS[1])
     assert draws[:, 0].min() < draws[:, 0].max()
     assert draws[:, 1].min() < draws[:, 1].max()
     params = draws[0]
@@ -1381,18 +1383,23 @@ def test_move_to_throw_pose_controller(monkeypatch):
     recorded_disabled: list[list[str] | None] = []
 
     def _recording_run_base_motion_planning(**kwargs):
+        """Record the call, then delegate to the real planner."""
         recorded_disabled.append(kwargs.get("disable_collision_objects"))
         return run_base_motion_planning(**kwargs)
 
-    monkeypatch.setattr(
-        "kinder_models.dynamic3d.tossing.parameterized_skills"
-        ".run_base_motion_planning",
-        _recording_run_base_motion_planning,
-    )
+    # Swapped explicitly rather than with pytest's monkeypatch fixture: no test in
+    # kinder-models uses a fixture, and the try/finally is the whole of what the
+    # fixture would do here.
+    skills_module = kinder_models.dynamic3d.tossing.parameterized_skills
+    original_run_base_motion_planning = skills_module.run_base_motion_planning
+    skills_module.run_base_motion_planning = _recording_run_base_motion_planning
 
     # Reset and execute the controller until it terminates. The held object is not
     # passed as a collision object, so this must plan without one being given.
-    controller.reset(state, params)
+    try:
+        controller.reset(state, params)
+    finally:
+        skills_module.run_base_motion_planning = original_run_base_motion_planning
     assert recorded_disabled == [["cube_0"]]
     for _ in range(400):
         action = controller.step()
@@ -1431,8 +1438,10 @@ def test_move_to_throw_pose_controller(monkeypatch):
 
 
 def test_toss_from_windup_matches_split_controllers():
-    """Test that the composed toss emits the same actions as the two-controller sequence
-    it replaces."""
+    """Test that the composed toss emits the actions of the sequence it replaces.
+
+    The two-controller sequence is move_arm_to_conf then toss.
+    """
 
     # Create the environment.
     num_cubes = 1
@@ -1441,6 +1450,11 @@ def test_toss_from_windup_matches_split_controllers():
         render_mode="rgb_array",
         scene_bg=False,
     )
+    if MAKE_VIDEOS:
+        env.unwrapped._object_centric_env.set_render_camera("task_view")  # type: ignore # pylint: disable=protected-access
+        env = RecordVideo(
+            env, "unit_test_videos", name_prefix=f"TidyBot3D-toss-windup-o{num_cubes}"
+        )
     assert isinstance(env.observation_space, ObjectCentricBoxSpace)
 
     # The two demonstrated arm configurations, exactly as test_pick_toss uses them.
@@ -1507,10 +1521,13 @@ def test_toss_from_windup_matches_split_controllers():
     obs, _ = env.reset(seed=125)
     initial_state = env.observation_space.devectorize(obs)
     shared_sim = PyBulletSim(initial_state)
-    clients_before = _count_connected_pybullet_clients()
     shared_controllers = create_lifted_controllers(
         env.action_space, pybullet_sim=shared_sim
     )
+    # Counted here, after the shared sim exists but before any controller has run, so
+    # that the baseline is not inflated by whatever the earlier composed run held.
+    gc.collect()
+    clients_before = _count_connected_pybullet_clients()
     shared_phases = _run_sequence(
         [("toss_from_windup", np.array([windup_conf, toss_conf]))], shared_controllers
     )
@@ -1528,14 +1545,17 @@ def test_toss_from_windup_matches_split_controllers():
     assert p.getConnectionInfo(physicsClientId=shared_sim.physics_client_id)[
         "isConnected"
     ]
+    gc.collect()
     assert _count_connected_pybullet_clients() == clients_before
 
     env.close()
 
 
 def test_toss_from_windup_samples_the_demonstrated_confs():
-    """Test that the composed toss samples the two demonstrated confs,
-    deterministically."""
+    """Test that the composed toss samples the two demonstrated confs.
+
+    The draw is deterministic: it ignores the rng entirely.
+    """
 
     # Create the environment.
     num_cubes = 1
@@ -1594,9 +1614,21 @@ def test_move_to_throw_pose_samples_a_throwable_standoff():
     rng = np.random.default_rng(123)
     draws = np.array([controller.sample_parameters(state, rng) for _ in range(50)])
 
+    # Measured on the pose the parameters actually imply, not on the sampled distance:
+    # NearBin's dx is bin.x - base.x, which is target_distance * cos(bin_yaw + rot).
+    # The two agree only because bin_init_region pins the bin's yaw at 0, and reading
+    # the pose keeps this honest if that ever changes.
+    target_pose = get_overhead_object_se2_pose(state, target)
+    standoff = np.array(
+        [
+            target_pose.x
+            - get_target_robot_pose_from_parameters(target_pose, distance, rot).x
+            for distance, rot in draws
+        ]
+    )
     low, high = THROW_STANDOFF_BOUNDS
-    assert np.all(draws[:, 0] >= low), draws[:, 0].min()
-    assert np.all(draws[:, 0] <= high), draws[:, 0].max()
+    assert np.all(standoff >= low), standoff.min()
+    assert np.all(standoff <= high), standoff.max()
     # Still a sampler, not a constant.
     assert draws[:, 0].min() < draws[:, 0].max()
 
@@ -1607,7 +1639,7 @@ def test_move_to_throw_pose_samples_a_pose_on_the_bin_axis():
     """Every sampled pose must be one NearBin accepts, in y as well as in x.
 
     NearBin has three conjuncts, and the standoff is only one of them. It also
-    requires the base to be on the bin's axis -- |dy| <= WAYPOINT_TOL -- because a
+    requires the base to be on the bin's axis -- |dy| <= NEAR_BIN_TOL -- because a
     radius test alone is satisfied by a whole ring of positions. The sampled rotation
     is what moves the base off that axis: get_target_robot_pose_from_parameters places
     the base at target_distance * sin(target_rot) off-axis, so drawing target_rot from
@@ -1635,8 +1667,21 @@ def test_move_to_throw_pose_samples_a_pose_on_the_bin_axis():
     rng = np.random.default_rng(123)
     draws = np.array([controller.sample_parameters(state, rng) for _ in range(50)])
 
-    off_axis = np.abs(draws[:, 0] * np.sin(draws[:, 1]))
-    assert np.all(off_axis <= WAYPOINT_TOL), off_axis.max()
+    # Measured on the pose the parameters actually imply, not on
+    # target_distance * sin(target_rot): NearBin's dy is bin.y - base.y in world
+    # coordinates, which is target_distance * sin(bin_yaw + target_rot). The two agree
+    # only because bin_init_region pins the bin's yaw at 0.
+    target_pose = get_overhead_object_se2_pose(state, target)
+    off_axis = np.array(
+        [
+            abs(
+                target_pose.y
+                - get_target_robot_pose_from_parameters(target_pose, distance, rot).y
+            )
+            for distance, rot in draws
+        ]
+    )
+    assert np.all(off_axis <= NEAR_BIN_TOL), off_axis.max()
     # Still a sampler, not a constant, in both components.
     assert draws[:, 0].min() < draws[:, 0].max()
     assert draws[:, 1].min() < draws[:, 1].max()


### PR DESCRIPTION
**TL;DR** Two new controllers for `dynamic3d/tossing` and a `pybullet_sim=` parameter on its factory, so a planner can produce a throw at all. Additive: no existing controller class or dict key changes, and `test_pick_toss` / `test_pick_ground_toss` are untouched. Suite **17/17**.

## Question / goal

Can `bilevel_planning` plan and execute a toss in `Tossing3D` using only the controllers this package exposes? Today it cannot, for three independent reasons, and this PR fixes all three.

## Background

`bilevel_planning` gets its continuous parameters from `GroundParameterizedController.sample_parameters`. For `MoveToTargetGroundController` that returns the constant `[0.5, 0.0]` — a standoff chosen for a stable grasp — so a planner grounding it has exactly one base pose available and cannot search for a throwing one. Separately, planning `move_to_target` towards the bin *while holding* the cube fails unless collisions against the held object are disabled; `test_pick_toss` and `test_pick_ground_toss` both pass `disable_collision_objects=["cube_0"]` by hand for precisely this call, which a planner has no way to do.

The second gap is structural. A toss is two arm motions back to back — `move_arm_to_conf` to a windup pose, then `toss` — but a `LiftedSkill` pairs one operator with one controller, so the sequence cannot be one skill today. Splitting it into two operators would need a predicate classifying the 7 windup joint angles against a tolerance nobody has measured.

Third, `RelationalControllerGenerator` grounds a fresh controller per sampling attempt, and these motion-planning controllers build their own `PyBulletSim` on first `reset`. `shelf`'s factory already takes a `pybullet_sim` so one client can be shared; `tossing`'s did not.

## Hypothesis

None — implementation task, not an experiment.

## Guidance given

Express the held object as an object parameter rather than a closure binding if it fits; compose the toss rather than splitting the operator, and verify the composition emits identical actions rather than assuming it; return the two demonstrated arm configurations as deterministic constants; match `shelf`'s factory signature exactly; leave every existing key and class alone.

## Methods

Three additive changes to `tossing/parameterized_skills.py`.

**`MoveToThrowPoseController(MoveToTargetGroundController)`**, registered as `move_to_throw_pose` over `[?robot, ?target, ?held]`. It overrides `sample_parameters` to draw a throw standoff, and overrides `reset` to default `disable_collision_objects` to the held object's name. The third variable follows `move_to_target_from_other_target`, which already takes a `?prev_target` purely to name an object the controller needs. `?held` is `MujocoMovableObjectType`, not `MujocoObjectType`: the broader type would let a planner ground it to a fixture, or to the same object as `?target`, in which case the object whose collisions get disabled is the throw target.

**`TossFromWindupController`**, registered as `toss_from_windup` over `[?robot]`. It owns a `MoveArmToConfController` and a `TossController` behind one phase flag. Its continuous parameter is a `(2, 7)` array of arm configurations; `sample_parameters` returns the two demonstrated ones as constants, replacing the `NotImplementedError` both sub-controllers raise. The toss is planned when the windup terminates, from the same state the split version plans from.

**`create_lifted_controllers` gains `pybullet_sim=None`**, matching `shelf`'s signature. Sharing it needs two thin private subclasses, because unlike `PickShelfController` the toss sub-controllers do not accept a `pybullet_sim` kwarg and this PR does not change them.

The sampling ranges are derived, not literal. `TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45)` brackets the 1.35 m both pick-and-toss tests drive to and sits strictly inside `NearBin`'s `THROW_STANDOFF_BOUNDS`. `TOSS_TARGET_ROT_BOUNDS` is derived from `WAYPOINT_TOL` and the standoff range, spending half the tolerance on the planned pose and leaving half for the controller, so retuning either cannot silently invalidate it.

**Both sampler tests measure the world-frame pose the parameters imply, not a proxy.** `NearBin`'s `dy` and `dx` are `target_distance * sin/cos(bin_yaw + target_rot)`; the tests previously used `target_distance * sin(target_rot)` and the raw sampled distance, which agree only because the task config pins the bin's yaw at 0. Both now go through `get_target_robot_pose_from_parameters`, the same helper the controller uses. The earlier assertion that draws fell inside the two intervals the sampler draws from with `rng.uniform` was dropped — it could not fail.

## Results

**17/17** in `tests/dynamic3d/tossing/`, ~32 s — the 11 pre-existing tests unmodified, including `test_pick_toss` and `test_pick_ground_toss`, plus 6 new. black / isort / docformatter / mypy clean, pylint 10.00/10.

- **The byte-identical claim is tested, not assumed.** `test_toss_from_windup_matches_split_controllers` runs windup-then-toss twice from seed 125, once split and once composed, and every action pair is `np.array_equal`. This holds because both sub-controllers' `terminated()` is a step counter over a precomputed profile rather than a state test, so moving the boundary between them inside one controller changes nothing about when either stops.
- **The world-frame rewrite is a robustness change, not a bug fix.** Measured over 500 draws: bin yaw is exactly 0.0, so the off-axis figures agree with the old proxy to 1.7e-18, and the standoff differs by at most 1.4e-4 (`d·cos(rot)` against `d`). Both assertions pass either way today; the point is that they keep their meaning if `bin_init_region` ever stops pinning the yaw.
- **The sampled standoff was not merely imprecise — it made the domain unplannable.** An earlier revision reused `MOVE_TO_TARGET_DISTANCE_BOUNDS = (0.5, 0.6)`, the *grasping* range, while `NearBin` admits only `(1.20, 1.65)`. Disjoint intervals, so no draw could ever satisfy it. Measured downstream in #92: `pick` refined in 67 actions, then every `move_to_throw_pose` attempt put the base **0.52 m** from the bin and failed. `NearBin`'s axis conjunct bit too — `target_rot` drawn from `(-pi/4, pi/4)` left roughly **4/100** draws admissible even once the standoff was right. Both fixed here; sampled off-axis offsets now peak at 0.0197 against a `NEAR_BIN_TOL` of 0.08.
- **The shared-sim leak check now has a valid baseline.** It counts connected PyBullet clients *before* the shared run rather than after the previous one — the old placement could absorb a client the previous run leaked into the baseline and compare it against itself — and calls `gc.collect()` before both counts, since the disconnect is a `weakref.finalize` (#87, now on `main`) that only fires when the sim is collected.

## Recommendation

Merge after review. One question remains: `move_to_throw_pose` is given no `params_space`, matching `move_to_target` in the same factory rather than `pick_shelf` in `shelf`'s. If bilevel planning needs a `Box` there it is a one-line addition — but the trajectory sampler in use calls `sample_parameters`, not `params_space`, so nothing depends on it today.
