### PR TITLE
Tossing3D: an oracle policy that selects the new throw controllers from state

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
@@ -17,12 +17,12 @@ is a value this repository already publishes:
   and the arm configurations for the toss are that test's own two confs, already module
   constants in parameterized_skills.
 
-Note that the standoff is passed explicitly and is deliberately outside
-MOVE_TO_TARGET_DISTANCE_BOUNDS, which MoveToThrowPoseController samples from. Those
-bounds are the grasping range; nothing constrains a caller-supplied parameter to them.
-1.35 m is the standoff test_pick_ground_toss drives to, and the test beside this module
-is what shows it lands the cube in the goal region -- that test prints the landing
-position without checking the goal.
+Note that the standoff is passed explicitly rather than sampled. It sits inside
+TOSS_TARGET_DISTANCE_BOUNDS, the range MoveToThrowPoseController draws from, but nothing
+constrains a caller-supplied parameter to that range either way. 1.35 m is the standoff
+test_pick_ground_toss drives to, and the test beside this module is what shows it lands
+the cube in the goal region -- that test prints the landing position without checking
+the goal.
 
 There is no other scripted policy in the monorepo to follow, so the shape here is the
 smallest one that keeps the existing test idiom intact: this class only *chooses* the

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
@@ -1,0 +1,146 @@
+"""A privileged solver for Tossing3D: pick the cube, drive to a throw pose, toss.
+
+The policy is a three-way branch on the abstract state, because the domain admits
+exactly one plan shape. What makes it an oracle rather than a fixed script is the
+continuous parameters -- the part a learner would have to find -- and every one of them
+is a value this repository already publishes:
+
+- ORACLE_PICK_DISTANCE and ORACLE_PICK_ROTATION are the pair that
+  PickShelfController.sample_parameters draws from np.random.default_rng(123), the rng
+  test_pick_ground_toss constructs to parameterize this exact grasp. With one cube in
+  the scene the sampler's rejection loop has nothing to reject against, so its first
+  draw is accepted. They are written out as literals because the linter bans np.random
+  in package code, and test_oracle_pick_parameters_match_the_sampler pins them against
+  the sampler itself.
+- ORACLE_THROW_STANDOFF is test_pick_ground_toss's own target_distance for the drive,
+  and the arm configurations for the toss are that test's own two confs, already module
+  constants in parameterized_skills.
+
+Note that the standoff is passed explicitly and is deliberately outside
+MOVE_TO_TARGET_DISTANCE_BOUNDS, which MoveToThrowPoseController samples from. Those
+bounds are the grasping range; nothing constrains a caller-supplied parameter to them,
+and 1.35 m is the only standoff in this repository demonstrated to land a cube in the
+goal region.
+
+There is no other scripted policy in the monorepo to follow, so the shape here is the
+smallest one that keeps the existing test idiom intact: this class only *chooses* the
+next ground controller and its parameters, and the caller runs the same step/observe/
+terminated loop the parameterized-skill tests already run. Nothing here steps the
+environment.
+"""
+
+from typing import Any
+
+import numpy as np
+from bilevel_planning.structs import GroundParameterizedController
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoMovableObjectType,
+    MujocoTidyBotRobotObjectType,
+)
+from numpy.typing import NDArray
+from relational_structs import GroundAtom, Object, ObjectCentricState
+
+from kinder_models.dynamic3d.shelf.parameterized_skills import (
+    create_lifted_controllers as shelf_create_lifted_controllers,
+)
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    TOSS_RELEASE_ARM_CONF,
+    TOSS_WINDUP_ARM_CONF,
+    create_lifted_controllers,
+)
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    BIN_NAME_PREFIX,
+    CUBE_NAME_PREFIX,
+    Holding,
+    NearBin,
+    Tossing3DStateAbstractor,
+)
+from kinder_models.dynamic3d.utils import PyBulletSim
+
+# The grasp, as drawn by PickShelfController's own sampler; see the module docstring.
+ORACLE_PICK_DISTANCE = 0.5682351863248143
+ORACLE_PICK_ROTATION = -0.7008563047585579
+
+# The base pose to throw from, relative to the bin.
+ORACLE_THROW_STANDOFF = 1.35
+ORACLE_THROW_ROTATION = 0.0
+
+
+class Tossing3DOraclePolicy:
+    """Chooses the next ground controller and its parameters from the state alone."""
+
+    def __init__(
+        self,
+        sim: ObjectCentricTidyBot3DEnv,
+        action_space: Any,
+        pybullet_sim: PyBulletSim | None = None,
+        throw_standoff: float = ORACLE_THROW_STANDOFF,
+    ) -> None:
+        """Initialize the oracle policy.
+
+        The pick comes from the shelf package: Tossing3D has no pick controller of its
+        own, which is why the two pick-and-toss tests reach into shelf for it too.
+        """
+        self._abstractor = Tossing3DStateAbstractor(sim)
+        self._controllers = create_lifted_controllers(
+            action_space, pybullet_sim=pybullet_sim
+        )
+        self._shelf_controllers = shelf_create_lifted_controllers(action_space)
+        self._throw_standoff = throw_standoff
+
+    def get_next_controller(
+        self, state: ObjectCentricState
+    ) -> tuple[str, GroundParameterizedController, NDArray[np.float64]] | None:
+        """The next controller to run, its objects already ground, and its parameters.
+
+        Returns None once the goal holds, which is the only terminal condition: a missed
+        toss leaves the cube on the far side of the barrier, where the policy asks for
+        the pick again and that grasp fails to plan. There is deliberately no recovery
+        branch, because the domain admits no recovery, and a fallback skill would hide
+        the irreversibility the environment exists to exhibit.
+        """
+        if self._abstractor.goal_deriver(state).check_state(state):
+            return None
+
+        robot = self._get_robot(state)
+        cube = self._get_movable_by_prefix(state, CUBE_NAME_PREFIX)
+        target_bin = self._get_movable_by_prefix(state, BIN_NAME_PREFIX)
+
+        atoms = self._abstractor.state_abstractor(state).atoms
+        holding = GroundAtom(Holding, [robot, cube]) in atoms
+        near_bin = GroundAtom(NearBin, [robot, target_bin]) in atoms
+
+        if holding and near_bin:
+            name = "toss_from_windup"
+            lifted = self._controllers[name]
+            objects: tuple[Object, ...] = (robot,)
+            params = np.array([TOSS_WINDUP_ARM_CONF, TOSS_RELEASE_ARM_CONF])
+        elif holding:
+            name = "move_to_throw_pose"
+            lifted = self._controllers[name]
+            objects = (robot, target_bin, cube)
+            params = np.array([self._throw_standoff, ORACLE_THROW_ROTATION])
+        else:
+            name = "pick_shelf"
+            lifted = self._shelf_controllers[name]
+            objects = (robot, cube)
+            params = np.array([ORACLE_PICK_DISTANCE, ORACLE_PICK_ROTATION])
+
+        return name, lifted.ground(objects), params
+
+    @staticmethod
+    def _get_robot(state: ObjectCentricState) -> Object:
+        robots = state.get_objects(MujocoTidyBotRobotObjectType)
+        assert len(robots) == 1, f"Expected 1 robot, got {len(robots)}"
+        return robots[0]
+
+    @staticmethod
+    def _get_movable_by_prefix(state: ObjectCentricState, prefix: str) -> Object:
+        matches = [
+            obj
+            for obj in state.get_objects(MujocoMovableObjectType)
+            if obj.name.startswith(prefix)
+        ]
+        assert len(matches) == 1, f"Expected 1 {prefix}, got {len(matches)}"
+        return matches[0]

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
@@ -9,24 +9,29 @@ is a value this repository already publishes:
   PickShelfController.sample_parameters draws from np.random.default_rng(123), the rng
   test_pick_ground_toss constructs to parameterize this exact grasp. With one cube in
   the scene the sampler's rejection loop has nothing to reject against, so its first
