### PR TITLE
VegaMotion3D skills: sample goal configurations near the seed instead of fixed-orientation IK

### DIFF
--- a/kinder-bilevel-planning/pyproject.toml
+++ b/kinder-bilevel-planning/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
    "hydra-core",
    "hydra-joblib-launcher",
    "omegaconf",
-   "kindergarden>=0.2.1",
+   "kindergarden>=0.2.2",
    "prpl_utils>=0.0.7",
    "relational_structs>=0.0.1",
    "tomsgeoms2d>=0.0.1",

--- a/kinder-models/pyproject.toml
+++ b/kinder-models/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
    "h5py",
    "flask-socketio",
    "opencv-python>=4.9.0",
-   "kindergarden>=0.2.1",
+   "kindergarden>=0.2.2",
    "relational_structs>=0.0.1",
    "bilevel_planning>=0.1.2",
 ]

--- a/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
@@ -70,9 +70,9 @@ from kinder_models.dynamic3d.utils import (
 def _ik_or_resample(*args: Any, **kwargs: Any) -> Any:
     """Solve inverse kinematics, turning an unreachable pose into a resample.
 
-    The backtracking refiner retries a skill with freshly sampled parameters
-    whenever a TrajectorySamplingFailure is raised, so an infeasible target is
-    rejected and resampled instead of aborting the whole episode.
+    The backtracking refiner retries a skill with freshly sampled parameters whenever a
+    TrajectorySamplingFailure is raised, so an infeasible target is rejected and
+    resampled instead of aborting the whole episode.
     """
     try:
         return inverse_kinematics(*args, **kwargs)

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_motion3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_motion3d/parameterized_skills.py
@@ -1,8 +1,8 @@
 """Parameterized skills for the VegaMotion3D environment.
 
 The only skill is moving the arm to the target, so this is pure motion planning: sample
-an end-effector pose at the target, solve IK for a goal configuration, plan a collision-
-free joint path to it, and emit the path as bounded joint deltas.
+a collision-free goal configuration whose end effector lies in the target sphere, plan a
+collision-free joint path to it, and emit the path as bounded joint deltas.
 """
 
 from __future__ import annotations
@@ -36,15 +36,14 @@ from prpl_kinematics.planning.configuration_space import ConfigurationSpace
 from prpl_kinematics.planning.motion_planner import MotionPlanner
 from prpl_kinematics.tree.kinematic_tree import Configuration
 from relational_structs import Object, ObjectCentricState, Variable
-from spatialmath import SE3, SO3
 
-# Sampled end-effector orientations are drawn within this angle of the orientation the
-# arm holds at home. Vega's analytic IK solves a non-SRS 7R arm, so orientation matters
-# a great deal for whether a reachable-looking target actually admits a solution:
-# measured over the environment's target bounds, uniformly random orientations solve
-# about 27% of the time, this cone about 95%, and the home orientation alone about 97%.
-# A cone keeps the sampler diverse without spending most draws on failures.
-DEFAULT_ORIENTATION_PERTURBATION = np.pi / 6
+# Goal configurations are drawn uniformly within a per-joint window around the current
+# configuration and accepted when the end effector lands inside the target sphere, so
+# acceptance is the fraction of the window whose end effector is on target: roughly
+# 0.2-0.3% per draw at ~0.6 ms per forward-kinematics call, i.e. a few hundred
+# milliseconds per successful sample. This budget makes exhaustion (which raises
+# TrajectorySamplingFailure) a several-sigma event rather than a routine one.
+DEFAULT_NUM_GOAL_CANDIDATES = 10_000
 
 
 def ompl_is_available() -> bool:
@@ -105,12 +104,22 @@ class GroundMoveToTargetController(
         objects: Sequence[Object],
         sim: ObjectCentricVegaMotion3DEnv,
         planner: MotionPlanner,
-        orientation_perturbation: float = DEFAULT_ORIENTATION_PERTURBATION,
+        collision_fn: Callable[[Configuration], bool],
+        goal_joint_window: float | None = None,
+        num_goal_candidates: int = DEFAULT_NUM_GOAL_CANDIDATES,
     ) -> None:
         super().__init__(objects)
         self._sim = sim
         self._planner = planner
-        self._orientation_perturbation = orientation_perturbation
+        self._collision_fn = collision_fn
+        # The window defaults to the environment's target-witness window: targets are
+        # placed at the end effector of a configuration within that window of home, so
+        # sampling the same window around the (initially home) current configuration is
+        # guaranteed a solution for every environment-generated target.
+        if goal_joint_window is None:
+            goal_joint_window = sim.config.target_witness_joint_delta
+        self._goal_joint_window = goal_joint_window
+        self._num_goal_candidates = num_goal_candidates
         self._manipulator = sim.robot.manipulators[sim.config.manipulator]
         self._space = sim.robot.groups[self._manipulator.group]
         self._robot, self._target = objects
@@ -124,20 +133,35 @@ class GroundMoveToTargetController(
         assert isinstance(x, VegaMotion3DObjectCentricState)
         self._sim.set_state(x)
 
-        # Sample an end-effector orientation within a cone around the home orientation.
-        axis = rng.normal(size=3)
-        axis /= np.linalg.norm(axis)
-        angle = self._orientation_perturbation * rng.random()
-        rotation = np.array(SO3.EulerVec(angle * axis))
-        home_pose = self._sim.target_reach_pose(x.target_position)
-        target_pose = SE3.Rt(rotation @ np.array(home_pose.R), x.target_position)
-
-        # Solve IK for a configuration whose end effector reaches that pose.
-        solution = self._manipulator.ik.solve(target_pose, self._sim.configuration)
-        if solution is None:
-            raise TrajectorySamplingFailure(f"IK failed for target pose {target_pose}")
-
-        return self._space.to_vector(solution)
+        # Sample goal configurations directly: draw arm configurations within a
+        # per-joint window around the current configuration and accept ones that are
+        # collision-free with the end effector inside the target sphere. Sampling near
+        # the current configuration keeps goals on the current arm branch, so the
+        # planned motion is commensurate with the goal's distance; solving IK at a
+        # sampled end-effector orientation instead can return solutions on a far
+        # shoulder branch and demand swings of hundreds of degrees (issue #110).
+        target = np.asarray(x.target_position)
+        current = np.asarray(x.arm_joint_positions)
+        lower, upper = self._space.bounds()
+        sample_lower = np.clip(current - self._goal_joint_window, lower, upper)
+        sample_upper = np.clip(current + self._goal_joint_window, lower, upper)
+        base_config = dict(self._sim.configuration)
+        target_radius = self._sim.config.target_radius
+        ee_frame = self._manipulator.ee_frame
+        for _ in range(self._num_goal_candidates):
+            joints = rng.uniform(sample_lower, sample_upper)
+            config = base_config | self._space.to_configuration(joints)
+            position = self._sim.tree.forward_kinematics(ee_frame, config).t
+            if np.linalg.norm(position - target) >= target_radius:
+                continue
+            if self._collision_fn(config):
+                continue
+            return joints
+        raise TrajectorySamplingFailure(
+            f"No goal configuration found for target {tuple(target)} within "
+            f"{self._goal_joint_window} rad per joint of the current configuration "
+            f"after {self._num_goal_candidates} samples"
+        )
 
     def reset(self, x: ObjectCentricState, params: Any) -> None:
         self._current_params = params
@@ -200,9 +224,10 @@ def create_lifted_controllers(
 
     if rng is None:
         rng = np.random.default_rng(0)
+    collision_fn = create_collision_fn(sim)
     planner = create_motion_planner(
         sim.robot.groups[sim.robot.manipulators[sim.config.manipulator].group],
-        create_collision_fn(sim),
+        collision_fn,
         rng,
         prefer_ompl=prefer_ompl,
     )
@@ -211,7 +236,7 @@ def create_lifted_controllers(
         """Controller for moving the robot arm to the target."""
 
         def __init__(self, objects):
-            super().__init__(objects, sim, planner)
+            super().__init__(objects, sim, planner, collision_fn)
 
     # Create variables for lifted controllers.
     robot = Variable("?robot", Kinematic3Dv2ArmRobotType)

--- a/kinder-models/tests/dynamic3d/shelf/test_shelf_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/shelf/test_shelf_parameterized_skills.py
@@ -54,6 +54,7 @@ def _save_demo(
     print(f"\nSaved demo to {save_path}")
     return save_path
 
+
 kinder.register_all_environments()
 
 

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -20,8 +20,7 @@ from relational_structs.utils import create_state_from_dict
 from spatialmath import SE2
 
 from kinder_models.dynamic3d.shelf.parameterized_skills import (
-    create_lifted_controllers as shelf_create_lifted_controllers,
-)
+    create_lifted_controllers as shelf_create_lifted_controllers,)
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     create_lifted_controllers,
     get_target_robot_pose_from_parameters,

--- a/kinder-models/tests/kinematic3d_v2/vega_motion3d/test_vega_motion3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d_v2/vega_motion3d/test_vega_motion3d_parameterized_skills.py
@@ -69,7 +69,7 @@ def test_move_to_target_controller(prefer_ompl):
     else:
         assert False, "Controller did not terminate"
 
-    # Reaching the sampled IK solution should also reach the environment's goal.
+    # Reaching the sampled goal configuration should also reach the environment's goal.
     assert terminated
 
     sim.close()
@@ -95,6 +95,64 @@ def test_sampled_parameters_reach_the_target():
 
     sim.close()
     env.close()
+
+
+def test_incident_target_plan_stays_near_start():
+    """Goals and plans for the hardware-incident target must stay near the start.
+
+    Regression test for issue #110 (fix direction 3 from kindergarden#150): for the
+    target (0.5, -0.4, 0.8), the old fixed-orientation IK sampler returned goals on the
+    far shoulder branch, 3.85 rad away on a single joint, and the planner faithfully
+    produced a ~220 degree swing that was first caught on hardware. Goal sampling within
+    a joint window of the current configuration bounds the net displacement by
+    construction; this test pins that down in sim, for the sampled goal and for the
+    executed plan.
+    """
+    env = kinder.make("kinder/VegaMotion3D-v0")
+    obs, _ = env.reset(seed=123)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    target_obj = state.get_object_from_name("target")
+    for feature, value in zip("xyz", (0.5, -0.4, 0.8), strict=True):
+        state.set(target_obj, feature, value)
+    sim, controller = _ground_controller(env, state, prefer_ompl=False)
+    env.close()
+
+    rng = np.random.default_rng(0)
+    start_joints = np.asarray(state.arm_joint_positions)
+    window = sim.config.target_witness_joint_delta
+
+    # The sampled goal stays within the joint window of the start on every joint. The
+    # incident goal violated this bound by nearly a factor of four.
+    params = controller.sample_parameters(state, rng)
+    assert np.max(np.abs(params - start_joints)) <= window
+
+    # Execute the plan in a second sim and bound the trajectory itself: every visited
+    # configuration stays within the window plus planner slack, so the plan cannot
+    # detour through a far branch on the way to a nearby goal.
+    executor = vega_motion3d.ObjectCentricVegaMotion3DEnv(allow_state_access=True)
+    executor.reset(seed=0)
+    executor.set_state(state)
+    controller.reset(state, params)
+    current = state
+    max_excursion = 0.0
+    for _ in range(500):
+        current, _, _, _, _ = executor.step(controller.step())
+        controller.observe(current)
+        joints = np.asarray(current.arm_joint_positions)
+        max_excursion = max(max_excursion, float(np.max(np.abs(joints - start_joints))))
+        if controller.terminated():
+            break
+    else:
+        assert False, "Controller did not terminate"
+
+    assert executor.goal_reached()
+    final_joints = np.asarray(current.arm_joint_positions)
+    assert np.max(np.abs(final_joints - start_joints)) <= window
+    assert max_excursion <= 2 * window
+
+    executor.close()
+    sim.close()
 
 
 def test_ompl_is_preferred_when_available():


### PR DESCRIPTION
Fixes #110. Companion to kindergarden#151, which fixed the environment half of kindergarden#150; this PR fixes the skill half.

## What

`GroundMoveToTargetController.sample_parameters` no longer samples an end-effector orientation and solves full-pose analytic IK. It draws arm configurations uniformly within a per-joint window around the current configuration and accepts the first one that is collision-free with its end effector inside the target sphere. The accepted configuration is the skill parameter, as before.

- The window defaults to the environment's `target_witness_joint_delta` (1.0 rad). The new environment places every target at the end effector of a configuration within that window of home, so window sampling around the (initially home) current configuration succeeds for every environment-generated target.
- The collision checker built in `create_lifted_controllers` is now shared between the planner and the sampler.
- The sampler's budget is 10,000 draws (one forward-kinematics call each, collision-checked only after the sphere test passes), then `TrajectorySamplingFailure`, which the refiner treats as a resample.
- Both `kindergarden>=` pins bump to 0.2.2 (kinder-models and kinder-bilevel-planning), since the old sampler calls `target_reach_pose`, which kindergarden#151 removed, and the new sampler reads `config.target_witness_joint_delta`, which it added.

## Why

The IK-based sampler caused the hardware incident in kindergarden#150: for the target (0.5, -0.4, 0.8), every configuration whose orientation is near home lies on the far shoulder branch, so seed-closest IK returned a goal 3.85 rad away on j1 and the planner produced a ~220 degree swing. Sampling goals within a joint window of the seed bounds the net displacement by construction, needs no IK, and stays diverse across draws.

## Measurements (M-series Mac, BiRRT path, kindergarden@main)

- Environment-generated target (seed 123): 18-75 ms per successful sample over 3 draws.
- Incident target (0.5, -0.4, 0.8): 143-757 ms per successful sample over 5 draws; every sampled goal within 0.98 rad of home on the worst joint, versus 3.85 rad before.

## Tests

- New `test_incident_target_plan_stays_near_start` (fix direction 3 from kindergarden#150): plants the incident target in a state, then asserts the sampled goal is within the joint window of the start, executes the plan in sim, and asserts the goal is reached with every visited configuration within twice the window of the start. Under the old sampler the first assertion fails by nearly a factor of four.
- Existing kinder-models suite passes against kindergarden@main: 56 passed, mypy clean, pylint clean. The kinder-bilevel-planning VegaMotion3D tests (the one downstream consumer, via the unchanged `create_lifted_controllers` interface) also pass.

## Not addressed

- **Merge is blocked on the kindergarden 0.2.2 release.** CI will fail to install until a release containing kindergarden#151 is on PyPI (in progress). If it lands under a different version number, the two pins need adjusting.
- The window is centered on the current configuration, but the environment's guarantee is relative to home. These coincide at the initial state, which is where bilevel planning samples this skill; from other configurations the sampler can exhaust its budget and resample upstream.
- Three files carry drive-by formatting normalization (`dynamic3d/sweep3D/parameterized_skills.py` and two dynamic3d test files): they were committed to main slightly off-format, and `run_ci_checks.sh` runs the autoformatter over the package. The output is idempotent under black + docformatter + isort in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
