### PR TITLE
kinder-models: enable base-motion collision-checking against scene obstacles

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
@@ -839,7 +839,10 @@ class SweepOriController(GroundParameterizedController[ObjectCentricState, Array
         target_base_pose = get_target_robot_pose_from_parameters(
             target_object_pose, target_distance, target_rot
         )
-        # Run motion planning.
+        # Run motion planning. At this point the wiper's own geometry sits
+        # within the robot's footprint (it is being carried), so treating it
+        # as a static obstacle would make every plan here collide with it.
+        wiper = self.objects[1]
         base_motion_plan = run_base_motion_planning(
             state=x,
             target_base_pose=target_base_pose,
@@ -848,6 +851,7 @@ class SweepOriController(GroundParameterizedController[ObjectCentricState, Array
             seed=0,  # use a constant seed to effectively make this "deterministic"
             extend_xy_magnitude=extend_xy_magnitude,
             extend_rot_magnitude=extend_rot_magnitude,
+            disable_collision_objects=[wiper.name],
         )
         if base_motion_plan is None:
             raise TrajectorySamplingFailure()

--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -7,6 +7,7 @@ from typing import Iterable
 import numpy as np
 import pybullet as p
 from kinder.envs.dynamic3d.object_types import (
+    MujocoDrawerObjectType,
     MujocoFixtureObjectType,
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
@@ -153,6 +154,10 @@ def get_overhead_kinematic2ds(state: ObjectCentricState) -> dict[str, Geom2D]:
         print(obj.name)
         if obj.is_instance(MujocoTidyBotRobotObjectType):
             pose = get_overhead_robot_se2_pose(state, obj)
+        elif obj.is_instance(MujocoDrawerObjectType):
+            # Drawers only expose a slide "pos" feature, not a top-down
+            # pose/bounding box, so they can't be represented as a Geom2D.
+            continue
         elif obj.is_instance(MujocoObjectType):
             pose = get_overhead_object_se2_pose(state, obj)
         else:
@@ -226,10 +231,11 @@ def run_base_motion_planning(
     obstacles = state.get_objects(MujocoObjectType)
     if disable_collision_objects is not None:
         obstacles = [o for o in obstacles if o.name not in disable_collision_objects]
-    obstacle_geoms: set[Geom2D] = set()
-    # uncomment to fully consider the collisions.
-    # geoms = get_overhead_kinematic2ds(state)
-    # obstacle_geoms = {geoms[o.name] for o in obstacles}
+    # Drawers are MujocoObjectType, but get_overhead_kinematic2ds() cannot build a
+    # Geom2D for one, so they are absent from geoms and would KeyError below.
+    obstacles = [o for o in obstacles if not o.is_instance(MujocoDrawerObjectType)]
+    geoms = get_overhead_kinematic2ds(state)
+    obstacle_geoms: set[Geom2D] = {geoms[o.name] for o in obstacles}
 
     # Set up the RRT methods.
     def sample_fn(_: SE2) -> SE2:

--- a/kinder-models/tests/dynamic3d/test_dynamic3d_utils.py
+++ b/kinder-models/tests/dynamic3d/test_dynamic3d_utils.py
@@ -11,6 +11,7 @@ from relational_structs import ObjectCentricState
 from relational_structs.spaces import ObjectCentricBoxSpace
 from spatialmath import SE2
 from tomsgeoms2d.structs import Rectangle
+from tomsgeoms2d.utils import geom2ds_intersect
 
 from kinder_models.dynamic3d.utils import (
     get_bounding_box,
@@ -234,3 +235,44 @@ def test_run_base_motion_planning():
     # outfile = "base_motion_planning.mp4"
     # iio.mimsave(outfile, imgs)
     # print(f"Wrote out to {outfile}")
+
+
+def test_run_base_motion_planning_avoids_obstacles():
+    """Tests that run_base_motion_planning() avoids scene obstacles."""
+
+    env = kinder.make("kinder/Shelf3D-o1-v0", render_mode="rgb_array")
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    obs, _ = env.reset(seed=123)
+    state = env.observation_space.devectorize(obs)
+    robot = _get_robot_from_state(state)
+
+    # cube1 sits directly between the robot's start pose and this target, so a
+    # straight-line path would drive right through it.
+    target_base_pose = SE2(1.0, 0.17, 0.0)
+    x_bounds = (-1.5, 1.5)
+    y_bounds = (-1.5, 1.5)
+    seed = 123
+    base_motion_plan = run_base_motion_planning(
+        state,
+        target_base_pose,
+        x_bounds,
+        y_bounds,
+        seed,
+        extend_xy_magnitude=0.05,
+        extend_rot_magnitude=np.pi / 2,
+    )
+
+    assert base_motion_plan is not None
+
+    geoms = get_overhead_kinematic2ds(state)
+    cube_geom = geoms["cube1"]
+    robot_width, robot_height, _ = get_bounding_box(state, robot)
+    for pose in base_motion_plan:
+        robot_geom = Rectangle.from_center(
+            pose.x,
+            pose.y,
+            robot_width,
+            robot_height,
+            rotation_about_center=pose.theta(),
+        )
+        assert not geom2ds_intersect(robot_geom, cube_geom)


### PR DESCRIPTION
# Josh-Generated

The Uncommenting of the collision check is the most important part. The others are to make the unit tests pass (though I'm not familiar with the code, so would appreciate a double check on them!)

# AI-Generated

## Summary

`run_base_motion_planning()` had collision-checking against scene objects hardcoded off:

```python
obstacle_geoms: set[Geom2D] = set()
# uncomment to fully consider the collisions.
# geoms = get_overhead_kinematic2ds(state)
# obstacle_geoms = {geoms[o.name] for o in obstacles}
```

so the RRT planner would drive the robot base straight through obstacles. Fixes #102 by uncommenting those two lines, per maintainer @yixuanhuang98's own suggestion on that issue.

The uncomment is the fix. It also makes two previously-unreachable code paths reachable, and both crash — so this PR carries the two smallest changes that keep the `dynamic3d` suite green, and nothing else:

- **`get_overhead_kinematic2ds()` raised `ValueError` on drawers.** `MujocoDrawerObjectType` exposes only a slide `pos` feature — no `x`/`y`/`qw`/etc. — so building a top-down `Geom2D` for one failed. Nothing called the geom builder on a drawer-bearing state while collision-checking was off, so the path was dead until now.
- **`SweepOriController.reset()` planned against the wiper it is carrying.** The wiper's geometry sits inside the robot's own footprint at that point, so treating it as a static obstacle made every plan here collide. Passed via the existing `disable_collision_objects` parameter, which is exactly what it is for.

**Why the drawer fix touches two sites.** Skipping drawers inside `get_overhead_kinematic2ds()` alone is not sufficient, and this was measured rather than assumed: `MujocoDrawerObjectType` *is* a `MujocoObjectType`, so `state.get_objects(MujocoObjectType)` still yields the drawer, and the obstacle-set comprehension then fails on the geom that is no longer there:

```
src/kinder_models/dynamic3d/utils.py:235: in <setcomp>
    obstacle_geoms: set[Geom2D] = {geoms[o.name] for o in obstacles}
E   KeyError: 'kitchen_cooking_area_drawer_s0c1'
```

The single-site version leaves the suite at 29/33, same count as no fix at all. The second filter is load-bearing, not stylistic. The safety net for a genuinely *new* unrepresentable type remains `get_overhead_kinematic2ds()`'s own `raise NotImplementedError`, unchanged here.

Rebased onto `main` at 199cfe0 (#84, which converts the sweep3D `assert base_motion_plan is not None` into a `TrajectorySamplingFailure`); the `disable_collision_objects` argument slots in above that raise.

## Test plan

Measured on this branch at 3e6661c, against `main` at 199cfe0, with `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl DISPLAY=:99`.

- [x] `test_run_base_motion_planning_avoids_obstacles` (new) — targets a pose on the far side of `cube1` from the robot's start in `Shelf3D-o1-v0`, so a straight-line path drives through it. With the test alone applied to `main` it fails (`assert not True`, robot `Rectangle(x=0.060, y=-0.148, width=0.5, height=0.5)` intersecting `cube1` `Rectangle(x=0.515, y=0.105, width=0.04, height=0.04)`); with the fix it passes **1/1**.
- [x] `pytest tests/dynamic3d/ -q` — **33/33 passed** (49.1 s) on this branch, against **32/32 passed** (48.3 s) on unmodified `main`. The difference is exactly the one new test, so no existing `dynamic3d` test regresses. Nothing is skipped or xfailed.
- [x] Intermediate states, recorded because they justify the diff's size — the bare uncomment alone is **29/33** (4 failures, all `ValueError: 'x' is not in list` on `kitchen_cooking_area_drawer_s0c1`); uncomment plus the drawer fix is **31/33**, the remaining 2 being `TrajectorySamplingFailure` from `parameterized_skills.py:853` in `SweepOriController.reset()`. Each of the two changes above is therefore doing real work, and the sweep3D one is invisible until the drawer one lands.
- [x] `mypy src/kinder_models/dynamic3d/utils.py src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py tests/dynamic3d/test_dynamic3d_utils.py` — `Success: no issues found in 3 source files`.
- [x] `mypy .` (package-wide, what CI runs) — `Found 6 errors in 5 files (checked 80 source files)`, identical to unmodified `main`; all six are pre-existing `import-not-found` on `kinder.envs.kinematic3d.*` modules absent from the local `kindergarden` checkout. No new errors.
- [x] `PYTHONPATH=kinder-models pylint --rcfile .pylintrc <the three files>` — 10.00/10, no `E0013`, no messages against any of the three. Plugin load confirmed positively rather than assumed: a scratch file calling `np.random.rand()` linted with the same invocation is flagged `C9900 np-random-disallowed`.
- [x] `black --check` and `isort --check-only` on the three touched files — clean. `run_autoformat.sh` was deliberately *not* run repo-wide: it currently rewrites ~28 unrelated files from tool-version drift.

## Followup

Neither of these is addressed here.

- `get_overhead_kinematic2ds()` (~line 153) has a bare `print(obj.name)`. It used to run never; with collision-checking on it runs on every `run_base_motion_planning()` call, so it becomes per-planning-call stdout spam. Worth removing separately.
- At `THROW_STANDOFF_BOUNDS`'s old boundary (standoff≈1.00 m in the tossing barrier scenario #102 was originally reported against), an earlier investigation measured the planner still displacing the barrier ~0.151 m — worse than unfixed at that exact point, likely corner-cutting where the RRT detours around the obstacle but path-tracking doesn't hug the plan tightly. That number was measured against a **bare uncomment**, before the two fixes in this PR, and has **not** been re-run against this branch. Inherited context to check, not a re-confirmed result.