-  draw is accepted. They are written out as literals because the linter bans np.random
-  in package code, and test_oracle_pick_parameters_match_the_sampler pins them against
-  the sampler itself.
+  draw is accepted -- so the two numbers do not depend on the seed or on the scene at
+  all. They are literals rather than a draw made here so that the oracle is
+  reproducible without carrying an rng, and
+  test_oracle_pick_parameters_match_the_sampler pins them against the sampler itself.
 - ORACLE_THROW_STANDOFF is test_pick_ground_toss's own target_distance for the drive,
   and the arm configurations for the toss are that test's own two confs, already module
   constants in parameterized_skills.
 
 Note that the standoff is passed explicitly and is deliberately outside
 MOVE_TO_TARGET_DISTANCE_BOUNDS, which MoveToThrowPoseController samples from. Those
-bounds are the grasping range; nothing constrains a caller-supplied parameter to them,
-and 1.35 m is the only standoff in this repository demonstrated to land a cube in the
-goal region.
+bounds are the grasping range; nothing constrains a caller-supplied parameter to them.
+1.35 m is the standoff test_pick_ground_toss drives to, and the test beside this module
+is what shows it lands the cube in the goal region -- that test prints the landing
+position without checking the goal.
 
 There is no other scripted policy in the monorepo to follow, so the shape here is the
 smallest one that keeps the existing test idiom intact: this class only *chooses* the
 next ground controller and its parameters, and the caller runs the same step/observe/
 terminated loop the parameterized-skill tests already run. Nothing here steps the
