### PR TITLE
kinder-models: stop get_overhead_kinematic2ds printing every object name

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -151,7 +151,6 @@ def get_overhead_kinematic2ds(state: ObjectCentricState) -> dict[str, Geom2D]:
     """Get a mapping from object name to Geom2D from an overhead perspective."""
     geoms: dict[str, Geom2D] = {}
     for obj in state:
-        print(obj.name)
         if obj.is_instance(MujocoTidyBotRobotObjectType):
             pose = get_overhead_robot_se2_pose(state, obj)
         elif obj.is_instance(MujocoDrawerObjectType):

--- a/kinder-models/tests/dynamic3d/test_dynamic3d_utils.py
+++ b/kinder-models/tests/dynamic3d/test_dynamic3d_utils.py
@@ -84,13 +84,16 @@ def test_get_overhead_robot_se2_pose():
     assert np.isclose(pose1.theta(), pose2.theta())
 
 
-def test_get_overhead_kinematic2ds():
+def test_get_overhead_kinematic2ds(capsys):
     """Tests for get_overhead_kinematic2ds()."""
     env = TidyBot3DEnv(task_config_path=str(_TEST_TASKS / "tidybot-ground-o1.json"))
     assert isinstance(env.observation_space, ObjectCentricBoxSpace)
     obs, _ = env.reset(seed=123)
     state = env.observation_space.devectorize(obs)
+    capsys.readouterr()  # discard anything the env setup above printed
     geoms = get_overhead_kinematic2ds(state)
+    # run_base_motion_planning() calls this on every plan, so it must stay quiet.
+    assert capsys.readouterr().out == ""
     assert len(geoms) == 2
     robot = _get_robot_from_state(state)
     robot_geom = geoms[robot.name]


### PR DESCRIPTION
## Summary

`get_overhead_kinematic2ds()` has a bare `print(obj.name)` in its loop over state
objects (`dynamic3d/utils.py:154`):

```python
    for obj in state:
        print(obj.name)
        if obj.is_instance(MujocoTidyBotRobotObjectType):
```

It was harmless while base collision-checking was off, because nothing reached the
geom builder. #103 turned that checking on, so `run_base_motion_planning()` now calls
it on **every** plan and the print became per-planning-call stdout spam in every
consumer. This is a regression #103 introduced, and its own `## Followup` recorded it.

Remove it. It is not converted to logging because the package has no logging
convention to convert it *to*: the only `import logging` anywhere in
`src/kinder_models/` is `teleop_utils.py` silencing werkzeug. A plain deletion is the
whole fix.

The one-line diff is covered by an assertion added to the existing
`test_get_overhead_kinematic2ds`, which captures stdout around the call and requires
it to be empty. Without it a future reintroduction is invisible — this print survived
review once already.

## Test plan

Measured on this branch at 86af637, against `main` at 4760956, with
`MUJOCO_GL=egl PYOPENGL_PLATFORM=egl` and `DISPLAY` set (unset `DISPLAY` makes
`register_all_environments()` force `osmesa`, under which every Dynamic3D env is
skipped in silence).

- [x] `pytest tests/dynamic3d/ -q` — **33/33 passed** (49.9 s) on this branch, against
  **33/33 passed** (49.7 s) on unmodified `main`. The count is unchanged because this
  PR adds an assertion to an existing test rather than a new test. Nothing is skipped
  or xfailed.
- [x] The new assertion fails on `main` for the right reason, not incidentally:
  `AssertionError: assert 'cube1\nrobot\n' == ''` — i.e. it captures exactly the two
  object names the print emits for `tidybot-ground-o1.json`.
- [x] `mypy src/kinder_models/dynamic3d/utils.py tests/dynamic3d/test_dynamic3d_utils.py`
  — `Success: no issues found in 2 source files`.
- [x] `PYTHONPATH=kinder-models pylint --rcfile .pylintrc` on both touched files —
  **10.00/10**, no `E0013`, no messages against either file. Plugin load confirmed
  positively rather than assumed: a scratch file calling `np.random.rand()` linted with
  the same invocation is flagged `C9900 np-random-disallowed`.
- [x] `black --check` and `isort --check-only` on both touched files — clean.
  `run_autoformat.sh` was deliberately **not** run repo-wide: it currently rewrites
  ~28 unrelated files from tool-version drift.

## Followup

Two items investigated alongside this one and deliberately **not** included.

**Drawers remain invisible to base collision-checking.** #103 skips
`MujocoDrawerObjectType` in the geom builder and filters it out of the obstacle set,
so having just fixed "the robot drives through the barrier", the robot can still drive
through drawers — now by explicit construction. Giving a drawer an overhead footprint
was investigated and is **not** a small change. Measured on `SweepIntoDrawer3D-o5-v0`
(seed 123):

- 10 of 22 objects in that scene are drawers; the geom builder builds 12 geoms and
  skips all 10.
- A drawer's state carries exactly **one** feature, `pos` (slide position). It does not
  inherit the parent `MujocoObjectType`'s pose — `MujocoObjectTypeFeatures` overrides
  the list per type. So `get_overhead_object_se2_pose` raises
  `ValueError: 'x' is not in list` and `get_bounding_box` raises
  `ValueError: 'bb_x' is not in list`. There is nothing in the state that locates a
  drawer at all.
- Each drawer is named `<fixture>_drawer_s<shelf>c<column>`, and every such `<fixture>`
  prefix (`kitchen_island`, `kitchen_cooking_area`, `kitchen_left_side`) **is** in the
  state as a `mujoco_fixture` with a full pose, and **is** already an obstacle. So a
  *closed* drawer is already inside a footprint that is already collision-checked; only
  the protruding part of an *open* drawer is genuinely missing.

Recovering that protrusion needs three things the state does not provide: a
drawer→fixture link (available only by string-prefix parsing of the object name), a
per-drawer offset and width within the fixture (`s0c1` indices exist, but the
index→metres mapping is scene-XML data, and the column count differs per fixture —
`kitchen_island` has c0/c1/c2 where others have only c1), and a decision about whether
a closed drawer should contribute anything. It would also be layered on top of a base
footprint that is already approximate: `get_bounding_box` returns the same hardcoded
`(0.61, 0.26, 1.0)` for *every* fixture, under its own `NOTE: hardcoded for now`.

That the repo has no general handle on a drawer is corroborated by the symbolic layer,
which special-cases a single drawer by name —
`sweep3D/state_abstractions.py` gates `DrawerOpen`/`DrawerClosed` on
`if drawer.name == "kitchen_island_drawer_s1c1"`. A general fix most likely belongs
upstream in `kindergarden`, by giving `MujocoDrawerObjectType` a pose and bounding box,
rather than being reconstructed here from object-name string parsing.

This is worth knowing rather than fixing blind, because base motion planning does run
while a drawer is open: `open_drawer` precedes `pick_wiper`, which plans the base.

**A stale docstring on `MoveToThrowPoseController`** says its held-object collision
exclusion "is a no-op today ... run_base_motion_planning currently leaves its obstacle
set empty". #103 made that false. It is not corrected here because that controller does
not exist on this repo's `main` — it lives only on the `josh/feature/tossing-throw-controllers`
branch, so the correction belongs on that branch and not in this PR.
