### PR TITLE
Bilevel planning env model for Tossing3D

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -1,0 +1,315 @@
+"""Bilevel planning models for the TidyBot3D Tossing3D environment.
+
+Three things here are unlike the other dynamic3d env models, and each is deliberate.
+
+1. The controllers are *padded* with ignored variables. LiftedSkill requires an
+   operator's parameters to equal its controller's variables, and these operators are
+   wider than the controllers they drive: Pick needs ?barrier to state Reachable and
+   ?bin to delete NearBin, while pick_shelf only drives ?robot and ?target. Padding
+   keeps the symbolic model expressive; weakening the operators instead would gut the
+   Toss add effect, which is the thing the planner plans toward. Upstream's own
+   move_to_target_from_other_target already carries a ?prev_target in that spirit.
+
+2. Ground operators are supplied by name. All three scene objects -- bin_0, cube_0 and
+   cuboid_barrier -- are typed MujocoMovableObjectType, and there are no fixtures in
+   the state, so lifted-operator typing cannot tell a bin from a barrier. sweep3D has
+   the same problem with its wiper and solves it the same way.
+
+3. Two controller factories are called, shelf's for pick_shelf and tossing's for the
+   rest, exactly as the monorepo's own test_pick_ground_toss does. Both are handed the
+   same PyBulletSim: RelationalControllerGenerator grounds a fresh controller per
+   sampling attempt, and each unshared client is a leaked PyBullet connection.
+"""
+
+from pathlib import Path
+from typing import Sequence
+
+import kinder
+import numpy as np
+from bilevel_planning.structs import (
+    LiftedParameterizedController,
+    LiftedSkill,
+    SesameModels,
+)
+from gymnasium.spaces import Space
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoFixtureObjectType,
+    MujocoMovableObjectType,
+    MujocoObjectType,
+    MujocoTidyBotRobotObjectType,
+)
+from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionSpace
+from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    create_lifted_controllers as tossing_create_lifted_controllers,
+)
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    HandEmpty,
+    Holding,
+    InGoalRegion,
+    NearBin,
+    OnGround,
+    Reachable,
+    Tossing3DStateAbstractor,
+)
+from kinder_models.dynamic3d.utils import PyBulletSim
+from numpy.typing import NDArray
+from relational_structs import (
+    GroundOperator,
+    LiftedAtom,
+    LiftedOperator,
+    Object,
+    ObjectCentricState,
+    Variable,
+)
+from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
+
+# The names the scene uses. All three are MujocoMovableObjectType, so these names are
+# the only thing that distinguishes them -- see the module docstring.
+ROBOT_NAME = "robot"
+CUBE_NAME = "cube_0"
+BIN_NAME = "bin_0"
+BARRIER_NAME = "cuboid_barrier"
+
+
+def create_bilevel_planning_models(
+    observation_space: Space,
+    action_space: Space,
+    num_objects: int = 1,
+) -> SesameModels:
+    """Create the env models for TidyBot Tossing3D."""
+    assert isinstance(observation_space, ObjectCentricBoxSpace)
+    assert isinstance(action_space, TidyBot3DRobotActionSpace)
+
+    task_config_path = str(
+        Path(kinder.__file__).parent
+        / "envs/dynamic3d/tasks/Tossing3D"
+        / f"Tossing3D-o{num_objects}.json"
+    )
+    sim = ObjectCentricTidyBot3DEnv(
+        task_config_path=task_config_path,
+        num_objects=num_objects,
+        allow_state_access=True,
+    )
+
+    # State and goal abstractors.
+    abstractor = Tossing3DStateAbstractor(sim)
+    state_abstractor = abstractor.state_abstractor
+    goal_deriver = abstractor.goal_deriver
+
+    # Need to call reset to initialize the qpos, qvel.
+    initial_state, _ = sim.reset()
+
+    # Convert observations into states. The important thing is that states are hashable.
+    def observation_to_state(o: NDArray[np.float32]) -> ObjectCentricState:
+        """Convert the vectors back into (hashable) object-centric states."""
+        return observation_space.devectorize(o)
+
+    # Create the transition function.
+    def transition_fn(
+        x: ObjectCentricState,
+        u: NDArray[np.float32],
+    ) -> ObjectCentricState:
+        """Simulate the action."""
+        state = x.copy()
+        sim.set_state(state)
+        obs, _, _, _, _ = sim.step(u)
+        return obs.copy()
+
+    # Types.
+    types = {
+        MujocoTidyBotRobotObjectType,
+        MujocoObjectType,
+        MujocoFixtureObjectType,
+        MujocoMovableObjectType,
+    }
+
+    # Create the state space.
+    state_space = ObjectCentricStateSpace(types)
+
+    # Predicates.
+    predicates = {
+        Holding,
+        HandEmpty,
+        OnGround,
+        InGoalRegion,
+        Reachable,
+        NearBin,
+    }
+
+    # Pick operator. ?barrier is what Reachable is stated against and ?bin is what
+    # NearBin is deleted against; neither reaches pick_shelf, which drives only the
+    # first two parameters.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    cube = Variable("?cube", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+    bin_obj = Variable("?bin", MujocoMovableObjectType)
+
+    PickOperator = LiftedOperator(
+        "pick",
+        [robot, cube, barrier, bin_obj],
+        preconditions={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [cube]),
+            LiftedAtom(Reachable, [cube, barrier]),
+        },
+        add_effects={
+            LiftedAtom(Holding, [robot, cube]),
+        },
+        delete_effects={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [cube]),
+            # Picking drives the base to a grasping standoff from the cube, which is
+            # not a throw pose, so any previously established NearBin is destroyed.
+            LiftedAtom(NearBin, [robot, bin_obj]),
+        },
+    )
+
+    # Move-to-throw-pose operator.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    bin_obj = Variable("?bin", MujocoMovableObjectType)
+    cube = Variable("?cube", MujocoMovableObjectType)
+
+    MoveToThrowPoseOperator = LiftedOperator(
+        "move_to_throw_pose",
+        [robot, bin_obj, cube],
+        preconditions={
+            LiftedAtom(Holding, [robot, cube]),
+        },
+        add_effects={
+            LiftedAtom(NearBin, [robot, bin_obj]),
+        },
+        delete_effects=set(),
+    )
+
+    # Toss operator. InGoalRegion is the add effect the whole plan exists to achieve.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    cube = Variable("?cube", MujocoMovableObjectType)
+    bin_obj = Variable("?bin", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    TossOperator = LiftedOperator(
+        "toss",
+        [robot, cube, bin_obj, barrier],
+        preconditions={
+            LiftedAtom(Holding, [robot, cube]),
+            LiftedAtom(NearBin, [robot, bin_obj]),
+        },
+        add_effects={
+            LiftedAtom(InGoalRegion, [cube]),
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [cube]),
+        },
+        delete_effects={
+            LiftedAtom(Holding, [robot, cube]),
+            # A tossed cube lands past the barrier, which is what Reachable measures.
+            LiftedAtom(Reachable, [cube, barrier]),
+        },
+    )
+
+    # Create the PyBullet simulator, shared by both controller factories -- see the
+    # module docstring for why sharing matters here specifically.
+    assert initial_state is not None
+    pybullet_sim = PyBulletSim(initial_state, rendering=False)
+    shelf_controllers = shelf_skills.create_lifted_controllers(
+        action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
+    )
+    tossing_controllers = tossing_create_lifted_controllers(
+        action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
+    )
+
+    # Controllers, padded out to their operators' parameters.
+    LiftedPickController = _pad_controller(
+        shelf_controllers["pick_shelf"], PickOperator.parameters
+    )
+    LiftedMoveToThrowPoseController = _pad_controller(
+        tossing_controllers["move_to_throw_pose"], MoveToThrowPoseOperator.parameters
+    )
+    LiftedTossController = _pad_controller(
+        tossing_controllers["toss_from_windup"], TossOperator.parameters
+    )
+
+    # Finalize the skills.
+    skills = {
+        LiftedSkill(PickOperator, LiftedPickController),
+        LiftedSkill(MoveToThrowPoseOperator, LiftedMoveToThrowPoseController),
+        LiftedSkill(TossOperator, LiftedTossController),
+    }
+
+    # Pre-compute ground operators with the known object bindings, because typing
+    # cannot distinguish the bin from the barrier.
+    ground_operators = _create_ground_operators(
+        initial_state, [PickOperator, MoveToThrowPoseOperator, TossOperator]
+    )
+
+    # Finalize the models.
+    return SesameModels(
+        observation_space,
+        state_space,
+        action_space,
+        transition_fn,
+        types,
+        predicates,
+        observation_to_state,
+        state_abstractor,
+        goal_deriver,
+        skills,
+        ground_operators=ground_operators,
+    )
+
+
+def _pad_controller(
+    controller: LiftedParameterizedController,
+    parameters: Sequence[Variable],
+) -> LiftedParameterizedController:
+    """Widen a lifted controller to an operator's parameters.
+
+    The controller's own variables must be a prefix of the operator's parameters; the
+    trailing ones are bound by the operator and dropped before the ground controller is
+    constructed. If the two already agree, the controller is returned unchanged.
+    """
+    num_used = len(controller.variables)
+    assert num_used <= len(parameters)
+    # NOTE: the types are deliberately not asserted equal. move_to_throw_pose's
+    # ?target is MujocoObjectType while the operator's ?bin is MujocoMovableObjectType,
+    # which is the narrower of the two; LiftedParameterizedController.ground asserts
+    # the real is_instance check at grounding time anyway.
+    if num_used == len(parameters):
+        return controller
+
+    controller_cls = controller.controller_cls
+
+    class _PaddedController(controller_cls):  # type: ignore[valid-type, misc]
+        """Drop the operator-only trailing objects before grounding."""
+
+        def __init__(self, objects: Sequence[Object]) -> None:
+            super().__init__(list(objects)[:num_used])
+
+    return LiftedParameterizedController(
+        list(parameters),
+        _PaddedController,
+        params_space=controller.params_space,
+    )
+
+
+def _create_ground_operators(
+    initial_state: ObjectCentricState,
+    operators: list[LiftedOperator],
+) -> set[GroundOperator]:
+    """Ground operators using known object bindings for this environment."""
+    name_to_obj: dict[str, Object] = {obj.name: obj for obj in initial_state}
+    param_to_object_name = {
+        "?robot": ROBOT_NAME,
+        "?cube": CUBE_NAME,
+        "?bin": BIN_NAME,
+        "?barrier": BARRIER_NAME,
+    }
+    ground_ops: set[GroundOperator] = set()
+    for operator in operators:
+        objects = tuple(
+            name_to_obj[param_to_object_name[param.name]]
+            for param in operator.parameters
+        )
+        ground_ops.add(operator.ground(objects))
+    return ground_ops

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -265,18 +265,24 @@ def _pad_controller(
 ) -> LiftedParameterizedController:
     """Widen a lifted controller to an operator's parameters.
 
-    The controller's own variables must be a prefix of the operator's parameters; the
-    trailing ones are bound by the operator and dropped before the ground controller is
-    constructed. If the two already agree, the controller is returned unchanged.
+    The controller's leading variables are the ones that reach it; any trailing
+    operator parameters are bound by the operator and dropped before the ground
+    controller is constructed.
+
+    The returned controller always declares the operator's *own* parameters, even when
+    the arities already match, because LiftedSkill.__post_init__ asserts
+    `tuple(operator.parameters) == tuple(controller.variables)` and Variables compare
+    by name as well as type. move_to_throw_pose is exactly that case: 3 variables
+    against 3 parameters, but named (?robot, ?target, ?held) against
+    (?robot, ?bin, ?cube).
+
+    The types are deliberately not asserted equal either. move_to_throw_pose's ?target
+    is MujocoObjectType while the operator's ?bin is MujocoMovableObjectType, which is
+    the narrower of the two; LiftedParameterizedController.ground makes the real
+    is_instance check at grounding time.
     """
     num_used = len(controller.variables)
     assert num_used <= len(parameters)