-environment.
+environment, though constructing one does reset it -- see __init__.
+
+The policy is written for the one-cube variant, Tossing3D-o1: with more cubes there is a
+choice of which to throw and which order to throw them in, and this makes neither.
 """
 
 from typing import Any
@@ -41,9 +46,7 @@ from kinder.envs.dynamic3d.object_types import (
 from numpy.typing import NDArray
 from relational_structs import GroundAtom, Object, ObjectCentricState
 
-from kinder_models.dynamic3d.shelf.parameterized_skills import (
-    create_lifted_controllers as shelf_create_lifted_controllers,
-)
+from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     TOSS_RELEASE_ARM_CONF,
     TOSS_WINDUP_ARM_CONF,
@@ -68,7 +71,12 @@ ORACLE_THROW_ROTATION = 0.0
 
 
 class Tossing3DOraclePolicy:
-    """Chooses the next ground controller and its parameters from the state alone."""
+    """Chooses the next ground controller and its parameters for Tossing3D-o1.
+
+    Reads the abstract state rather than raw features, which also means it inherits
+    Tossing3DStateAbstractor's dependence on the live simulator: InGoalRegion is checked
+    against the environment's own goal region, not against the state argument.
+    """
 
     def __init__(
         self,
@@ -81,12 +89,16 @@ class Tossing3DOraclePolicy:
 
         The pick comes from the shelf package: Tossing3D has no pick controller of its
         own, which is why the two pick-and-toss tests reach into shelf for it too.
+
+        Construct this *before* the episode starts. Tossing3DStateAbstractor resets sim
+        to read its objects, so building a policy mid-episode discards that episode, and
+        it allocates a PyBullet client that lives as long as the policy does.
         """
         self._abstractor = Tossing3DStateAbstractor(sim)
         self._controllers = create_lifted_controllers(
             action_space, pybullet_sim=pybullet_sim
         )
-        self._shelf_controllers = shelf_create_lifted_controllers(action_space)
+        self._shelf_controllers = shelf_skills.create_lifted_controllers(action_space)
         self._throw_standoff = throw_standoff
 
     def get_next_controller(
@@ -94,11 +106,14 @@ class Tossing3DOraclePolicy:
     ) -> tuple[str, GroundParameterizedController, NDArray[np.float64]] | None:
         """The next controller to run, its objects already ground, and its parameters.
 
-        Returns None once the goal holds, which is the only terminal condition: a missed
-        toss leaves the cube on the far side of the barrier, where the policy asks for
-        the pick again and that grasp fails to plan. There is deliberately no recovery
-        branch, because the domain admits no recovery, and a fallback skill would hide
-        the irreversibility the environment exists to exhibit.
+        Returns None once the goal holds, which is the only terminal condition. There is
+        deliberately no recovery branch: a toss that carries the cube past the barrier
+        is unrecoverable -- the base cannot follow it, so the pick will not plan -- and a
+        fallback skill would hide the irreversibility the environment exists to exhibit.
+        A toss that falls short leaves the cube on the near side instead, where Reachable
+        still holds and the policy simply asks for the pick again, so a caller that
+        cannot tolerate an unbounded retry should cap the number of selections. Neither
+        miss is exercised by a test.
         """
         if self._abstractor.goal_deriver(state).check_state(state):
             return None
@@ -137,6 +152,13 @@ class Tossing3DOraclePolicy:
 
     @staticmethod
     def _get_movable_by_prefix(state: ObjectCentricState, prefix: str) -> Object:
