### PR TITLE
Add bilevel planning models for VegaMotion3D

### DIFF
--- a/kinder-bilevel-planning/pyproject.toml
+++ b/kinder-bilevel-planning/pyproject.toml
@@ -25,7 +25,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Backs the kinematic3d_v2 env models. See the same extra in kinder-models.
+prpl-kinematics = ["prpl_kinematics[planning]>=0.0.1"]
 develop = [
+    # Installed for development and CI so the kinematic3d_v2 models are linted, type
+    # checked, and tested.
+    "prpl_kinematics[planning]>=0.0.1",
     "black",
     "docformatter",
     "ipykernel",
@@ -71,6 +76,10 @@ exclude = ["venv/*", ".venv/*", "third-party/*"]
 [[tool.mypy.overrides]]
 module = [
     "matplotlib.*",
+    # Optional; see the prpl-kinematics extra.
+    "prpl_kinematics.*",
+    "spatialmath.*",
+    "pybullet.*",
     "mujoco",
     "mujoco.*",
     "ruckig",

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/__init__.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/__init__.py
@@ -21,6 +21,7 @@ def create_bilevel_planning_models(
         current_file.parent / "kinematic2d" / f"{env_name}.py",
         current_file.parent / "dynamic2d" / f"{env_name}.py",
         current_file.parent / "kinematic3d" / f"{env_name}.py",
+        current_file.parent / "kinematic3d_v2" / f"{env_name}.py",
         current_file.parent / "dynamic3d" / f"{env_name}.py",
     ]
 

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d_v2/vega_motion3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d_v2/vega_motion3d.py
@@ -1,0 +1,120 @@
+"""Bilevel planning models for the VegaMotion3D environment."""
+
+import numpy as np
+from bilevel_planning.structs import (
+    LiftedSkill,
+    SesameModels,
+)
+from gymnasium.spaces import Space
+from kinder.envs.kinematic3d_v2.base_env import ArmJointDeltaActionSpace
+from kinder.envs.kinematic3d_v2.object_types import (
+    Kinematic3Dv2ArmRobotType,
+    Kinematic3Dv2PointType,
+)
+from kinder.envs.kinematic3d_v2.vega_motion3d import (
+    ObjectCentricVegaMotion3DEnv,
+    VegaMotion3DEnvConfig,
+    VegaMotion3DObjectCentricState,
+)
+from kinder_models.kinematic3d_v2.vega_motion3d.parameterized_skills import (
+    create_lifted_controllers,
+)
+from kinder_models.kinematic3d_v2.vega_motion3d.state_abstractions import (
+    AtTarget,
+    create_goal_deriver,
+    create_state_abstractor,
+)
+from numpy.typing import NDArray
+from relational_structs import (
+    LiftedAtom,
+    LiftedOperator,
+    ObjectCentricState,
+    Variable,
+)
+from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
+
+
+def create_bilevel_planning_models(
+    observation_space: Space,
+    action_space: Space,
+    config: VegaMotion3DEnvConfig | None = None,
+    prefer_ompl: bool = True,
+) -> SesameModels:
+    """Create the env models for VegaMotion3D.
+
+    ``config`` overrides the env config of the internal sim. Defaults to
+    ``VegaMotion3DEnvConfig()`` if not provided. ``prefer_ompl`` selects the OMPL
+    motion planner when ompl is installed; set it to False to force the BiRRT
+    fallback.
+    """
+    assert isinstance(observation_space, ObjectCentricBoxSpace)
+    assert isinstance(action_space, ArmJointDeltaActionSpace)
+
+    if config is None:
+        config = VegaMotion3DEnvConfig()
+    sim = ObjectCentricVegaMotion3DEnv(config=config, allow_state_access=True)
+
+    # Convert observations into states. The important thing is that states are hashable.
+    def observation_to_state(o: NDArray[np.float32]) -> ObjectCentricState:
+        """Convert the vectors back into (hashable) object-centric states."""
+        return observation_space.devectorize(o)
+
+    # Create the transition function.
+    def transition_fn(
+        x: ObjectCentricState,
+        u: NDArray[np.float32],
+    ) -> ObjectCentricState:
+        """Simulate the action."""
+        state = x.copy()
+        assert isinstance(state, VegaMotion3DObjectCentricState)
+        sim.set_state(state)
+        obs, _, _, _, _ = sim.step(u)
+        return obs.copy()
+
+    # Types.
+    types = {Kinematic3Dv2ArmRobotType, Kinematic3Dv2PointType}
+
+    # Create the state space.
+    state_space = ObjectCentricStateSpace(types)
+
+    # Predicates.
+    predicates = {AtTarget}
+
+    # Abstractions.
+    state_abstractor = create_state_abstractor(sim)
+    goal_deriver = create_goal_deriver(state_abstractor)
+
+    # Operators.
+    robot = Variable("?robot", Kinematic3Dv2ArmRobotType)
+    target = Variable("?target", Kinematic3Dv2PointType)
+
+    MoveToTargetOperator = LiftedOperator(
+        "MoveToTarget",
+        [robot, target],
+        preconditions=set(),
+        add_effects={LiftedAtom(AtTarget, [robot, target])},
+        delete_effects=set(),
+    )
+
+    # Controllers.
+    controllers = create_lifted_controllers(action_space, sim, prefer_ompl=prefer_ompl)
+    LiftedMoveToTargetController = controllers["move_to_target"]
+
+    # Finalize the skills.
+    skills = {
+        LiftedSkill(MoveToTargetOperator, LiftedMoveToTargetController),
+    }
+
+    # Finalize the models.
+    return SesameModels(
+        observation_space,
+        state_space,
+        action_space,
+        transition_fn,
+        types,
+        predicates,
+        observation_to_state,
+        state_abstractor,
+        goal_deriver,
+        skills,
+    )

--- a/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_motion3d.py
+++ b/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_motion3d.py
@@ -8,8 +8,8 @@ from gymnasium.wrappers import RecordVideo
 from kinder_bilevel_planning.agent import BilevelPlanningAgent
 from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 
-# VegaMotion3D needs the optional prpl_kinematics backend, and is not in a kindergarden
-# release yet. Skip the module rather than fail collection when either is missing.
+# VegaMotion3D needs prpl_kinematics, which is an optional extra of both kindergarden and
+# this package. Skip the module rather than fail collection when it is not installed.
 pytest.importorskip("kinder.envs.kinematic3d_v2.vega_motion3d")
 pytest.importorskip("kinder_models.kinematic3d_v2.vega_motion3d.parameterized_skills")
 

--- a/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_motion3d.py
+++ b/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_motion3d.py
@@ -1,0 +1,64 @@
+"""Tests for vega_motion3d.py."""
+
+import kinder
+import pytest
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+
+from kinder_bilevel_planning.agent import BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+# VegaMotion3D needs the optional prpl_kinematics backend, and is not in a kindergarden
+# release yet. Skip the module rather than fail collection when either is missing.
+pytest.importorskip("kinder.envs.kinematic3d_v2.vega_motion3d")
+pytest.importorskip("kinder_models.kinematic3d_v2.vega_motion3d.parameterized_skills")
+
+kinder.register_all_environments()
+
+
+@pytest.mark.parametrize("prefer_ompl", [True, False])
+def test_vega_motion3d_bilevel_planning(prefer_ompl):
+    """Tests for bilevel planning in the VegaMotion3D environment.
+
+    Parameterized over both planners so the BiRRT fallback is covered even when ompl is
+    installed.
+    """
+    env = kinder.make("kinder/VegaMotion3D-v0", render_mode="rgb_array")
+
+    if MAKE_VIDEOS:
+        env = RecordVideo(
+            env, "unit_test_videos", name_prefix=f"VegaMotion3D-bilevel-{prefer_ompl}"
+        )
+
+    env_models = create_bilevel_planning_models(
+        "vega_motion3d",
+        env.observation_space,
+        env.action_space,
+        prefer_ompl=prefer_ompl,
+    )
+    agent = BilevelPlanningAgent(
+        env_models,
+        seed=123,
+        max_abstract_plans=1,
+        samples_per_step=1,
+        planning_timeout=60.0,
+        max_skill_horizon=1000,
+    )
+    obs, info = env.reset(seed=123)
+    total_reward = 0
+    agent.reset(obs, info)
+
+    for _ in range(1000):
+        action = agent.step()
+        obs, reward, terminated, truncated, info = env.step(action)
+        total_reward += reward
+        agent.update(obs, reward, terminated or truncated, info)
+        if terminated or truncated:
+            break
+
+    else:
+        assert False, "Did not terminate successfully"
+
+    assert terminated, "Episode truncated rather than reaching the goal"
+
+    env.close()

--- a/kinder-models/pyproject.toml
+++ b/kinder-models/pyproject.toml
@@ -21,7 +21,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Backs the kinematic3d_v2 skills. Optional for the same reason it is optional in
+# kindergarden: it overlaps heavily with pybullet_helpers and both are large. The
+# `planning` extra of prpl_kinematics adds OMPL, which the skills prefer when present
+# and fall back from to BiRRT when absent.
+prpl-kinematics = ["prpl_kinematics[planning]>=0.0.1"]
 develop = [
+    # Installed for development and CI so the kinematic3d_v2 skills are linted, type
+    # checked, and tested.
+    "prpl_kinematics[planning]>=0.0.1",
     "black",
     "docformatter",
     "isort",
@@ -63,6 +71,10 @@ exclude = ["venv/*", ".venv/*", "third-party/*"]
 [[tool.mypy.overrides]]
 module = [
     "matplotlib.*",
+    # Optional; see the prpl-kinematics extra.
+    "prpl_kinematics.*",
+    "spatialmath.*",
+    "pybullet.*",
     "pygame.*",
     "dill.*",
     "mujoco.*",

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_motion3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_motion3d/parameterized_skills.py
@@ -1,0 +1,229 @@
+"""Parameterized skills for the VegaMotion3D environment.
+
+The only skill is moving the arm to the target, so this is pure motion planning: sample
+an end-effector pose at the target, solve IK for a goal configuration, plan a collision-
+free joint path to it, and emit the path as bounded joint deltas.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any, Callable, Sequence
+
+import numpy as np
+import pybullet as p
+from bilevel_planning.structs import (
+    GroundParameterizedController,
+    LiftedParameterizedController,
+)
+from bilevel_planning.trajectory_samplers.trajectory_sampler import (
+    TrajectorySamplingFailure,
+)
+from gymnasium.spaces import Box
+from kinder.envs.kinematic3d_v2.base_env import ArmJointDeltaActionSpace
+from kinder.envs.kinematic3d_v2.object_types import (
+    ARM_NUM_JOINTS,
+    Kinematic3Dv2ArmRobotType,
+    Kinematic3Dv2PointType,
+)
+from kinder.envs.kinematic3d_v2.vega_motion3d import (
+    ObjectCentricVegaMotion3DEnv,
+    VegaMotion3DObjectCentricState,
+)
+from prpl_kinematics.collision import PyBulletCollisionChecker
+from prpl_kinematics.planning import BiRRTPlanner
+from prpl_kinematics.planning.configuration_space import ConfigurationSpace
+from prpl_kinematics.planning.motion_planner import MotionPlanner
+from prpl_kinematics.tree.kinematic_tree import Configuration
+from relational_structs import Object, ObjectCentricState, Variable
+from spatialmath import SE3, SO3
+
+# Sampled end-effector orientations are drawn within this angle of the orientation the
+# arm holds at home. Vega's analytic IK solves a non-SRS 7R arm, so orientation matters
+# a great deal for whether a reachable-looking target actually admits a solution:
+# measured over the environment's target bounds, uniformly random orientations solve
+# about 27% of the time, this cone about 95%, and the home orientation alone about 97%.
+# A cone keeps the sampler diverse without spending most draws on failures.
+DEFAULT_ORIENTATION_PERTURBATION = np.pi / 6
+
+
+def ompl_is_available() -> bool:
+    """Whether the optional ompl package can be imported.
+
+    ompl is an extra of prpl_kinematics (``prpl_kinematics[planning]``) because it
+    publishes wheels for fewer platforms than everything else.
+    """
+    return importlib.util.find_spec("ompl") is not None
+
+
+def create_motion_planner(
+    space: ConfigurationSpace,
+    collision_fn: Callable[[Configuration], bool],
+    rng: np.random.Generator,
+    timeout: float = 5.0,
+    prefer_ompl: bool = True,
+) -> MotionPlanner:
+    """An OMPL planner when ompl is installed, otherwise a BiRRT planner.
+
+    Both satisfy the same ``MotionPlanner`` protocol. Note that OMPL's RNG is
+    process-global rather than per-instance, so ``rng`` seeds only the BiRRT fallback;
+    call ``prpl_kinematics.planning.seed_ompl`` once per process to make OMPL runs
+    reproducible.
+    """
+    if prefer_ompl and ompl_is_available():
+        planning = importlib.import_module("prpl_kinematics.planning")
+        planner: MotionPlanner = planning.OMPLPlanner(
+            space, collision_fn, timeout=timeout
+        )
+        return planner
+    return BiRRTPlanner(space, collision_fn, rng)
+
+
+def create_collision_fn(
+    sim: ObjectCentricVegaMotion3DEnv,
+) -> Callable[[Configuration], bool]:
+    """A self-collision check for the robot in ``sim``.
+
+    This builds a checker over the environment's kinematic tree rather than reusing the
+    environment's own, which is not exposed. The tree is shared, so the two stay in
+    agreement; the cost is one extra PyBullet client held for the process lifetime.
+    """
+    physics_client_id = p.connect(p.DIRECT)
+    collision_checker = PyBulletCollisionChecker(physics_client_id)
+    collision_checker.load(sim.tree)
+    collision_checker.ignore(sim.robot.allowed_collision_pairs)
+    return collision_checker.in_collision
+
+
+class GroundMoveToTargetController(
+    GroundParameterizedController[ObjectCentricState, np.ndarray]
+):
+    """Controller for moving the robot arm to the target."""
+
+    def __init__(
+        self,
+        objects: Sequence[Object],
+        sim: ObjectCentricVegaMotion3DEnv,
+        planner: MotionPlanner,
+        orientation_perturbation: float = DEFAULT_ORIENTATION_PERTURBATION,
+    ) -> None:
+        super().__init__(objects)
+        self._sim = sim
+        self._planner = planner
+        self._orientation_perturbation = orientation_perturbation
+        self._manipulator = sim.robot.manipulators[sim.config.manipulator]
+        self._space = sim.robot.groups[self._manipulator.group]
+        self._robot, self._target = objects
+        self._current_params: np.ndarray | None = None
+        self._current_plan: list[np.ndarray] | None = None
+        self._current_state: ObjectCentricState | None = None
+
+    def sample_parameters(
+        self, x: ObjectCentricState, rng: np.random.Generator
+    ) -> np.ndarray:
+        assert isinstance(x, VegaMotion3DObjectCentricState)
+        self._sim.set_state(x)
+
+        # Sample an end-effector orientation within a cone around the home orientation.
+        axis = rng.normal(size=3)
+        axis /= np.linalg.norm(axis)
+        angle = self._orientation_perturbation * rng.random()
+        rotation = np.array(SO3.EulerVec(angle * axis))
+        home_pose = self._sim.target_reach_pose(x.target_position)
+        target_pose = SE3.Rt(rotation @ np.array(home_pose.R), x.target_position)
+
+        # Solve IK for a configuration whose end effector reaches that pose.
+        solution = self._manipulator.ik.solve(target_pose, self._sim.configuration)
+        if solution is None:
+            raise TrajectorySamplingFailure(f"IK failed for target pose {target_pose}")
+
+        return self._space.to_vector(solution)
+
+    def reset(self, x: ObjectCentricState, params: Any) -> None:
+        self._current_params = params
+        self._current_plan = None
+        self._current_state = x
+
+    def terminated(self) -> bool:
+        return self._current_plan is not None and len(self._current_plan) == 0
+
+    def step(self) -> np.ndarray:
+        assert self._current_state is not None
+        assert self._current_params is not None
+        assert isinstance(self._current_state, VegaMotion3DObjectCentricState)
+        self._sim.set_state(self._current_state)
+
+        # Generate the motion plan if it doesn't exist yet.
+        if self._current_plan is None:
+            start = self._sim.configuration
+            goal = dict(start)
+            goal.update(self._space.to_configuration(self._current_params))
+            path = self._planner.plan(start, goal)
+            if path is None:
+                raise TrajectorySamplingFailure("Motion planning failed")
+
+            # Densify so that consecutive waypoints are within one action of each other.
+            # Planners return waypoints at whatever spacing search produced, which can
+            # exceed what a single action can cover.
+            max_step = self._sim.config.max_action_mag / 2
+            vectors = [self._space.to_vector(config) for config in path]
+            plan: list[np.ndarray] = []
+            for previous, following in zip(vectors[:-1], vectors[1:], strict=True):
+                plan.extend(self._space.interpolate(previous, following, max_step))
+            self._current_plan = plan
+
+        # Pop the next target joint positions from the plan.
+        assert self._current_plan is not None
+        target_joints = self._current_plan.pop(0)
+
+        # Every Vega arm joint is bounded, so a plain difference is the correct delta;
+        # no wrapping is possible on these joints.
+        current_joints = np.asarray(self._current_state.arm_joint_positions)
+        delta = target_joints - current_joints
+        max_magnitude = self._sim.config.max_action_mag
+        action = np.clip(delta, -max_magnitude, max_magnitude)
+
+        return action.astype(np.float32)
+
+    def observe(self, x: ObjectCentricState) -> None:
+        self._current_state = x
+
+
+def create_lifted_controllers(
+    action_space: ArmJointDeltaActionSpace,
+    sim: ObjectCentricVegaMotion3DEnv,
+    rng: np.random.Generator | None = None,
+    prefer_ompl: bool = True,
+) -> dict[str, LiftedParameterizedController]:
+    """Create lifted parameterized controllers for VegaMotion3D."""
+    del action_space  # the action space is implied by the environment
+
+    if rng is None:
+        rng = np.random.default_rng(0)
+    planner = create_motion_planner(
+        sim.robot.groups[sim.robot.manipulators[sim.config.manipulator].group],
+        create_collision_fn(sim),
+        rng,
+        prefer_ompl=prefer_ompl,
+    )
+
+    class MoveToTargetController(GroundMoveToTargetController):
+        """Controller for moving the robot arm to the target."""
+
+        def __init__(self, objects):
+            super().__init__(objects, sim, planner)
+
+    # Create variables for lifted controllers.
+    robot = Variable("?robot", Kinematic3Dv2ArmRobotType)
+    target = Variable("?target", Kinematic3Dv2PointType)
+
+    move_to_target_controller: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot, target],
+            MoveToTargetController,
+            Box(-np.inf, np.inf, (ARM_NUM_JOINTS,)),
+        )
+    )
+    return {
+        "move_to_target": move_to_target_controller,
+    }

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_motion3d/state_abstractions.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_motion3d/state_abstractions.py
@@ -1,0 +1,70 @@
+"""State abstractions for the VegaMotion3D environment."""
+
+from typing import Callable
+
+from bilevel_planning.structs import (
+    RelationalAbstractGoal,
+    RelationalAbstractState,
+)
+from kinder.envs.kinematic3d_v2.object_types import (
+    Kinematic3Dv2ArmRobotType,
+    Kinematic3Dv2PointType,
+)
+from kinder.envs.kinematic3d_v2.vega_motion3d import (
+    ObjectCentricVegaMotion3DEnv,
+    VegaMotion3DObjectCentricState,
+)
+from relational_structs import (
+    GroundAtom,
+    Object,
+    ObjectCentricState,
+    Predicate,
+)
+
+# Predicates.
+AtTarget = Predicate("AtTarget", [Kinematic3Dv2ArmRobotType, Kinematic3Dv2PointType])
+
+StateAbstractor = Callable[[ObjectCentricState], RelationalAbstractState]
+GoalDeriver = Callable[[ObjectCentricState], RelationalAbstractGoal]
+
+
+def _get_robot_and_target(state: ObjectCentricState) -> tuple[Object, Object]:
+    """The unique robot and target in the state."""
+    robots = state.get_objects(Kinematic3Dv2ArmRobotType)
+    targets = state.get_objects(Kinematic3Dv2PointType)
+    assert len(robots) == 1, f"Expected 1 robot, got {len(robots)}"
+    assert len(targets) == 1, f"Expected 1 target, got {len(targets)}"
+    return robots[0], targets[0]
+
+
+def create_state_abstractor(sim: ObjectCentricVegaMotion3DEnv) -> StateAbstractor:
+    """Create a state abstractor backed by ``sim``.
+
+    Whether the end effector has reached the target is a function of forward kinematics,
+    not of the state features alone, so this defers to the environment's own goal check
+    rather than recomputing the threshold and risking drift from it.
+    """
+
+    def state_abstractor(state: ObjectCentricState) -> RelationalAbstractState:
+        """Get the abstract state for the current state."""
+        robot, target = _get_robot_and_target(state)
+        atoms: set[GroundAtom] = set()
+        assert isinstance(state, VegaMotion3DObjectCentricState)
+        sim.set_state(state)
+        if sim.goal_reached():
+            atoms.add(GroundAtom(AtTarget, [robot, target]))
+        return RelationalAbstractState(atoms, {robot, target})
+
+    return state_abstractor
+
+
+def create_goal_deriver(state_abstractor: StateAbstractor) -> GoalDeriver:
+    """Create a goal deriver that pairs with ``state_abstractor``."""
+
+    def goal_deriver(state: ObjectCentricState) -> RelationalAbstractGoal:
+        """The goal is to have the end effector at the target region."""
+        robot, target = _get_robot_and_target(state)
+        atoms = {GroundAtom(AtTarget, [robot, target])}
+        return RelationalAbstractGoal(atoms, state_abstractor)
+
+    return goal_deriver

--- a/kinder-models/tests/kinematic3d_v2/vega_motion3d/test_vega_motion3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d_v2/vega_motion3d/test_vega_motion3d_parameterized_skills.py
@@ -7,8 +7,8 @@ from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
 from relational_structs.spaces import ObjectCentricBoxSpace
 
-# VegaMotion3D needs the optional prpl_kinematics backend, and is not in a kindergarden
-# release yet. Skip the module rather than fail collection when either is missing.
+# VegaMotion3D needs prpl_kinematics, which is an optional extra of both kindergarden and
+# this package. Skip the module rather than fail collection when it is not installed.
 vega_motion3d = pytest.importorskip("kinder.envs.kinematic3d_v2.vega_motion3d")
 skills = pytest.importorskip(
     "kinder_models.kinematic3d_v2.vega_motion3d.parameterized_skills"

--- a/kinder-models/tests/kinematic3d_v2/vega_motion3d/test_vega_motion3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d_v2/vega_motion3d/test_vega_motion3d_parameterized_skills.py
@@ -1,0 +1,117 @@
+"""Tests for VegaMotion3D parameterized skills."""
+
+import kinder
+import numpy as np
+import pytest
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+from relational_structs.spaces import ObjectCentricBoxSpace
+
+# VegaMotion3D needs the optional prpl_kinematics backend, and is not in a kindergarden
+# release yet. Skip the module rather than fail collection when either is missing.
+vega_motion3d = pytest.importorskip("kinder.envs.kinematic3d_v2.vega_motion3d")
+skills = pytest.importorskip(
+    "kinder_models.kinematic3d_v2.vega_motion3d.parameterized_skills"
+)
+prpl_planning = pytest.importorskip("prpl_kinematics.planning")
+
+ObjectCentricVegaMotion3DEnv = vega_motion3d.ObjectCentricVegaMotion3DEnv
+create_lifted_controllers = skills.create_lifted_controllers
+create_motion_planner = skills.create_motion_planner
+ompl_is_available = skills.ompl_is_available
+
+kinder.register_all_environments()
+
+
+def _ground_controller(env, state, prefer_ompl=True):
+    """Ground a move-to-target skill against a fresh internal sim."""
+    sim = ObjectCentricVegaMotion3DEnv(allow_state_access=True)
+    controllers = create_lifted_controllers(
+        env.action_space, sim, prefer_ompl=prefer_ompl
+    )
+    controller = controllers["move_to_target"].ground(
+        (state.get_object_from_name("robot"), state.get_object_from_name("target"))
+    )
+    return sim, controller
+
+
+@pytest.mark.parametrize("prefer_ompl", [True, False])
+def test_move_to_target_controller(prefer_ompl):
+    """The controller should drive the arm to the target and then terminate.
+
+    Parameterized over both planners so the BiRRT fallback is covered even when ompl is
+    installed.
+    """
+    env = kinder.make("kinder/VegaMotion3D-v0", render_mode="rgb_array")
+    if MAKE_VIDEOS:
+        env = RecordVideo(
+            env, "unit_test_videos", name_prefix=f"VegaMotion3D-ompl{prefer_ompl}"
+        )
+
+    obs, _ = env.reset(seed=123)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    sim, controller = _ground_controller(env, state, prefer_ompl=prefer_ompl)
+
+    rng = np.random.default_rng(123)
+    params = controller.sample_parameters(state, rng)
+    assert params.shape == (7,)
+
+    controller.reset(state, params)
+    terminated = False
+    for _ in range(500):
+        obs, _, terminated, _, _ = env.step(controller.step())
+        next_state = env.observation_space.devectorize(obs)
+        controller.observe(next_state)
+        state = next_state
+        if controller.terminated():
+            break
+    else:
+        assert False, "Controller did not terminate"
+
+    # Reaching the sampled IK solution should also reach the environment's goal.
+    assert terminated
+
+    sim.close()
+    env.close()
+
+
+def test_sampled_parameters_reach_the_target():
+    """Sampled parameters should be joint positions whose end effector is on target."""
+    env = kinder.make("kinder/VegaMotion3D-v0", render_mode="rgb_array")
+    obs, _ = env.reset(seed=7)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    sim, controller = _ground_controller(env, state)
+
+    rng = np.random.default_rng(0)
+    params = controller.sample_parameters(state, rng)
+
+    # Put the sim at the sampled configuration and check the end effector is in range.
+    sim.set_state(state)
+    sim.set_arm_joint_positions(params)
+    distance = np.linalg.norm(sim.end_effector_pose.t - np.array(state.target_position))
+    assert distance < sim.config.target_radius
+
+    sim.close()
+    env.close()
+
+
+def test_ompl_is_preferred_when_available():
+    """create_motion_planner should pick OMPL when ompl is importable."""
+    sim = ObjectCentricVegaMotion3DEnv(allow_state_access=True)
+    manipulator = sim.robot.manipulators[sim.config.manipulator]
+    space = sim.robot.groups[manipulator.group]
+    rng = np.random.default_rng(0)
+
+    forced = create_motion_planner(space, lambda _: False, rng, prefer_ompl=False)
+    assert isinstance(forced, prpl_planning.BiRRTPlanner)
+
+    default = create_motion_planner(space, lambda _: False, rng)
+    if ompl_is_available():
+        assert not isinstance(default, prpl_planning.BiRRTPlanner)
+        assert type(default).__name__ == "OMPLPlanner"
+    else:
+        assert isinstance(default, prpl_planning.BiRRTPlanner)
+
+    sim.close()


### PR DESCRIPTION
Bilevel planning models for the new `VegaMotion3D` environment (Princeton-Robot-Planning-and-Learning/kindergarden#140), laid out like the TidyBot models: skills and abstractions in `kinder-models`, `SesameModels` wiring in `kinder-bilevel-planning`.

The environment has exactly one skill — move the arm to the target — so the models are pure motion planning: sample an end-effector pose at the target, solve IK for a goal configuration, plan a collision-free joint path, emit it as bounded joint deltas.

## OMPL by default

Motion planning goes through `prpl_kinematics` rather than `pybullet_helpers`, since that is what backs the environment. `create_motion_planner` returns an `OMPLPlanner` when `ompl` is importable and a `BiRRTPlanner` otherwise; both satisfy the same `MotionPlanner` protocol. `prefer_ompl=False` forces the fallback, so the tests are parameterized over both and the BiRRT path stays covered even where `ompl` is installed.

`ompl` is an extra of `prpl_kinematics` (`prpl_kinematics[planning]`) precisely because it ships wheels for fewer platforms, so "use it if installed" is the right default rather than a hard requirement.

Both solve the environment locally:

```
prefer_ompl=True  -> solved in 43 steps, 0.43s
prefer_ompl=False -> solved in 34 steps, 0.33s
```

## Why the orientation sampler is a cone, not uniform

The older `Motion3D` skills sampled end-effector orientation uniformly over SO(3). Copying that here would mostly produce sampling failures. Vega's analytic IK solves a non-SRS 7R arm, so orientation largely decides whether a reachable-looking target admits a solution at all. Measured over the environment's target bounds:

| Orientation sampling | IK success |
|---|---|
| uniform over SO(3) | 27% |
| within 30° of home (**chosen**) | 95% |
| home orientation only | 97% |

A cone keeps the sampler diverse without spending most draws on failures. The width is `DEFAULT_ORIENTATION_PERTURBATION` and is per-controller configurable.

## Abstractions

`AtTarget` defers to the environment's own `goal_reached()` instead of recomputing the distance threshold. Whether the end effector is on target depends on forward kinematics rather than state features alone, so recomputing it here would duplicate the threshold and invite drift from the environment. This is why the abstractor is a factory closing over a sim rather than a bare function as in the TidyBot models.

## Packaging

`prpl_kinematics` is an optional extra in both packages, mirroring how kindergarden treats it, and is in `develop` so CI covers the new code. `env_models/__init__.py` gains `kinematic3d_v2` in its lookup path.

## Verification

New tests pass locally against kindergarden `main` plus `prpl_kinematics[planning]`: 4 in kinder-models, 2 in kinder-bilevel-planning, covering the controller end to end on both planners, that sampled parameters really put the end effector in range, and planner selection.

**The tests skip in CI for now.** `kindergarden==0.2.0`, the current release, predates `kinematic3d_v2`, so `pytest.importorskip` skips the modules. They activate on the next kindergarden release with no change here.

## Note

That same release will break the stale `Motion3D`/`Ground3D` models — see #105, which I updated with the details while working on this. Pointing a venv at kindergarden `main` today produces 8 mypy errors and 7 test failures across these two packages, all confined to those files and none from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
