### PR TITLE
Switch prpl_llm_utils dependency to the PyPI release

### DIFF
--- a/kinder-vlm-planning/pyproject.toml
+++ b/kinder-vlm-planning/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
    "hydra-joblib-launcher",
    "omegaconf",
    "kindergarden>=0.2.1",
-   "prpl_llm_utils@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=prpl-llm-utils",
+   "prpl_llm_utils>=0.1.0",
    "bilevel_planning>=0.1.2",
 ]
 


### PR DESCRIPTION
## What

Replace the git-URL dependency on `prpl_llm_utils` (installed from the `prpl-mono` repo subdirectory) with the PyPI release, now that the package is published there (see Princeton-Robot-Planning-and-Learning/prpl-mono#527).

```diff
-   "prpl_llm_utils@git+https://github.com/Princeton-Robot-Planning-and-Learning/prpl-mono.git#subdirectory=prpl-llm-utils",
+   "prpl_llm_utils>=0.1.0",
```

PyPI currently has `prpl_llm_utils` 0.1.0, matching the distribution name already used in the pyproject.

## Why

Installing from a git subdirectory requires cloning all of `prpl-mono` on every fresh install and pins consumers to whatever `main` happens to be. The PyPI release installs faster and gives a versioned dependency.

## Verification

- `kinder-vlm-planning/pyproject.toml` was the only place in the repo declaring this dependency; `prpl_requirements.txt` and the CI install scripts only track local sibling packages, so no other changes were needed.
- Reinstalled `prpl_llm_utils` from PyPI and `kinder-vlm-planning` editable in the repo venv, then ran `run_ci_checks.sh` in `kinder-vlm-planning`: mypy clean, pylint pass, all 34 tests pass.

## Not addressed

- No version cap. If future `prpl_llm_utils` releases break the API, a `<0.2` bound (or a lockfile) can be added then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