+        """Find the one movable whose name starts with prefix.
+
+        The bin, the cube and the barrier are all MujocoMovableObjectType, so they can
+        only be told apart by name, as the state abstractor does. Note how narrowly
+        "cuboid_barrier" misses the "cube" prefix. The assertion is what confines this
+        policy to Tossing3D-o1: with two cubes it fires rather than picking one.
+        """
         matches = [
             obj
             for obj in state.get_objects(MujocoMovableObjectType)

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
@@ -7,11 +7,12 @@ is a value this repository already publishes:
 
 - ORACLE_PICK_DISTANCE and ORACLE_PICK_ROTATION are the pair that
   PickShelfController.sample_parameters draws from np.random.default_rng(123), the rng
-  test_pick_ground_toss constructs to parameterize this exact grasp. With one cube in
-  the scene the sampler's rejection loop has nothing to reject against, so its first
-  draw is accepted -- so the two numbers do not depend on the seed or on the scene at
-  all. They are literals rather than a draw made here so that the oracle is
-  reproducible without carrying an rng, and
+  test_pick_ground_toss constructs to parameterize this exact grasp. The rejection loop
+  rejects a draw only when the base pose it implies lands within 0.6 m of a *different*
+  cube, so with one cube in the scene the first draw is always accepted and the pair is
+  a function of the seed alone -- it does not depend on the cube's pose. They are
+  literals rather than a draw made here so that the oracle is reproducible without
+  carrying an rng, and
   test_oracle_pick_parameters_match_the_sampler pins them against the sampler itself.
 - ORACLE_THROW_STANDOFF is test_pick_ground_toss's own target_distance for the drive,
   and the arm configurations for the toss are that test's own two confs, already module
@@ -24,17 +25,18 @@ test_pick_ground_toss drives to, and the test beside this module is what shows i
 the cube in the goal region -- that test prints the landing position without checking
 the goal.
 
-There is no other scripted policy in the monorepo to follow, so the shape here is the
-smallest one that keeps the existing test idiom intact: this class only *chooses* the
-next ground controller and its parameters, and the caller runs the same step/observe/
-terminated loop the parameterized-skill tests already run. Nothing here steps the
-environment, though constructing one does reset it -- see __init__.
+The one precedent in the monorepo is kinder-ds-policies, whose Transport3DScriptedPolicy
+(policies/kinematic3d/transport3d.py) drives the same kind of parameterized skills. It
+is a different interface, not a different implementation of this one: a StatefulPolicy
+maps a vectorized observation straight to an action and owns the step/observe/terminated
+bookkeeping internally, whereas this class only *chooses* the next ground controller and
+its parameters and leaves that loop to the caller -- the same loop the parameterized-
+skill tests already run. Nothing here steps the environment, though constructing one
+does reset it -- see __init__.
 
 The policy is written for the one-cube variant, Tossing3D-o1: with more cubes there is a
 choice of which to throw and which order to throw them in, and this makes neither.
 """
-
-from typing import Any
 
 import numpy as np
 from bilevel_planning.structs import GroundParameterizedController
@@ -43,8 +45,9 @@ from kinder.envs.dynamic3d.object_types import (
     MujocoMovableObjectType,
     MujocoTidyBotRobotObjectType,
 )
+from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionSpace
 from numpy.typing import NDArray
-from relational_structs import GroundAtom, Object, ObjectCentricState
+from relational_structs import Array, GroundAtom, Object, ObjectCentricState
 
 from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
@@ -69,11 +72,19 @@ ORACLE_PICK_ROTATION = -0.7008563047585579
 ORACLE_THROW_STANDOFF = 1.35
 ORACLE_THROW_ROTATION = 0.0
 
+# The name of the chosen controller, the controller already ground on its objects, and
+# the continuous parameters to reset it with. Named because the full form does not fit
+# in 88 columns.
+_ControllerSelection = tuple[
+    str, GroundParameterizedController[ObjectCentricState, Array], NDArray[np.float64]
+]
+
 
 class Tossing3DOraclePolicy:
     """Chooses the next ground controller and its parameters for Tossing3D-o1.
 
-    Reads the abstract state rather than raw features, which also means it inherits
+    Branches on the abstract state rather than on raw features -- it still reads the
+    state directly to find its objects -- which means it inherits
     Tossing3DStateAbstractor's dependence on the live simulator: InGoalRegion is checked
     against the environment's own goal region, not against the state argument.
     """
@@ -81,7 +92,7 @@ class Tossing3DOraclePolicy:
     def __init__(
         self,
         sim: ObjectCentricTidyBot3DEnv,
-        action_space: Any,
+        action_space: TidyBot3DRobotActionSpace,
         pybullet_sim: PyBulletSim | None = None,
         throw_standoff: float = ORACLE_THROW_STANDOFF,
     ) -> None:
@@ -93,6 +104,11 @@ class Tossing3DOraclePolicy:
         Construct this *before* the episode starts. Tossing3DStateAbstractor resets sim
         to read its objects, so building a policy mid-episode discards that episode, and
         it allocates a PyBullet client that lives as long as the policy does.
+
+        pybullet_sim is deliberately not forwarded to the shelf factory, which accepts
+        the same keyword. PickShelfController.reset writes base_link_to_held_obj onto
+        the sim it plans in, so sharing one across the pick and the toss would be a
+        behaviour change rather than only an allocation saving.
         """
         self._abstractor = Tossing3DStateAbstractor(sim)
         self._controllers = create_lifted_controllers(
@@ -103,17 +119,20 @@ class Tossing3DOraclePolicy:
 
     def get_next_controller(
         self, state: ObjectCentricState
-    ) -> tuple[str, GroundParameterizedController, NDArray[np.float64]] | None:
+    ) -> _ControllerSelection | None:
         """The next controller to run, its objects already ground, and its parameters.
 
         Returns None once the goal holds, which is the only terminal condition. There is
-        deliberately no recovery branch: a toss that carries the cube past the barrier
-        is unrecoverable -- the base cannot follow it, so the pick will not plan -- and a
-        fallback skill would hide the irreversibility the environment exists to exhibit.
-        A toss that falls short leaves the cube on the near side instead, where Reachable
-        still holds and the policy simply asks for the pick again, so a caller that
-        cannot tolerate an unbounded retry should cap the number of selections. Neither
-        miss is exercised by a test.
+        deliberately no recovery branch: a toss that carries the cube past the barrier is
+        unrecoverable, and a fallback skill would hide the irreversibility the
+        environment exists to exhibit. Note what that costs: this never reads Reachable,
+        the predicate state_abstractions added to make that irreversibility expressible,
+        so it still selects pick_shelf for a cube it cannot reach, and
+        PickShelfController.reset then fails its `assert base_motion_plan is not None`.
+        The caller sees an AssertionError, not a signal it can act on. A toss that falls
+        short leaves the cube on the near side instead, where the policy simply asks for
+        the pick again, so a caller that cannot tolerate an unbounded retry should cap
+        the number of selections. Neither miss is exercised by a test.
         """
         if self._abstractor.goal_deriver(state).check_state(state):
             return None

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/oracle_policy.py
@@ -25,14 +25,34 @@ test_pick_ground_toss drives to, and the test beside this module is what shows i
 the cube in the goal region -- that test prints the landing position without checking
 the goal.
 
-The one precedent in the monorepo is kinder-ds-policies, whose Transport3DScriptedPolicy
-(policies/kinematic3d/transport3d.py) drives the same kind of parameterized skills. It
-is a different interface, not a different implementation of this one: a StatefulPolicy
-maps a vectorized observation straight to an action and owns the step/observe/terminated
-bookkeeping internally, whereas this class only *chooses* the next ground controller and
-its parameters and leaves that loop to the caller -- the same loop the parameterized-
-skill tests already run. Nothing here steps the environment, though constructing one
-does reset it -- see __init__.
+This module lives here and not in kinder-ds-policies, which is the package for
+hand-written policies over these skills and holds the one precedent,
+Transport3DScriptedPolicy (policies/kinematic3d/transport3d.py). That was considered and
+rejected on the interface, which this class cannot satisfy without being rewritten into
+a different class:
+
+- StatefulPolicy (policies/base.py) declares exactly two abstract methods, reset() and
+  __call__(observation: NDArray[float32]) -> NDArray[float32]. This class implements
+  neither. It takes an ObjectCentricState, not a vectorized observation, and returns a
+  (name, ground controller, parameters) triple, not an action -- it *chooses* the next
+  skill and leaves the step/observe/terminated loop to the caller, which is the loop the
+  parameterized-skill tests already run.
+- The loader (policies/__init__.py) discovers a policy by filename, probing
+  <subdir>/{env_name}.py, and requires the module to define
+  create_domain_specific_policy at module scope. Neither this filename nor this module
+  qualifies.
+- experiments/collect_demos_ds.py constructs a policy with observation_space= and
+  action_space= alone. This class needs the ObjectCentricTidyBot3DEnv itself, which that
+  script never has -- the test reaches it through env.unwrapped._object_centric_env.
+- Nothing in that package bridges a selector to an action stream. The ground-reset-and-
+  pump loop exists only inlined in Transport3DScriptedPolicy.__call__, and it indexes a
+  fixed sequence built once up front, whereas this class re-derives its choice from the
+  abstract state on every call.
+
+Moving it would therefore mean adding reset() and __call__, inlining that pumping loop,
+and having the factory build its own simulator -- a StatefulPolicy wrapping this one,
+which is a thing to write when a demo-collection run needs it, not a relocation. Nothing
+here steps the environment, though constructing one does reset it -- see __init__.
 
 The policy is written for the one-cube variant, Tossing3D-o1: with more cubes there is a
 choice of which to throw and which order to throw them in, and this makes neither.

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
@@ -1,0 +1,63 @@
+"""Tests for the tossing oracle policy."""
+
+import kinder
+from conftest import MAKE_VIDEOS  # pylint: disable=import-error
+from gymnasium.wrappers import RecordVideo
+from relational_structs import ObjectCentricState
+
+from kinder_models.dynamic3d.tossing.oracle_policy import Tossing3DOraclePolicy
+
+kinder.register_all_environments()
+
+
+def test_tossing3d_oracle_policy():
+    """The oracle solves Tossing3D-o1 end to end.
+
+    Three controllers, chosen from the abstract state alone, put the cube in the goal
+    region -- which is the environment's own success criterion, so this asserts
+    _check_goals() rather than a hand-written box test.
+    """
+
+    # Create the environment.
+    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", scene_bg=False)
+    if MAKE_VIDEOS:
+        env.unwrapped._object_centric_env.set_render_camera(  # type: ignore # pylint: disable=protected-access
+            "task_view"
+        )
+        env = RecordVideo(env, "unit_test_videos", name_prefix="Tossing3D-oracle")
+    sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
+
+    # The policy builds its own abstractor and controllers from the environment.
+    policy = Tossing3DOraclePolicy(sim, env.action_space)
+
+    obs, _ = env.reset(seed=125)
+    state = env.observation_space.devectorize(obs)
+    assert isinstance(state, ObjectCentricState)
+    assert not sim._check_goals()  # pylint: disable=protected-access
+
+    # Run whatever the oracle asks for until it says the goal is reached. The bound is
+    # the plan length the domain admits (pick, drive, toss) and not a search budget:
+    # exceeding it means the oracle re-selected a controller, which is a failure.
+    executed = []
+    for _ in range(3):
+        selection = policy.get_next_controller(state)
+        if selection is None:
+            break
+        name, controller, params = selection
+        executed.append(name)
+        controller.reset(state, params)
+        for _ in range(400):
+            action = controller.step()
+            obs, _, _, _, _ = env.step(action)
+            state = env.observation_space.devectorize(obs)
+            controller.observe(state)
+            if controller.terminated():
+                break
+        else:
+            assert False, f"Controller {name} did not terminate"
+
+    assert executed == ["pick_shelf", "move_to_throw_pose", "toss_from_windup"]
+    assert sim._check_goals()  # pylint: disable=protected-access
+    assert policy.get_next_controller(state) is None
+
+    env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
@@ -28,7 +28,6 @@ def test_tossing3d_oracle_policy():
     region -- which is the environment's own success criterion, so this asserts
     _check_goals() rather than a hand-written box test.
     """
-
     # Create the environment.
     env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", scene_bg=False)
     if MAKE_VIDEOS:
@@ -46,9 +45,10 @@ def test_tossing3d_oracle_policy():
     assert isinstance(state, ObjectCentricState)
     assert not sim._check_goals()  # pylint: disable=protected-access
 
-    # Run whatever the oracle asks for until it says the goal is reached. The bound is
-    # the plan length the domain admits (pick, drive, toss) and not a search budget:
-    # exceeding it means the oracle re-selected a controller, which is a failure.
+    # Run whatever the oracle asks for. The bound is the plan length the domain admits
+    # (pick, drive, toss); a policy that re-selected a controller would be caught by the
+    # executed-sequence assertion and by the final get_next_controller() call, not by
+    # this loop, which merely stops.
     executed = []
     for _ in range(3):
         selection = policy.get_next_controller(state)
@@ -76,7 +76,7 @@ def test_tossing3d_oracle_policy():
     # parameter is not a sampled one, and this pins that: the base really did stop at
     # the requested standoff rather than at a clamped 0.5-0.6 m. The base does not move
     # again after the drive, so the final state carries the same pose.
-    robot = policy._get_robot(state)  # pylint: disable=protected-access
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
     target_bin = state.get_object_from_name("bin_0")
     standoff = np.hypot(
         state.get(target_bin, "x") - state.get(robot, "pos_base_x"),
@@ -90,8 +90,8 @@ def test_tossing3d_oracle_policy():
 def test_oracle_pick_parameters_match_the_sampler():
     """The oracle's grasp literals are PickShelfController's own rng-123 draw.
 
-    They are literals in the package because the linter bans np.random there, so
-    nothing in the package itself can show where they came from. This does.
+    The package states their provenance in a docstring and cannot check it, since it
+    holds them as constants rather than drawing them. This checks it.
     """
     env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", scene_bg=False)
     obs, _ = env.reset(seed=125)

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
@@ -4,9 +4,15 @@ import kinder
 import numpy as np
 from conftest import MAKE_VIDEOS  # pylint: disable=import-error
 from gymnasium.wrappers import RecordVideo
+from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
 from relational_structs import ObjectCentricState
 
+from kinder_models.dynamic3d.shelf.parameterized_skills import (
+    create_lifted_controllers as shelf_create_lifted_controllers,
+)
 from kinder_models.dynamic3d.tossing.oracle_policy import (
+    ORACLE_PICK_DISTANCE,
+    ORACLE_PICK_ROTATION,
     ORACLE_THROW_STANDOFF,
     Tossing3DOraclePolicy,
 )
@@ -77,5 +83,27 @@ def test_tossing3d_oracle_policy():
         state.get(target_bin, "y") - state.get(robot, "pos_base_y"),
     )
     assert abs(standoff - ORACLE_THROW_STANDOFF) < WAYPOINT_TOL
+
+    env.close()
+
+
+def test_oracle_pick_parameters_match_the_sampler():
+    """The oracle's grasp literals are PickShelfController's own rng-123 draw.
+
+    They are literals in the package because the linter bans np.random there, so
+    nothing in the package itself can show where they came from. This does.
+    """
+    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", scene_bg=False)
+    obs, _ = env.reset(seed=125)
+    state = env.observation_space.devectorize(obs)
+    assert isinstance(state, ObjectCentricState)
+
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    controllers = shelf_create_lifted_controllers(env.action_space)
+    controller = controllers["pick_shelf"].ground((robot, cube))
+
+    params = controller.sample_parameters(state, np.random.default_rng(123))
+    assert np.allclose(params, [ORACLE_PICK_DISTANCE, ORACLE_PICK_ROTATION])
 
     env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
@@ -1,11 +1,16 @@
 """Tests for the tossing oracle policy."""
 
 import kinder
+import numpy as np
 from conftest import MAKE_VIDEOS  # pylint: disable=import-error
 from gymnasium.wrappers import RecordVideo
 from relational_structs import ObjectCentricState
 
-from kinder_models.dynamic3d.tossing.oracle_policy import Tossing3DOraclePolicy
+from kinder_models.dynamic3d.tossing.oracle_policy import (
+    ORACLE_THROW_STANDOFF,
+    Tossing3DOraclePolicy,
+)
+from kinder_models.dynamic3d.utils import WAYPOINT_TOL
 
 kinder.register_all_environments()
 
@@ -59,5 +64,18 @@ def test_tossing3d_oracle_policy():
     assert executed == ["pick_shelf", "move_to_throw_pose", "toss_from_windup"]
     assert sim._check_goals()  # pylint: disable=protected-access
     assert policy.get_next_controller(state) is None
+
+    # The oracle hands move_to_throw_pose an explicit 1.35 m standoff, which is outside
+    # the MOVE_TO_TARGET_DISTANCE_BOUNDS that controller *samples* from. A supplied
+    # parameter is not a sampled one, and this pins that: the base really did stop at
+    # the requested standoff rather than at a clamped 0.5-0.6 m. The base does not move
+    # again after the drive, so the final state carries the same pose.
+    robot = policy._get_robot(state)  # pylint: disable=protected-access
+    target_bin = state.get_object_from_name("bin_0")
+    standoff = np.hypot(
+        state.get(target_bin, "x") - state.get(robot, "pos_base_x"),
+        state.get(target_bin, "y") - state.get(robot, "pos_base_y"),
+    )
+    assert abs(standoff - ORACLE_THROW_STANDOFF) < WAYPOINT_TOL
 
     env.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_oracle_policy.py
@@ -7,9 +7,7 @@ from gymnasium.wrappers import RecordVideo
 from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
 from relational_structs import ObjectCentricState
 
-from kinder_models.dynamic3d.shelf.parameterized_skills import (
-    create_lifted_controllers as shelf_create_lifted_controllers,
-)
+from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
 from kinder_models.dynamic3d.tossing.oracle_policy import (
     ORACLE_PICK_DISTANCE,
     ORACLE_PICK_ROTATION,
@@ -68,14 +66,19 @@ def test_tossing3d_oracle_policy():
             assert False, f"Controller {name} did not terminate"
 
     assert executed == ["pick_shelf", "move_to_throw_pose", "toss_from_windup"]
+    # The cube is already down when the toss controller terminates: release happens at
+    # 0.46 of the swing profile, leaving over half of it -- longer than the flight -- to
+    # run before terminated() is True. No settling loop is needed, but if the profile or
+    # the release fraction is retuned, this is the assertion that will start failing.
     assert sim._check_goals()  # pylint: disable=protected-access
     assert policy.get_next_controller(state) is None
 
-    # The oracle hands move_to_throw_pose an explicit 1.35 m standoff, which is outside
-    # the MOVE_TO_TARGET_DISTANCE_BOUNDS that controller *samples* from. A supplied
-    # parameter is not a sampled one, and this pins that: the base really did stop at
-    # the requested standoff rather than at a clamped 0.5-0.6 m. The base does not move
-    # again after the drive, so the final state carries the same pose.
+    # The oracle hands move_to_throw_pose an explicit 1.35 m standoff rather than
+    # letting it sample one from TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45). Nothing
+    # clamps or re-samples a supplied parameter, and this pins that: the base really did
+    # stop at the requested standoff, not merely somewhere inside the sampler's range.
+    # The base does not move again after the drive, so the final state carries the same
+    # pose.
     robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
     target_bin = state.get_object_from_name("bin_0")
     standoff = np.hypot(
@@ -93,14 +96,14 @@ def test_oracle_pick_parameters_match_the_sampler():
     The package states their provenance in a docstring and cannot check it, since it
     holds them as constants rather than drawing them. This checks it.
     """
-    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", scene_bg=False)
+    env = kinder.make("kinder/Tossing3D-o1-v0", scene_bg=False)
     obs, _ = env.reset(seed=125)
     state = env.observation_space.devectorize(obs)
     assert isinstance(state, ObjectCentricState)
 
     robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
     cube = state.get_object_from_name("cube_0")
-    controllers = shelf_create_lifted_controllers(env.action_space)
+    controllers = shelf_skills.create_lifted_controllers(env.action_space)
     controller = controllers["pick_shelf"].ground((robot, cube))
 
     params = controller.sample_parameters(state, np.random.default_rng(123))


### PR DESCRIPTION
**TL;DR** Adds `dynamic3d/tossing/oracle_policy.py`: a privileged solver that picks the next ground controller for `Tossing3D` from the abstract state alone — pick, drive to a throw pose, toss — plus an end-to-end test asserting the environment's own `_check_goals()`. First consumer of #90's controllers, so it is also integration evidence for them. Nothing existing is modified. Suite **19/19** locally.

## Question / goal

Is there a parameterisation, drawn only from values this repository already publishes, under which the new `move_to_throw_pose` and `toss_from_windup` controllers solve `Tossing3D` end to end when selected from state rather than hardcoded in sequence?

## Background

`test_pick_ground_toss` already solves this domain, but as a flat script: it grounds four controllers in a fixed order and supplies their parameters inline. Nothing selects a controller from the state, so nothing exercises the abstract state (#89) and the two new controllers (#90) together, and there is no reusable solver a learner could be scored against.

Every continuous parameter is a value upstream publishes rather than one invented here:

- `ORACLE_PICK_DISTANCE` / `ORACLE_PICK_ROTATION` — the pair `PickShelfController.sample_parameters` draws from `np.random.default_rng(123)`, the rng `test_pick_ground_toss` constructs for this exact grasp. Written as literals because the linter bans `np.random` in package code.
- `ORACLE_THROW_STANDOFF = 1.35` — that same test's own `target_distance`.
- The two arm configurations — `TOSS_WINDUP_ARM_CONF` / `TOSS_RELEASE_ARM_CONF`, already module constants from #90.

## Hypothesis

None — implementation task, not an experiment.

## Guidance given

Drive the *new* lifted controllers rather than the raw ones, so the PR doubles as integration evidence for #90. Verify rather than assume that the explicit 1.35 m standoff survives `move_to_throw_pose`, whose sampler draws its own. And decide, from the codebase's own conventions rather than taste, whether this module belongs here or in `kinder-ds-policies`.

## Methods

`Tossing3DOraclePolicy(sim, action_space, pybullet_sim=None, throw_standoff=1.35)` builds a `Tossing3DStateAbstractor` and both controller factories (the pick comes from `shelf`, as the two pick-and-toss tests already do). `get_next_controller(state)` returns `None` when the derived goal holds, and otherwise branches on two atoms: `Holding ∧ NearBin → toss_from_windup`, `Holding → move_to_throw_pose`, else `pick_shelf`. There is no recovery branch — after a missed toss the cube is behind the barrier, the policy asks for the pick again, and that grasp fails to plan. That is the domain's irreversibility, and a fallback skill would hide it.

The class only *chooses*: it returns `(name, ground_controller, params)` and never steps the environment, so the caller runs the same `step`/`observe`/`terminated` loop the existing skill tests already run.

The test runs at most 3 selections on seed 125, asserts the executed sequence, asserts `sim._check_goals()`, asserts the policy then returns `None`, and asserts the final base-to-bin distance.

## Results

**19/19** in `tests/dynamic3d/tossing/` locally, ~33 s, against a real simulator.

- The executed sequence is exactly `pick_shelf → move_to_throw_pose → toss_from_windup`, chosen from the abstract state, and the cube ends in `blocks_goal_region`.
- **The explicit 1.35 m standoff is not clamped.** The final base-to-bin distance is within `WAYPOINT_TOL` of 1.35, not a sampled value — sampling bounds constrain `sample_parameters`, not a supplied parameter. Now pinned by an assertion rather than inferred from the throw succeeding.
- The grasp literals are pinned against the sampler itself: `PickShelfController.sample_parameters(state, np.random.default_rng(123))` returns them to `np.allclose`, so the two magic numbers are checkable rather than asserted.
- black / isort / docformatter / mypy clean, pylint 10.00/10.

> **TODO (drag-and-drop):** the clip is regenerated and ready — drop
> http://127.0.0.1:8765/tossing3d-oracle-policy.gif in here.
>
> **What it shows:** the oracle solving `Tossing3D-o1` end to end, choosing every controller from the abstract state alone — `pick_shelf` → `move_to_throw_pose` → `toss_from_windup`. The base stops at a measured 1.3510 m from the bin, i.e. the explicit `ORACLE_THROW_STANDOFF` of 1.35 it was handed rather than a clamped sample; the cube comes to rest at x = 1.9902 inside the shaded `blocks_goal_region`, and `_check_goals()` is `True`. Produced by this PR's own test via `pytest --make-videos` (**1/1** passing), 128 simulator steps at the environment's own 20 fps.
>
> **Caveat, and it is the same one as the CI note below:** the clip was rendered against `kindergarden` #126, so the bin sits at x = 2.0 and its measured footprint, x in [1.8501, 2.1501], coincides with the shaded goal region, x in [1.8500, 2.1500]. A reviewer running this against `kindergarden` `main` — bin at x = 2.23, outside the goal region — will watch the same throw and see `_check_goals()` return `False`.
>
> Rendering settings only, nothing that touches physics, seeds or assertions: the `task_view` camera the test already selects, the MimicLabs lab background instead of the bare `simple` ground plane, and `blocks_goal_region` shaded blue because it ships at alpha `0` and the clip is about where that region is.

**Placement decided: this stays in `kinder_models`, and the module docstring now says why**, so the question is not reopened. `kinder-ds-policies` is the package for hand-written policies over these skills and holds a direct precedent, but the interface is what settles it. `StatefulPolicy` declares exactly two abstract methods, `reset()` and `__call__(observation) -> action`; this class implements neither, taking an `ObjectCentricState` and returning a `(name, ground controller, parameters)` triple. Its loader discovers policies by filename, probing `<subdir>/{env_name}.py`, and requires a module-level `create_domain_specific_policy` — so neither `oracle_policy.py` nor this module qualifies. And `collect_demos_ds.py` constructs a policy from `observation_space=` and `action_space=` alone, while this one needs the `ObjectCentricTidyBot3DEnv` that the test reaches through `env.unwrapped._object_centric_env`. Nothing in that package bridges a selector to an action stream either: the ground-reset-and-pump loop is inlined in `Transport3DScriptedPolicy.__call__` and indexes a fixed sequence built once up front, where this class re-derives its choice every call. Moving it means writing a `StatefulPolicy` that wraps this one — worth doing when a demo-collection run needs it, but that is a new class, not a relocation.

**One caveat: this test will not pass on upstream CI today, and CI is currently red here for exactly that reason.** Every package depends on `kindergarden>=0.1.0`, which resolves to the published 0.2.0 wheel; its `Tossing3D-o1.json` puts `bin_init_region` at x = 2.23 while `blocks_goal_region` inflates to [1.85, 2.15]. Those are disjoint, so the demonstrated throw lands the cube *in the bin* and `_check_goals()` is `False`. Local verification was against kindergarden #126 (https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/126), which moves the bin back inside the region — the same scene defect, surfacing here as a red test rather than as a silently wrong success criterion.

## Recommendation

Merge after #90 and kindergarden #126 (https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/126). Three known gaps, all deliberate: `Tossing3D-o1` only, since with two cubes there is a choice of which to throw and in what order and this policy makes neither; neither miss is exercised, so a caller that cannot tolerate an unbounded retry after a short toss should cap the number of selections; and constructing the policy resets the simulator and allocates a PyBullet client, which is documented on `__init__` but is a wart. One open question for the maintainer: whether `get_next_controller`'s tuple return is the right interface, or whether it should hand back an already-`reset` controller.
