### PR TITLE
kinder-models: add state abstractions for Tossing3D

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/shelf/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/shelf/parameterized_skills.py
@@ -34,14 +34,14 @@ from relational_structs import (
 from spatialmath import SE2
 
 from kinder_models.dynamic3d.utils import (
-    _ARM_MAX_ACCEL,
-    _ARM_MAX_VEL,
+    _ARM_MAX_ACCELERATION,
+    _ARM_MAX_VELOCITY,
     ARM_MOVEMENT_CUPBOARD,
     BASE_DISTANCE_TO_CUPBOARD,
     BASE_TO_CUPBOARD_ROTATION,
     GRASP_CLOSE_THRESHOLD,
     GRASP_TRANSFORM_TO_OBJECT,
-    GRIPPER_OPEN_THRESHOLD,
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
     MAX_SAMPLER_ATTEMPTS,
     MOVE_TO_TARGET_DISTANCE_BOUNDS,
     MOVE_TO_TARGET_ROT_BOUNDS,
@@ -49,7 +49,7 @@ from kinder_models.dynamic3d.utils import (
     PLACE_SAMPLER_X_OFFSET_BOUNDS,
     PLACE_SAMPLER_Y_OFFSET_BOUNDS,
     ROBOT_ARM_POSE_TO_BASE,
-    WAYPOINT_TOL,
+    WAYPOINT_TOLERANCE,
     WORLD_X_BOUNDS,
     WORLD_Y_BOUNDS,
     PyBulletSim,
@@ -257,13 +257,13 @@ class PickShelfController(GroundParameterizedController[ObjectCentricState, Arra
         curr = np.array(self._get_current_robot_arm_conf()[:7])
         final = np.array(plan[-1][:7])
         self._approach_trajectory, self._approach_traj_dir = _compute_per_joint_profile(
-            curr, final, _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            curr, final, _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._approach_start_joints = curr.copy()
         self._approach_step_idx = 0
         # Compute trapezoidal velocity profile for retract (grasp conf → home).
         self._retract_trajectory, self._retract_traj_dir = _compute_per_joint_profile(
-            final, self.home_joints[:7], _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            final, self.home_joints[:7], _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._retract_start_joints = final.copy()
         self._retract_step_idx = 0
@@ -381,14 +381,16 @@ class PickShelfController(GroundParameterizedController[ObjectCentricState, Arra
         return 0.0
 
     def _robot_is_close_to_conf(
-        self, conf: JointPositions, atol: float = WAYPOINT_TOL
+        self, conf: JointPositions, atol: float = WAYPOINT_TOLERANCE
     ) -> bool:
         current_conf = self._get_current_robot_arm_conf()
         assert self._pybullet_sim is not None
         dist = self._pybullet_sim.get_joint_distance(current_conf, conf)
         return dist < atol
 
-    def _robot_is_close_to_pose(self, pose: SE2, atol: float = WAYPOINT_TOL) -> bool:
+    def _robot_is_close_to_pose(
+        self, pose: SE2, atol: float = WAYPOINT_TOLERANCE
+    ) -> bool:
         robot_pose = self._get_current_robot_pose()
         return bool(
             np.isclose(robot_pose.x, pose.x, atol=atol)
@@ -594,13 +596,13 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
         curr = np.array(self._get_current_robot_arm_conf()[:7])
         final = np.array(plan[-1][:7])
         self._approach_trajectory, self._approach_traj_dir = _compute_per_joint_profile(
-            curr, final, _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            curr, final, _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._approach_start_joints = curr.copy()
         self._approach_step_idx = 0
         # Compute trapezoidal velocity profile for retract (place conf → home).
         self._retract_trajectory, self._retract_traj_dir = _compute_per_joint_profile(
-            final, self.home_joints[:7], _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            final, self.home_joints[:7], _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._retract_start_joints = final.copy()
         self._retract_step_idx = 0
@@ -651,7 +653,7 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
             self._approach_step_idx += 1
             return action
         if self._pre_place and not self._open_gripper:
-            if self._get_current_robot_gripper_pose() < GRIPPER_OPEN_THRESHOLD:
+            if self._get_current_robot_gripper_pose() < GRIPPER_OPEN_COMMAND_TOLERANCE:
                 self._open_gripper = True
             action = np.zeros(11, dtype=np.float32)
             action[-1] = 0
@@ -714,14 +716,16 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
         return 0.0
 
     def _robot_is_close_to_conf(
-        self, conf: JointPositions, atol: float = WAYPOINT_TOL
+        self, conf: JointPositions, atol: float = WAYPOINT_TOLERANCE
     ) -> bool:
         current_conf = self._get_current_robot_arm_conf()
         assert self._pybullet_sim is not None
         dist = self._pybullet_sim.get_joint_distance(current_conf, conf)
         return dist < atol
 
-    def _robot_is_close_to_pose(self, pose: SE2, atol: float = WAYPOINT_TOL) -> bool:
+    def _robot_is_close_to_pose(
+        self, pose: SE2, atol: float = WAYPOINT_TOLERANCE
+    ) -> bool:
         robot_pose = self._get_current_robot_pose()
         return bool(
             np.isclose(robot_pose.x, pose.x, atol=atol)

--- a/kinder-models/src/kinder_models/dynamic3d/shelf/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/shelf/state_abstractions.py
@@ -19,6 +19,13 @@ from relational_structs import (
 )
 
 from kinder_models.dynamic3d.shelf.parameterized_skills import PyBulletSim
+from kinder_models.dynamic3d.utils import (
+    END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
+    GRIPPER_GRASPING_THRESHOLD,
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
+    MINIMUM_HOLDING_HEIGHT,
+    ON_GROUND_TOLERANCE,
+)
 
 # Predicates.
 OnFixture = Predicate("OnFixture", [MujocoObjectType, MujocoFixtureObjectType])
@@ -65,38 +72,36 @@ class CupboardRealStateAbstractor:
         all_mujoco_objects = set(fixtures) | set(movables)
 
         # OnGround.
-        on_ground_tol = 0.05
         for target in movables:
             z = state.get(target, "z")
             bb_z = state.get(target, "bb_z")
             # Handle flipped cases later.
             if (
-                np.isclose(z - bb_z / 2, 0.0, atol=on_ground_tol)
-                and np.isclose(state.get(target, "qx"), 0.0, atol=on_ground_tol)
-                and np.isclose(state.get(target, "qy"), 0.0, atol=on_ground_tol)
+                np.isclose(z - bb_z / 2, 0.0, atol=ON_GROUND_TOLERANCE)
+                and np.isclose(state.get(target, "qx"), 0.0, atol=ON_GROUND_TOLERANCE)
+                and np.isclose(state.get(target, "qy"), 0.0, atol=ON_GROUND_TOLERANCE)
             ):
                 atoms.add(GroundAtom(OnGround, [target]))
 
         # HandEmpty.
-        handempty_tol = 1e-3
         gripper_val = state.get(robot, "pos_gripper")
-        if np.isclose(gripper_val, 0.0, atol=handempty_tol):
+        if np.isclose(gripper_val, 0.0, atol=GRIPPER_OPEN_COMMAND_TOLERANCE):
             atoms.add(GroundAtom(HandEmpty, [robot]))
 
         # Holding.
         # checking the ee pose and target pose.
-        GraspThreshold = 0.1
         gripper_val = state.get(robot, "pos_gripper")
-        if gripper_val > GraspThreshold:
+        if gripper_val > GRIPPER_GRASPING_THRESHOLD:
             for target in movables:
                 target_ee_pose = self._pybullet_sim.get_ee_pose()
-                if state.get(target, "z") > 0.1:
+                if state.get(target, "z") > MINIMUM_HOLDING_HEIGHT:
                     if (
-                        abs(target_ee_pose.position[0] - state.get(target, "x")) < 0.05
+                        abs(target_ee_pose.position[0] - state.get(target, "x"))
+                        < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
                         and abs(target_ee_pose.position[1] - state.get(target, "y"))
-                        < 0.05
+                        < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
                         and abs(target_ee_pose.position[2] - state.get(target, "z"))
-                        < 0.05
+                        < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
                     ):
                         atoms.add(GroundAtom(Holding, [robot, target]))
 

--- a/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
@@ -40,19 +40,19 @@ from relational_structs import (
 from spatialmath import SE2
 
 from kinder_models.dynamic3d.utils import (
-    _ARM_MAX_ACCEL,
-    _ARM_MAX_VEL,
+    _ARM_MAX_ACCELERATION,
+    _ARM_MAX_VELOCITY,
     DRAWER_TRANSFORM_TO_OBJECT,
     DRAWER_TRANSFORM_TO_OBJECT_END,
     GRASP_CLOSE_THRESHOLD,
-    GRIPPER_OPEN_THRESHOLD,
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
     OPEN_DRAWER_DISTANCE_BOUNDS,
     OPEN_DRAWER_ROT_BOUNDS,
     PICK_WIPER_DISTANCE_BOUNDS,
     PICK_WIPER_ROT_BOUNDS,
     SWEEP_DISTANCE_BOUNDS,
     SWEEP_ROT_BOUNDS,
-    WAYPOINT_TOL,
+    WAYPOINT_TOLERANCE,
     WIPER_SWEEP_TRANSFORM,
     WIPER_SWEEP_TRANSFORM_END,
     WIPER_SWEEP_TRANSFORM_END_2,
@@ -287,19 +287,19 @@ class OpenDrawerSweepController(
         grasp_conf = np.array(plan[-1][:7])
         open_conf = np.array(open_plan[-1][:7])
         self._approach_trajectory, self._approach_traj_dir = _compute_per_joint_profile(
-            curr, grasp_conf, _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            curr, grasp_conf, _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._approach_start_joints = curr.copy()
         self._approach_step_idx = 0
         # Compute trapezoidal velocity profile for open-drawer (grasp conf -> open conf).
         self._open_trajectory, self._open_traj_dir = _compute_per_joint_profile(
-            grasp_conf, open_conf, _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            grasp_conf, open_conf, _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._open_start_joints = grasp_conf.copy()
         self._open_step_idx = 0
         # Compute trapezoidal velocity profile for retract (open conf -> home).
         self._retract_trajectory, self._retract_traj_dir = _compute_per_joint_profile(
-            open_conf, self.home_joints[:7], _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            open_conf, self.home_joints[:7], _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._retract_start_joints = open_conf.copy()
         self._retract_step_idx = 0
@@ -375,7 +375,7 @@ class OpenDrawerSweepController(
             self._open_step_idx += 1
             return action
         if self._lifted and not self._open_gripper:
-            if self._get_current_robot_gripper_pose() < GRIPPER_OPEN_THRESHOLD:
+            if self._get_current_robot_gripper_pose() < GRIPPER_OPEN_COMMAND_TOLERANCE:
                 self._open_gripper = True
             action = np.zeros(11, dtype=np.float32)
             action[-1] = 0
@@ -438,14 +438,16 @@ class OpenDrawerSweepController(
         return 0.0
 
     def _robot_is_close_to_conf(
-        self, conf: JointPositions, atol: float = WAYPOINT_TOL
+        self, conf: JointPositions, atol: float = WAYPOINT_TOLERANCE
     ) -> bool:
         current_conf = self._get_current_robot_arm_conf()
         assert self._pybullet_sim is not None
         dist = self._pybullet_sim.get_joint_distance(current_conf, conf)
         return dist < atol
 
-    def _robot_is_close_to_pose(self, pose: SE2, atol: float = WAYPOINT_TOL) -> bool:
+    def _robot_is_close_to_pose(
+        self, pose: SE2, atol: float = WAYPOINT_TOLERANCE
+    ) -> bool:
         robot_pose = self._get_current_robot_pose()
         return bool(
             np.isclose(robot_pose.x, pose.x, atol=atol)
@@ -622,13 +624,13 @@ class PickWiperOriController(GroundParameterizedController[ObjectCentricState, A
         curr = np.array(self._get_current_robot_arm_conf()[:7])
         grasp_conf = np.array(plan[-1][:7])
         self._approach_trajectory, self._approach_traj_dir = _compute_per_joint_profile(
-            curr, grasp_conf, _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            curr, grasp_conf, _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._approach_start_joints = curr.copy()
         self._approach_step_idx = 0
         # Compute trapezoidal velocity profile for retract (grasp conf -> home).
         self._retract_trajectory, self._retract_traj_dir = _compute_per_joint_profile(
-            grasp_conf, self.home_joints[:7], _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            grasp_conf, self.home_joints[:7], _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._retract_start_joints = grasp_conf.copy()
         self._retract_step_idx = 0
@@ -746,14 +748,16 @@ class PickWiperOriController(GroundParameterizedController[ObjectCentricState, A
         return 0.0
 
     def _robot_is_close_to_conf(
-        self, conf: JointPositions, atol: float = WAYPOINT_TOL
+        self, conf: JointPositions, atol: float = WAYPOINT_TOLERANCE
     ) -> bool:
         current_conf = self._get_current_robot_arm_conf()
         assert self._pybullet_sim is not None
         dist = self._pybullet_sim.get_joint_distance(current_conf, conf)
         return dist < atol
 
-    def _robot_is_close_to_pose(self, pose: SE2, atol: float = WAYPOINT_TOL) -> bool:
+    def _robot_is_close_to_pose(
+        self, pose: SE2, atol: float = WAYPOINT_TOLERANCE
+    ) -> bool:
         robot_pose = self._get_current_robot_pose()
         return bool(
             np.isclose(robot_pose.x, pose.x, atol=atol)
@@ -954,13 +958,13 @@ class SweepOriController(GroundParameterizedController[ObjectCentricState, Array
         sweep_start_conf = np.array(plan[-1][:7])
         sweep_end_conf = np.array(retract_plan[-1][:7])
         self._approach_trajectory, self._approach_traj_dir = _compute_per_joint_profile(
-            curr, sweep_start_conf, _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            curr, sweep_start_conf, _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._approach_start_joints = curr.copy()
         self._approach_step_idx = 0
         # Compute trapezoidal velocity profile for sweep (sweep start -> sweep end conf).
         self._sweep_trajectory, self._sweep_traj_dir = _compute_per_joint_profile(
-            sweep_start_conf, sweep_end_conf, _ARM_MAX_VEL, _ARM_MAX_ACCEL
+            sweep_start_conf, sweep_end_conf, _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
         self._sweep_start_joints = sweep_start_conf.copy()
         self._sweep_step_idx = 0
@@ -1068,14 +1072,16 @@ class SweepOriController(GroundParameterizedController[ObjectCentricState, Array
         return 0.0
 
     def _robot_is_close_to_conf(
-        self, conf: JointPositions, atol: float = WAYPOINT_TOL
+        self, conf: JointPositions, atol: float = WAYPOINT_TOLERANCE
     ) -> bool:
         current_conf = self._get_current_robot_arm_conf()
         assert self._pybullet_sim is not None
         dist = self._pybullet_sim.get_joint_distance(current_conf, conf)
         return dist < atol
 
-    def _robot_is_close_to_pose(self, pose: SE2, atol: float = WAYPOINT_TOL) -> bool:
+    def _robot_is_close_to_pose(
+        self, pose: SE2, atol: float = WAYPOINT_TOLERANCE
+    ) -> bool:
         robot_pose = self._get_current_robot_pose()
         return bool(
             np.isclose(robot_pose.x, pose.x, atol=atol)

--- a/kinder-models/src/kinder_models/dynamic3d/sweep3D/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/sweep3D/state_abstractions.py
@@ -19,6 +19,7 @@ from relational_structs import (
 )
 
 from kinder_models.dynamic3d.shelf.parameterized_skills import PyBulletSim
+from kinder_models.dynamic3d.utils import GRIPPER_OPEN_COMMAND_TOLERANCE
 
 # Predicates.
 DrawerOpen = Predicate("DrawerOpen", [MujocoDrawerObjectType])
@@ -87,9 +88,8 @@ class Sweep3DStateAbstractor:
                 atoms.add(GroundAtom(OnTable, [target]))
 
         # HandEmpty.
-        handempty_tol = 1e-3
         gripper_val = state.get(robot, "pos_gripper")
-        if np.isclose(gripper_val, 0.0, atol=handempty_tol):
+        if np.isclose(gripper_val, 0.0, atol=GRIPPER_OPEN_COMMAND_TOLERANCE):
             atoms.add(GroundAtom(HandEmpty, [robot]))
 
         # Holding.

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -31,13 +31,13 @@ from relational_structs import (
 from spatialmath import SE2
 
 from kinder_models.dynamic3d.utils import (
-    _ARM_MAX_ACCEL,
-    _ARM_MAX_VEL,
-    _CONTROL_DT,
+    _ARM_MAX_ACCELERATION,
+    _ARM_MAX_VELOCITY,
+    _CONTROL_TIMESTEP,
     GRASP_CLOSE_THRESHOLD,
     GRIPPER_CLOSED_THRESHOLD,
-    GRIPPER_OPEN_THRESHOLD,
-    WAYPOINT_TOL,
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
+    WAYPOINT_TOLERANCE,
     WORLD_X_BOUNDS,
     WORLD_Y_BOUNDS,
     PyBulletSim,
@@ -158,7 +158,9 @@ class MoveToTargetGroundController(
             return GRASP_CLOSE_THRESHOLD
         return 0.0
 
-    def _robot_is_close_to_pose(self, pose: SE2, atol: float = WAYPOINT_TOL) -> bool:
+    def _robot_is_close_to_pose(
+        self, pose: SE2, atol: float = WAYPOINT_TOLERANCE
+    ) -> bool:
         robot_pose = self._get_current_robot_pose()
         return bool(
             np.isclose(robot_pose.x, pose.x, atol=atol)
@@ -230,8 +232,8 @@ class MoveArmToConfController(GroundParameterizedController[ObjectCentricState, 
         self._trajectory, self._traj_dir = _compute_per_joint_profile(
             curr,
             final,
-            _ARM_MAX_VEL,
-            _ARM_MAX_ACCEL,
+            _ARM_MAX_VELOCITY,
+            _ARM_MAX_ACCELERATION,
         )
         self._start_joint_angles = curr.copy()
         self._step_idx = 0
@@ -248,7 +250,7 @@ class MoveArmToConfController(GroundParameterizedController[ObjectCentricState, 
 
         # Velocity via finite difference.
         if idx > 0:
-            ds = (self._trajectory[idx] - self._trajectory[idx - 1]) / _CONTROL_DT
+            ds = (self._trajectory[idx] - self._trajectory[idx - 1]) / _CONTROL_TIMESTEP
         else:
             ds = 0.0
 
@@ -365,7 +367,7 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
             max_vel=np.deg2rad(140),
             max_accel=np.deg2rad(300),
             max_decel=np.deg2rad(200),
-            step_size=_CONTROL_DT,
+            step_size=_CONTROL_TIMESTEP,
         )
         self._start_joint_angles = np.array(curr_joint_angles[:7])
         self._has_released = False
@@ -385,7 +387,7 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         s = float(self._trajectory[idx])
         # Compute velocity via finite difference of the profile.
         if idx > 0:
-            ds = (self._trajectory[idx] - self._trajectory[idx - 1]) / _CONTROL_DT
+            ds = (self._trajectory[idx] - self._trajectory[idx - 1]) / _CONTROL_TIMESTEP
         else:
             ds = 0.0
 
@@ -544,8 +546,8 @@ class MoveArmToEndEffectorController(
         self._trajectory, self._traj_dir = _compute_per_joint_profile(
             curr,
             final,
-            _ARM_MAX_VEL,
-            _ARM_MAX_ACCEL,
+            _ARM_MAX_VELOCITY,
+            _ARM_MAX_ACCELERATION,
         )
         self._start_joint_angles = curr.copy()
         self._step_idx = 0
@@ -562,7 +564,7 @@ class MoveArmToEndEffectorController(
 
         # Velocity via finite difference.
         if idx > 0:
-            ds = (self._trajectory[idx] - self._trajectory[idx - 1]) / _CONTROL_DT
+            ds = (self._trajectory[idx] - self._trajectory[idx - 1]) / _CONTROL_TIMESTEP
         else:
             ds = 0.0
 
@@ -695,7 +697,9 @@ class OpenGripperController(GroundParameterizedController[ObjectCentricState, Ar
         robot = self.objects[0]
         return state.get(robot, "pos_gripper")
 
-    def _robot_gripper_is_open(self, atol: float = GRIPPER_OPEN_THRESHOLD) -> bool:
+    def _robot_gripper_is_open(
+        self, atol: float = GRIPPER_OPEN_COMMAND_TOLERANCE
+    ) -> bool:
         current_gripper_pose = self._get_current_gripper_pose()
         return current_gripper_pose < atol
 

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -1,0 +1,217 @@
+"""State abstractions for the Tossing3D environment.
+
+MovableIsDownX records that one movable is at lower x than another -- in practice which
+side of cuboid_barrier (x ~ 1.3) a cube is on, so an operator model can express that a
+toss past it is irreversible.
+
+TODO: only Tossing3D-o1 is supported; no operator says which cube a throw is aimed at.
+"""
+
+import numpy as np
+from bilevel_planning.structs import (
+    RelationalAbstractGoal,
+    RelationalAbstractState,
+)
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoFixtureObjectType,
+    MujocoMovableObjectType,
+    MujocoObjectType,
+    MujocoTidyBotRobotObjectType,
+)
+from prpl_utils.utils import get_signed_angle_distance
+from relational_structs import (
+    GroundAtom,
+    Object,
+    ObjectCentricState,
+    Predicate,
+)
+
+from kinder_models.dynamic3d.utils import (
+    END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
+    GRIPPER_GRASPING_THRESHOLD,
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
+    MINIMUM_HOLDING_HEIGHT,
+    ON_GROUND_TOLERANCE,
+    WAYPOINT_TOLERANCE,
+    PyBulletSim,
+)
+
+# Upstream types cube, bin and barrier alike, so names state the type, not the subset.
+MovableInGoalRegion = Predicate("MovableInGoalRegion", [MujocoMovableObjectType])
+OnGround = Predicate("OnGround", [MujocoObjectType])
+Holding = Predicate("Holding", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType])
+HandEmpty = Predicate("HandEmpty", [MujocoTidyBotRobotObjectType])
+MovableIsDownX = Predicate(
+    "MovableIsDownX", [MujocoMovableObjectType, MujocoMovableObjectType]
+)
+RobotAtThrowPose = Predicate(
+    "RobotAtThrowPose", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType]
+)
+
+# The environment's inflated region, not the task JSON's "ranges".
+GOAL_REGION_NAME = "blocks_goal_region"
+
+CUBE_NAME_PREFIX = "cube"
+BIN_NAME_PREFIX = "bin"
+BARRIER_NAME = "cuboid_barrier"
+
+# Throwable-from standoffs, not the 0.5 m grasping one. Brackets the test's 1.35 m.
+THROW_STANDOFF_BOUNDS = (1.20, 1.65)
+
+# Wider than WAYPOINT_TOLERANCE: the sampler already spends half of it off-axis.
+THROW_POSE_TOLERANCE = 2 * WAYPOINT_TOLERANCE
+
+
+class Tossing3DStateAbstractor:
+    """State abstractor for the Tossing3D environment."""
+
+    def __init__(self, sim: ObjectCentricTidyBot3DEnv) -> None:
+        """Initialize the state abstractor."""
+        initial_state, _ = sim.reset()
+        cubes = self._get_cubes(initial_state)
+        assert len(cubes) == 1, (
+            f"only Tossing3D-o1 is supported, got {len(cubes)} cubes; see this "
+            "module's TODO for what o2 would need"
+        )
+        self._pybullet_sim = PyBulletSim(initial_state, rendering=False)
+        self._robot_name = sim.robot_name
+        self._sim = sim
+
+    def state_abstractor(self, state: ObjectCentricState) -> RelationalAbstractState:
+        """Get the abstract state for the current state."""
+        # Not pure: poses come from `state`, the goal region from the live simulator.
+        atoms: set[GroundAtom] = set()
+
+        self._pybullet_sim.set_state(state)
+
+        robot = state.get_object_from_name(self._robot_name)
+        fixtures = state.get_objects(MujocoFixtureObjectType)
+        movables = state.get_objects(MujocoMovableObjectType)
+        all_mujoco_objects = set(fixtures) | set(movables)
+        cubes = self._get_cubes(state)
+        bins = [o for o in movables if o.name.startswith(BIN_NAME_PREFIX)]
+        barriers = [o for o in movables if o.name == BARRIER_NAME]
+
+        if self._check_gripper_open(state, robot):
+            atoms.add(GroundAtom(HandEmpty, [robot]))
+
+        for cube in cubes:
+            if self._check_on_ground(state, cube):
+                atoms.add(GroundAtom(OnGround, [cube]))
+            if self._check_holding(state, robot, cube):
+                atoms.add(GroundAtom(Holding, [robot, cube]))
+            if self._check_in_goal_region(state, cube):
+                atoms.add(GroundAtom(MovableInGoalRegion, [cube]))
+            for barrier in barriers:
+                if self._check_is_down_x(state, cube, barrier):
+                    atoms.add(GroundAtom(MovableIsDownX, [cube, barrier]))
+
+        for target_bin in bins:
+            if self._check_at_throw_pose(state, robot, target_bin):
+                atoms.add(GroundAtom(RobotAtThrowPose, [robot, target_bin]))
+
+        objects = {robot} | all_mujoco_objects
+        return RelationalAbstractState(atoms, objects)
+
+    @staticmethod
+    def _check_gripper_open(state: ObjectCentricState, robot: Object) -> bool:
+        """Whether the gripper is commanded open, which implies an empty hand.
+
+        Reads the command, not finger pose, so this and Holding are not complementary.
+        """
+        return bool(
+            np.isclose(
+                state.get(robot, "pos_gripper"),
+                0.0,
+                atol=GRIPPER_OPEN_COMMAND_TOLERANCE,
+            )
+        )
+
+    @staticmethod
+    def _check_on_ground(state: ObjectCentricState, movable: Object) -> bool:
+        """Whether a movable rests flat on the ground.
+
+        Flat because the bounding box is pose-independent, so the bottom-face
+        arithmetic only holds while axis-aligned. A toss cannot predict this.
+        """
+        z = state.get(movable, "z")
+        bounding_box_height = state.get(movable, "bb_z")
+        return bool(
+            np.isclose(z - bounding_box_height / 2, 0.0, atol=ON_GROUND_TOLERANCE)
+            and np.isclose(state.get(movable, "qx"), 0.0, atol=ON_GROUND_TOLERANCE)
+            and np.isclose(state.get(movable, "qy"), 0.0, atol=ON_GROUND_TOLERANCE)
+        )
+
+    def _check_holding(
+        self, state: ObjectCentricState, robot: Object, movable: Object
+    ) -> bool:
+        """Whether the gripper is closed on this movable and lifting it."""
+        z = state.get(movable, "z")
+        if (
+            state.get(robot, "pos_gripper") <= GRIPPER_GRASPING_THRESHOLD
+            or z <= MINIMUM_HOLDING_HEIGHT
+        ):
+            return False
+        ee_pose = self._pybullet_sim.get_ee_pose()
+        return bool(
+            abs(ee_pose.position[0] - state.get(movable, "x"))
+            < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
+            and abs(ee_pose.position[1] - state.get(movable, "y"))
+            < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
+            and abs(ee_pose.position[2] - z) < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
+        )
+
+    @staticmethod
+    def _check_is_down_x(
+        state: ObjectCentricState, movable: Object, other: Object
+    ) -> bool:
+        """Whether a movable is at lower x than another, read live rather than fixed."""
+        return state.get(movable, "x") < state.get(other, "x")
+
+    @staticmethod
+    def _check_at_throw_pose(
+        state: ObjectCentricState, robot: Object, target: Object
+    ) -> bool:
+        """Whether the base is at a throwable standoff, on axis, facing the target."""
+        low, high = THROW_STANDOFF_BOUNDS
+        dx = state.get(target, "x") - state.get(robot, "pos_base_x")
+        dy = state.get(target, "y") - state.get(robot, "pos_base_y")
+        heading_error = abs(
+            get_signed_angle_distance(
+                np.arctan2(dy, dx), state.get(robot, "pos_base_rot")
+            )
+        )
+        return bool(
+            abs(dy) <= THROW_POSE_TOLERANCE
+            and low - THROW_POSE_TOLERANCE <= dx <= high + THROW_POSE_TOLERANCE
+            and heading_error <= THROW_POSE_TOLERANCE
+        )
+
+    def goal_deriver(self, state: ObjectCentricState) -> RelationalAbstractGoal:
+        """The goal is to toss every cube into the goal region."""
+        atoms = {GroundAtom(MovableInGoalRegion, [o]) for o in self._get_cubes(state)}
+        return RelationalAbstractGoal(atoms, self.state_abstractor)
+
+    def _get_cubes(self, state: ObjectCentricState) -> list[Object]:
+        """Get the cubes, told apart from the bin and the barrier by name."""
+        movables = state.get_objects(MujocoMovableObjectType)
+        return [o for o in movables if o.name.startswith(CUBE_NAME_PREFIX)]
+
+    def _check_in_goal_region(self, state: ObjectCentricState, cube: Object) -> bool:
+        """Check whether a cube's centre lies in the goal region."""
+        ground_fixture = self._sim._ground_fixture  # pylint: disable=protected-access
+        assert ground_fixture is not None, "Ground fixture not initialized"
+        position = np.array(
+            [
+                state.get(cube, "x"),
+                state.get(cube, "y"),
+                state.get(cube, "z"),
+            ],
+            dtype=np.float32,
+        )
+        return ground_fixture.check_in_region(
+            position,
+            GOAL_REGION_NAME,
+            self._sim._robot_env,  # pylint: disable=protected-access
+        )

--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -34,25 +34,33 @@ from tomsgeoms2d.structs import Geom2D, Rectangle
 from tomsgeoms2d.utils import geom2ds_intersect
 
 # Control period in seconds (10 Hz).
-_CONTROL_DT = 0.1
+_CONTROL_TIMESTEP = 0.1
 
 # Robot geometry.
 ROBOT_ARM_POSE_TO_BASE = Pose((0.12, 0.0, 0.4))
 
 # Arm joint velocity and acceleration limits (rad/s, rad/s²).
-_ARM_MAX_VEL = np.deg2rad(np.array([80.0, 80.0, 80.0, 80.0, 70.0, 70.0, 70.0]))
-_ARM_MAX_ACCEL = np.deg2rad(np.array([297.0, 150.0, 150.0, 150.0, 150.0, 150.0, 150.0]))
+_ARM_MAX_VELOCITY = np.deg2rad(np.array([80.0, 80.0, 80.0, 80.0, 70.0, 70.0, 70.0]))
+_ARM_MAX_ACCELERATION = np.deg2rad(
+    np.array([297.0, 150.0, 150.0, 150.0, 150.0, 150.0, 150.0])
+)
 
 # Base motion limits.
 MAX_BASE_MOVEMENT_MAGNITUDE = 1e-1
 
 # Gripper thresholds.
-GRIPPER_OPEN_THRESHOLD = 0.01
 GRASP_CLOSE_THRESHOLD = 1.0  # for stable grasp
 GRIPPER_CLOSED_THRESHOLD = 0.02
 
 # Waypoint tolerance for arm configuration convergence.
-WAYPOINT_TOL = 4 * 1e-2
+WAYPOINT_TOLERANCE = 4 * 1e-2
+
+# State-abstraction tolerances, shared by every dynamic3d state_abstractor.
+GRIPPER_OPEN_COMMAND_TOLERANCE = 1e-3
+ON_GROUND_TOLERANCE = 0.05
+GRIPPER_GRASPING_THRESHOLD = 0.1
+MINIMUM_HOLDING_HEIGHT = 0.1
+END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE = 0.05
 
 # Base navigation sampling bounds.
 MOVE_TO_TARGET_DISTANCE_BOUNDS = (0.5, 0.6)
@@ -393,7 +401,7 @@ def _compute_per_joint_profile(
         max_vel=effective_max_vel,
         max_accel=effective_max_accel,
         max_decel=effective_max_accel,
-        step_size=_CONTROL_DT,
+        step_size=_CONTROL_TIMESTEP,
     )
     return trajectory, direction
 

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -1,0 +1,193 @@
+"""Tests for tossing state_abstractions.py."""
+
+import kinder
+import numpy as np
+import pytest
+from conftest import MAKE_VIDEOS  # pylint: disable=import-error
+from gymnasium.wrappers import RecordVideo
+from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
+from relational_structs import GroundAtom, ObjectCentricState
+from relational_structs.spaces import ObjectCentricBoxSpace
+
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    create_lifted_controllers,
+)
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    HandEmpty,
+    Holding,
+    MovableInGoalRegion,
+    MovableIsDownX,
+    OnGround,
+    RobotAtThrowPose,
+    Tossing3DStateAbstractor,
+)
+
+# The standoff the pick-and-toss tests drive to, inside THROW_STANDOFF_BOUNDS.
+THROW_STANDOFF = 1.35
+
+
+def _get_robot_from_state(state: ObjectCentricState):
+    """Helper to get robot object from state by type."""
+    robots = state.get_objects(MujocoTidyBotRobotObjectType)
+    assert len(robots) == 1, f"Expected 1 robot, got {len(robots)}"
+    return list(robots)[0]
+
+
+def _make_env_and_abstractor(record_name: str | None = None):
+    """A reset Tossing3D-o1 env, its abstractor, and the initial state."""
+    kinder.register_all_environments()
+    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array")
+    if MAKE_VIDEOS and record_name is not None:
+        env.unwrapped._object_centric_env.set_render_camera("task_view")  # type: ignore # pylint: disable=protected-access
+        env = RecordVideo(env, "unit_test_videos", name_prefix=record_name)
+    sim = env.unwrapped._object_centric_env  # type: ignore # pylint: disable=protected-access
+    abstractor = Tossing3DStateAbstractor(sim)
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    return env, abstractor, state
+
+
+def test_hand_empty_holds_when_the_gripper_is_open():
+    """The gripper starts commanded open, so the hand reads empty."""
+    env, abstractor, state = _make_env_and_abstractor()
+    robot = _get_robot_from_state(state)
+    atoms = abstractor.state_abstractor(state).atoms
+    assert GroundAtom(HandEmpty, [robot]) in atoms
+    env.close()
+
+
+def test_on_ground_holds_for_a_cube_resting_flat():
+    """A settled cube is both at floor height and unrotated about x and y."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    atoms = abstractor.state_abstractor(state).atoms
+    assert GroundAtom(OnGround, [cube]) in atoms
+    env.close()
+
+
+def test_on_ground_fails_for_a_tilted_cube_at_the_same_height():
+    """Tilt alone breaks it, which is also what keeps the bb arithmetic valid."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    tilted = state.copy()
+    tilted.set(cube, "qx", 0.5)
+    atoms = abstractor.state_abstractor(tilted).atoms
+    assert GroundAtom(OnGround, [cube]) not in atoms
+    env.close()
+
+
+def test_movable_is_down_x_holds_short_of_the_barrier():
+    """The cube starts at lower x than cuboid_barrier."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    atoms = abstractor.state_abstractor(state).atoms
+    assert GroundAtom(MovableIsDownX, [cube, barrier]) in atoms
+    env.close()
+
+
+def test_movable_is_down_x_fails_past_the_barrier():
+    """Losing this atom is what makes a toss irreversible rather than retryable."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    thrown = state.copy()
+    thrown.set(cube, "x", state.get(barrier, "x") + 0.5)
+    atoms = abstractor.state_abstractor(thrown).atoms
+    assert GroundAtom(MovableIsDownX, [cube, barrier]) not in atoms
+    env.close()
+
+
+def test_holding_holds_for_a_lifted_cube_at_the_end_effector():
+    """Needs all three: gripper commanded closed, cube lifted, cube at the ee."""
+    env, abstractor, state = _make_env_and_abstractor()
+    robot = _get_robot_from_state(state)
+    cube = state.get_object_from_name("cube_0")
+    # Sync the sim first, so the ee pose is the one the abstractor will read.
+    abstractor.state_abstractor(state)
+    ee = abstractor._pybullet_sim.get_ee_pose()  # pylint: disable=protected-access
+    grasped = state.copy()
+    grasped.set(robot, "pos_gripper", 1.0)
+    grasped.set(cube, "x", ee.position[0])
+    grasped.set(cube, "y", ee.position[1])
+    grasped.set(cube, "z", ee.position[2])
+    atoms = abstractor.state_abstractor(grasped).atoms
+    assert GroundAtom(Holding, [robot, cube]) in atoms
+    env.close()
+
+
+def test_movable_in_goal_region_is_absent_before_any_throw():
+    """The abstraction must agree with the environment's own success check."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    atoms = abstractor.state_abstractor(state).atoms
+    assert GroundAtom(MovableInGoalRegion, [cube]) not in atoms
+    assert not abstractor._sim._check_goals()  # pylint: disable=protected-access
+    env.close()
+
+
+def test_movable_in_goal_region_uses_the_inflated_region():
+    """x = 2.14 is outside the task JSON's literal 2.10 but inside the inflated 2.15.
+
+    That gap is the point: the environment inflates "ranges" by the ground placement
+    threshold, and the predicate has to inflate with it.
+    """
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    landed = state.copy()
+    landed.set(cube, "x", 2.14)
+    landed.set(cube, "y", 0.0)
+    landed.set(cube, "z", 0.025)
+    atoms = abstractor.state_abstractor(landed).atoms
+    assert GroundAtom(MovableInGoalRegion, [cube]) in atoms
+    env.close()
+
+
+def test_the_goal_is_every_cube_in_the_goal_region():
+    """And the initial state does not satisfy it."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    goal = abstractor.goal_deriver(state)
+    assert goal.atoms == {GroundAtom(MovableInGoalRegion, [cube])}
+    assert not goal.check_state(state)
+    env.close()
+
+
+def test_robot_at_throw_pose_holds_after_driving_to_a_throw_standoff():
+    """Checked against the controller that establishes it, not a hand-set state."""
+    env, abstractor, state = _make_env_and_abstractor("Tossing3D-state-abstraction")
+    robot = _get_robot_from_state(state)
+    target_bin = state.get_object_from_name("bin_0")
+    controller = create_lifted_controllers(env.action_space)["move_to_target"].ground(
+        (robot, target_bin)
+    )
+    # cube_0 rests at x = 0.71 and the base is headed for x = 0.65, so it is excluded
+    # the way MoveToThrowPoseController excludes the object it holds.
+    controller.reset(
+        state,
+        np.array([THROW_STANDOFF, 0.0]),
+        disable_collision_objects=["cube_0"],
+    )
+    for _ in range(300):
+        obs, _, _, _, _ = env.step(controller.step())
+        state = env.observation_space.devectorize(obs)
+        controller.observe(state)
+        if controller.terminated():
+            break
+    else:
+        assert False, "Controller did not terminate"
+
+    atoms = abstractor.state_abstractor(state).atoms
+    assert GroundAtom(RobotAtThrowPose, [robot, target_bin]) in atoms
+    env.close()
+
+
+def test_the_abstractor_rejects_the_two_cube_variant():
+    """o2 is out of scope: no operator says which cube a throw is aimed at."""
+    kinder.register_all_environments()
+    env = kinder.make("kinder/Tossing3D-o2-v0", render_mode="rgb_array")
+    sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
+    with pytest.raises(AssertionError, match="only Tossing3D-o1 is supported"):
+        Tossing3DStateAbstractor(sim)
+    env.close()


### PR DESCRIPTION
Adds the Tossing3D state abstractor — `MovableInGoalRegion`, `OnGround`, `Holding`,
`HandEmpty`, `MovableIsOnLeftSide`, `RobotAtThrowPose` — plus its test file. One commit.

## Question / goal

Give Tossing3D a symbolic state abstraction a planner can consume, and land it as one
reviewable commit at the bottom of the Tossing3D port stack.

## Background

`kinder_models.dynamic3d.tossing` shipped parameterized controllers but nothing that
turned an `ObjectCentricState` into a `RelationalAbstractState`, so no planner could
reason about the domain symbolically. This is rung 1 of two: rung 2 (https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/113) adds the
throw-pose and composed-toss controllers and the two release parameters.

Five of the six predicates have precedent in `shelf/state_abstractions.py` or sweep3D.
`RobotAtThrowPose` does not — it is the one predicate here with no upstream analogue,
which is why the test checks it against the controller that establishes it rather than
only against the initial state.

This branch previously appeared as #89, which is closed. It has been rebased onto current
`main` and squashed to one commit.

## Hypothesis

None — implementation task, not an experiment.

## Guidance given

One commit. Trim comments hard: keep the fact — the citation, the measured value, the
constraint — and cut the prose explaining why the fact matters; never delete a measured
number or a "why this value" one-liner. Cut every diff-relative phrase. Name each
predicate for the type it actually ranges over. Extract each predicate's evaluation into
its own helper. Every line ≤ 88 characters.

## Methods

**Predicate names state their argument type, not a subset of it.** Upstream types the
cube, the bin and the barrier all as `MujocoMovableObjectType`, so a name like
`InGoalRegion` would read as if it were cube-only when the signature admits any movable.
Hence `MovableInGoalRegion` and `MovableIsOnLeftSide`. `RobotAtThrowPose` names the robot
for the same reason.

**Each predicate's evaluation is a `_check_*` helper**, so the atom-assembly loop in
`state_abstractor` reads as the set of predicates rather than as their arithmetic.

**`_check_on_ground` requires the object to be flat, not merely at floor height.**
`get_bounding_box_dimensions()` is documented as independent of the object's pose, so
`z - bb_z / 2` is the bottom face only while the body is axis-aligned. The `qx ≈ 0` /
`qy ≈ 0` conditions are therefore load-bearing for the height arithmetic itself, not just
a graspability nicety.

**`_check_gripper_open` reads the gripper *command*, not finger pose** — `pos_gripper` is
built as `ctrl["gripper"][0] / 255.0` — so `HandEmpty` and `Holding` are deliberately not
complementary, and the docstring says so.

**`MovableInGoalRegion` asks the live simulator**, via `ground_fixture.check_in_region`,
rather than reading the task JSON's `ranges`. The environment inflates that region by its
ground-placement threshold, so a literal read of the JSON would disagree with
`_check_goals()`. `test_movable_in_goal_region_uses_the_inflated_region` pins exactly that
gap: x = 2.14 is outside the JSON's 2.10 and inside the inflated 2.15.

**Only `Tossing3D-o1` is supported**, and the abstractor asserts it rather than degrading
quietly: with two cubes, no operator says which cube a throw is aimed at.
`test_the_abstractor_rejects_the_two_cube_variant` constructs the o2 env and asserts the
`AssertionError`. The module docstring carries the TODO.

**The test excludes `cube_0` from base-motion collision checking.** Upstream PR #103
turned base-motion collision-checking on in `run_base_motion_planning` — `obstacle_geoms`
had been hardcoded empty — and `state.get_objects(MujocoObjectType)` is subtype-inclusive
via `Object.is_instance`, so every movable including the held cube is now an obstacle to
the robot's own base plan. Reproduced at seed 125, where `cube_0` rests at x = 0.713,
y = -0.003 and the target base pose is x = 0.650, y = 0.0 — 6 cm apart:

| `disable_collision_objects` | plan found |
| --- | --- |
| `None` | no |
| `["cube_0"]` | **yes** |
| `["cuboid_barrier"]` | no |
| `["cube_0", "cuboid_barrier"]` | **yes** |

So the cube alone blocks the plan. The test passes `disable_collision_objects=["cube_0"]`,
mirroring what rung 2's own `MoveToThrowPoseController` does.

## Results

- **One commit**, 2 files, on current `main`.
- `kinder-models/tests/dynamic3d/tossing/` — **35/35 passing** at this branch's tip
  (11 of those are this file's).
- `black` and `isort` clean at the repo's own settings; every added line ≤ 88 characters.

## Recommendation

Merge as rung 1. Rung 2 (https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/113) stacks on this branch and is where the controllers
that can actually *reach* `RobotAtThrowPose` live — on this rung alone the predicate is
satisfiable only by driving `move_to_target` by hand, which is what its test does.

Two follow-ups, neither blocking:

- `ON_GROUND_TOLERANCE` is used as both a height tolerance (metres) and a quaternion-
  component tolerance. They happen to want the same number today; they are not the same
  quantity.
- The open/closed gripper decision ultimately bottoms out in an unnamed literal `0.2`
  inside each `_get_current_robot_gripper_pose()`. That quantisation means
  `GRIPPER_OPEN_COMMAND_TOLERANCE`'s exact value cannot currently change any outcome.