-    # NOTE: the types are deliberately not asserted equal. move_to_throw_pose's
-    # ?target is MujocoObjectType while the operator's ?bin is MujocoMovableObjectType,
-    # which is the narrower of the two; LiftedParameterizedController.ground asserts
-    # the real is_instance check at grounding time anyway.
-    if num_used == len(parameters):
-        return controller
 
     controller_cls = controller.controller_cls
 

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -41,9 +41,7 @@ from kinder.envs.dynamic3d.object_types import (
 )
 from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionSpace
 from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
-from kinder_models.dynamic3d.tossing.parameterized_skills import (
-    create_lifted_controllers as tossing_create_lifted_controllers,
-)
+from kinder_models.dynamic3d.tossing import parameterized_skills as tossing_skills
 from kinder_models.dynamic3d.tossing.state_abstractions import (
     HandEmpty,
     Holding,
@@ -215,7 +213,7 @@ def create_bilevel_planning_models(
     shelf_controllers = shelf_skills.create_lifted_controllers(
         action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
     )
-    tossing_controllers = tossing_create_lifted_controllers(
+    tossing_controllers = tossing_skills.create_lifted_controllers(
         action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
     )
 
@@ -265,16 +263,15 @@ def _pad_controller(
 ) -> LiftedParameterizedController:
     """Widen a lifted controller to an operator's parameters.
 
-    The controller's leading variables are the ones that reach it; any trailing
-    operator parameters are bound by the operator and dropped before the ground
-    controller is constructed.
+    The controller's leading variables are the ones that reach it; any trailing operator
+    parameters are bound by the operator and dropped before the ground controller is
+    constructed.
 
     The returned controller always declares the operator's *own* parameters, even when
     the arities already match, because LiftedSkill.__post_init__ asserts
-    `tuple(operator.parameters) == tuple(controller.variables)` and Variables compare
-    by name as well as type. move_to_throw_pose is exactly that case: 3 variables
-    against 3 parameters, but named (?robot, ?target, ?held) against
-    (?robot, ?bin, ?cube).
+    `tuple(operator.parameters) == tuple(controller.variables)` and Variables compare by
+    name as well as type. move_to_throw_pose is exactly that case: 3 variables against 3
+    parameters, but named (?robot, ?target, ?held) against (?robot, ?bin, ?cube).
 
     The types are deliberately not asserted equal either. move_to_throw_pose's ?target
     is MujocoObjectType while the operator's ?bin is MujocoMovableObjectType, which is

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -18,7 +18,9 @@ Three things here are unlike the other dynamic3d env models, and each is deliber
 3. Two controller factories are called, shelf's for pick_shelf and tossing's for the
    rest, exactly as the monorepo's own test_pick_ground_toss does. Both are handed the
    same PyBulletSim: RelationalControllerGenerator grounds a fresh controller per
-   sampling attempt, and each unshared client is a leaked PyBullet connection.
+   sampling attempt, so an unshared sim would connect a PyBullet client and reload the
+   robot on every attempt. Since #87 that client is disconnected on collection rather
+   than leaked -- so this is a per-attempt cost, not a leak, but the cost is real.
 """
 
 from pathlib import Path
@@ -43,6 +45,7 @@ from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionS
 from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
 from kinder_models.dynamic3d.tossing import parameterized_skills as tossing_skills
 from kinder_models.dynamic3d.tossing.state_abstractions import (
+    BARRIER_NAME,
     HandEmpty,
     Holding,
     InGoalRegion,
@@ -64,11 +67,12 @@ from relational_structs import (
 from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
 
 # The names the scene uses. All three are MujocoMovableObjectType, so these names are
-# the only thing that distinguishes them -- see the module docstring.
+# the only thing that distinguishes them -- see the module docstring. The barrier's is
+# imported rather than repeated: it is the same literal the state abstractor picks the
+# barrier out by, and Reachable stops being emitted if the two drift apart.
 ROBOT_NAME = "robot"
 CUBE_NAME = "cube_0"
 BIN_NAME = "bin_0"
-BARRIER_NAME = "cuboid_barrier"
 
 
 def create_bilevel_planning_models(
@@ -205,6 +209,13 @@ def create_bilevel_planning_models(
             # with no OnGround. Claiming it here made every refinement of this skill
             # fail, since the trajectory sampler requires the achieved abstract state
             # to equal the predicted one exactly, not merely to contain the effects.
+            #
+            # That cuts both ways and is this model's one soft spot: a cube that
+            # happens to settle flat -- which includes flat on the bin's interior
+            # floor, where z - bb_z/2 = 0.02 is inside ON_GROUND_TOL -- puts OnGround
+            # back and fails refinement, and the toss samples no parameters, so a retry
+            # draws the identical trajectory. Making that impossible means changing
+            # OnGround in state_abstractions, not this operator.
         },
         delete_effects={
             LiftedAtom(Holding, [robot, cube]),
@@ -287,6 +298,13 @@ def _pad_controller(
     """
     num_used = len(controller.variables)
     assert num_used <= len(parameters)
+    # Padding is positional, so the leading parameters must be the controller's own
+    # variables. ground() type-checks against the operator's types, not these, so a
+    # reordered parameter list would otherwise bind the wrong objects in silence.
+    assert all(
+        v.type in (p.type, p.type.parent)
+        for p, v in zip(parameters[:num_used], controller.variables)
+    ), "Padded controller's leading parameters do not match its variables"
 
     controller_cls = controller.controller_cls
 
@@ -295,6 +313,10 @@ def _pad_controller(
 
         def __init__(self, objects: Sequence[Object]) -> None:
             super().__init__(list(objects)[:num_used])
+
+    # Otherwise all three padded controllers report as "_PaddedController", since
+    # LiftedParameterizedController.name is the class's own __name__.
+    _PaddedController.__name__ = f"Padded{controller_cls.__name__}"
 
     return LiftedParameterizedController(
         list(parameters),

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -197,7 +197,14 @@ def create_bilevel_planning_models(
         add_effects={
             LiftedAtom(InGoalRegion, [cube]),
             LiftedAtom(HandEmpty, [robot]),
-            LiftedAtom(OnGround, [cube]),
+            # OnGround is deliberately NOT added. It requires the cube to be flat
+            # (|qx|, |qy| <= ON_GROUND_TOL) as well as resting, because the grasp the
+            # pick controller builds is modelled on a flat cube -- and a thrown cube
+            # tumbles, so it comes to rest at an arbitrary orientation. Measured: after
+            # a refined toss the abstract state is {HandEmpty, InGoalRegion, NearBin}
+            # with no OnGround. Claiming it here made every refinement of this skill
+            # fail, since the trajectory sampler requires the achieved abstract state
+            # to equal the predicted one exactly, not merely to contain the effects.
         },
         delete_effects={
             LiftedAtom(Holding, [robot, cube]),

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -58,4 +58,12 @@ def test_tidybot3d_tossing_bilevel_planning():
     else:
         assert False, "Did not terminate successfully"
 
+    # Running out of plan is not success. The refiner only ever returns a trajectory it
+    # simulated into the goal, but it simulates through transition_fn, which restores a
+    # state into a *separate* simulator; that the same actions also reach the goal when
+    # replayed in the real env is a different claim and is the one worth pinning.
+    assert terminated, "Executed the whole plan without the environment terminating"
+    final_state = env_models.observation_to_state(obs)
+    assert env_models.goal_deriver(final_state).check_state(final_state)
+
     env.close()

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -17,11 +17,8 @@ def test_tidybot3d_tossing_bilevel_planning():
     standoff from the bin, and toss. What bilevel planning has to supply is the
     continuous parameters of each of those three skills.
     """
-
     num_objects = 1
-    env = kinder.make(
-        f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array"
-    )
+    env = kinder.make(f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array")
 
     if MAKE_VIDEOS:
         env = RecordVideo(env, "unit_test_videos", name_prefix="TidyBot3D-tossing3d")

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -1,0 +1,64 @@
+"""Tests for tidybot3d_tossing3D.py."""
+
+import kinder
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+
+from kinder_bilevel_planning.agent import BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+kinder.register_all_environments()
+
+
+def test_tidybot3d_tossing_bilevel_planning():
+    """Tests for bilevel planning in the Tossing3D environment.
+
+    The plan shape is fixed: pick the cube off the ground, drive to a throw
+    standoff from the bin, and toss. What bilevel planning has to supply is the
+    continuous parameters of each of those three skills.
+    """
+
+    num_objects = 1
+    env = kinder.make(
+        f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array"
+    )
+
+    if MAKE_VIDEOS:
+        env = RecordVideo(env, "unit_test_videos", name_prefix="TidyBot3D-tossing3d")
+
+    seed = 123
+    obs, info = env.reset(seed=seed)
+    total_reward = 0
+
+    env_models = create_bilevel_planning_models(
+        "tidybot3d_tossing3D",
+        env.observation_space,
+        env.action_space,
+        num_objects=num_objects,
+    )
+    agent = BilevelPlanningAgent(
+        env_models,
+        seed=seed,
+        max_abstract_plans=1,
+        samples_per_step=1,
+        planning_timeout=120.0,
+        max_skill_horizon=400,
+    )
+
+    agent.reset(obs, info)
+    for _ in range(4000):
+        action = agent.step()
+        obs, reward, terminated, truncated, info = env.step(action)
+        total_reward += reward
+        agent.update(obs, reward, terminated or truncated, info)
+        if (
+            terminated
+            or truncated
+            or len(agent._current_plan) == 0  # pylint: disable=protected-access
+        ):
+            break
+
+    else:
+        assert False, "Did not terminate successfully"
+
+    env.close()

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -13,9 +13,10 @@ kinder.register_all_environments()
 def test_tidybot3d_tossing_bilevel_planning():
     """Tests for bilevel planning in the Tossing3D environment.
 
-    The plan shape is fixed: pick the cube off the ground, drive to a throw
-    standoff from the bin, and toss. What bilevel planning has to supply is the
-    continuous parameters of each of those three skills.
+    The plan shape is fixed: pick the cube off the ground, drive to a throw standoff
+    from the bin, and toss. What bilevel planning has to supply is the grasp standoff
+    and the throw standoff; the toss itself samples nothing, so the two demonstrated
+    arm confs are constants that only have to survive refinement.
     """
     num_objects = 1
     env = kinder.make(f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array")
@@ -63,6 +64,9 @@ def test_tidybot3d_tossing_bilevel_planning():
     # state into a *separate* simulator; that the same actions also reach the goal when
     # replayed in the real env is a different claim and is the one worth pinning.
     assert terminated, "Executed the whole plan without the environment terminating"
+    # And the planner's own abstraction agrees with the environment: InGoalRegion is
+    # checked against the model sim's goal region, so this catches the two drifting
+    # apart, which is what would make a refined plan and a real success diverge.
     final_state = env_models.observation_to_state(obs)
     assert env_models.goal_deriver(final_state).check_state(final_state)
 


### PR DESCRIPTION
**TL;DR** Adds the bilevel-planning env model for `Tossing3D-o1`, so the domain can be planned in rather than only scripted. Passing locally **1/1**, after a root cause that turned out to live one PR down the stack.

## Question / goal

Can `Tossing3D` be driven by `BilevelPlanningAgent`, the way `shelf3D`, `sweep3D` and `base_motion` already are?

## Background

`kinder-bilevel-planning`'s `env_models/` holds one module per environment, discovered by filename — `env_models/__init__.py` builds the path from `env_name` and loads it with `spec_from_file_location` — so a new domain is wired in by dropping a file in, with no registry to edit. `Tossing3D` was the one `dynamic3d` environment without such a module. The pieces it needs shipped below this PR: the state abstractions (#89), the two throw controllers plus a `pybullet_sim=` factory parameter (#90), and the oracle policy (#91) that demonstrated the plan shape end to end.

## Hypothesis

None — implementation task, not an experiment.

## Guidance given

Follow `tidybot3d_sweep3D.py` rather than shelf, because `sweep3D` is the one with `_create_ground_operators`. Pad the controllers with ignored variables rather than weakening the operators. Use name-based `ground_operators=`. Call both controller factories with the same `PyBulletSim`. Ship the hydra config.

## Methods

New `env_models/dynamic3d/tidybot3d_tossing3D.py`, new `tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py`, new `experiments/conf/env/tossing3d-o1.yaml`. Nothing existing in this package is modified.

Three operators — `pick`, `move_to_throw_pose`, `toss` — over the six predicates from #89, driven by shelf's `pick_shelf` and tossing's `move_to_throw_pose` / `toss_from_windup`. Three points worth attention:

1. **The controllers are padded with operator-only variables.** `LiftedSkill.__post_init__` asserts `tuple(operator.parameters) == tuple(controller.variables)`, and these operators are wider: `pick` needs `?barrier` to state `Reachable` and `?bin` to delete `NearBin`, while `pick_shelf` drives only `?robot` and `?target`. A `_pad_controller` helper rebuilds the lifted controller with the operator's parameters and drops the trailing objects. The assert compares `Variable`s by **name** as well as type, so padding is required even where arities match — `move_to_throw_pose` is 3 against 3, named `(?robot, ?target, ?held)` against `(?robot, ?bin, ?cube)`. Weakening the operators instead would remove `toss`'s `InGoalRegion` add effect, which is what the planner plans toward. **Padding is positional, so `_pad_controller` now asserts the leading operator parameters really are the controller's own variables** — `ground()` type-checks against the *operator's* types, so a reordered parameter list would otherwise bind the wrong objects in silence.
2. **Ground operators are supplied by name.** `bin_0`, `cube_0` and `cuboid_barrier` are all `MujocoMovableObjectType` and there are no fixtures in the state, so lifted-operator typing cannot tell a bin from a barrier. `sweep3D` does the same for its wiper.
3. **Both controller factories get the same `PyBulletSim`** — what #90's `pybullet_sim=` parameter is for. `RelationalControllerGenerator` grounds a fresh controller per sampling attempt, and on this domain an unshared client leaks ~136 MB per skill execution.

## Results

**The test passes locally, 1/1**, in ~5 s: the planner finds the abstract plan `pick → move_to_throw_pose → toss`, refines **3/3** steps, and the replayed trajectory reaches `terminated=True` with `(InGoalRegion cube_0)` holding. Whole-suite checks alongside it: **19/19** `kinder-models` `dynamic3d/tossing` tests. black / isort / docformatter / mypy clean, pylint 10.00/10.

Getting there needed two fixes, and **the larger one was not in this PR**:

| # | defect | where it landed |
|---|---|---|
| 1 | `MoveToThrowPoseController` sampled a base pose no throw can be thrown from, so `NearBin` was unreachable and the domain unplannable | **#90**, two commits |
| 2 | `toss` claimed an `OnGround` add effect that does not hold after a throw | this PR |

On (1): the sampler drew its standoff from `MOVE_TO_TARGET_DISTANCE_BOUNDS = (0.5, 0.6)`, the *grasping* range, while `NearBin` admits only `(1.20, 1.65)` — disjoint, so no draw could ever satisfy it. Traced live: `pick` refined in 67 actions, then every `move_to_throw_pose` attempt put the base **0.52 m** from the bin and failed.

On (2): the trajectory sampler requires the achieved abstract state to **equal** the predicted one, not merely to contain the effects. `OnGround` additionally requires the cube to be flat, because the grasp `pick_shelf` builds is modelled on a flat cube — and a thrown cube tumbles. Measured: the achieved state after a refined toss is `{HandEmpty, InGoalRegion, NearBin}`.

The new `_pad_controller` assertion was negative-controlled rather than assumed: with the real parameter lists all three skills build, and with `?robot` moved to the tail it raises, so it has teeth.

> **TODO (drag-and-drop):** the clip is ready — drop
> http://127.0.0.1:8765/tossing3d-bilevel-planning.gif in here.
>
> **What it shows:** `BilevelPlanningAgent` actually solving the task — abstract plan `pick → move_to_throw_pose → toss`, 3/3 steps refined, replayed in the real environment to `terminated=True` with `InGoalRegion(cube_0)` holding (108 of the 113 planned actions run before the environment terminates and the loop breaks). Produced by this PR's own `test_tidybot3d_tossing3d.py` via `pytest --make-videos`, **1/1** passing.
>
> **The thing to watch is the standoff, and it is captioned into the frame.** The refiner *samples* 1.2971 m; #91's oracle is *handed* 1.35. Same three skills, same scene — the difference between the two PRs is that this one searches for the continuous parameter instead of being told it. There is no scaling curve to go with it because there is nothing here to train: this is abstract search plus continuous-parameter sampling, with no learned weights and no training loop anywhere in `kinder-bilevel-planning`.
>
> **Caveat, and it is the same one as the CI note below:** the clip was rendered against `kindergarden` #126, so the bin sits at x = 2.0 and its measured footprint, x in [1.8502, 2.1502], coincides with the shaded goal region, x in [1.8500, 2.1500]. A reviewer running this against `kindergarden` `main` — bin at x = 2.23, outside the goal region — gets the unrefinable final skill and the misleading `AgentFailure: No plan found` described below, not this clip.
>
> Rendering settings only, nothing that touches physics, seeds or assertions — the `task_view` camera, the MimicLabs lab background, and `blocks_goal_region` shaded blue (it ships at alpha `0`). Verified rather than assumed: with and without the lab background the run is identical to the digit — 108 steps, standoff 1.29709768373082, cube at rest x = 2.0247931480407715.
>
> **One rendering-side bug found while making this, worth an upstream issue but out of scope here:** `MjRenderContextOffscreen.render()` (`kindergarden`, `src/kinder/envs/dynamic3d/mujoco_utils.py`) never calls `gl_ctx.make_current()`, so it draws through whichever GL context was made current last. This test builds a *second* `ObjectCentricTidyBot3DEnv` — the planner's own simulator inside `create_bilevel_planning_models` — whose render context steals the EGL context at construction, after which every frame from the recorded environment comes back as untextured grey geometry, from the correct camera and with no error raised. Re-asserting the context before each frame fixes it. Nothing in this PR's behaviour is affected, since the test only renders under `--make-videos`.

## Recommendation

Review the model, but **merge order matters**: this depends on #90's two new commits, without which the test cannot pass.

**Expect upstream CI to fail here, and expect the failure to be misleading** — it is red for this reason now. As on #91, the published `kindergarden` 0.2.0 wheel that CI resolves puts the `Tossing3D-o1` bin at x = 2.23 while `blocks_goal_region` inflates to [1.85, 2.15] — disjoint, so a cube landing in the bin scores `False`. Because `InGoalRegion` is what the planner plans *toward*, that scene makes the final skill unrefinable and the job fails with `AgentFailure: No plan found` — **the same message this PR's real bug produced**. Do not read a red `unit-tests` here as the bug being unfixed; the local runs are against the corrected scene. **Do not merge before kindergarden #126 (https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/126).**
