### PR TITLE
kinder-bilevel-planning: add bilevel planning models for Tossing3D

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -1,0 +1,269 @@
+"""Bilevel planning models for the TidyBot3D Tossing3D environment."""
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import kinder
+import numpy as np
+from bilevel_planning.structs import (
+    LiftedParameterizedController,
+    LiftedSkill,
+    SesameModels,
+)
+from gymnasium.spaces import Space
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoMovableObjectType,
+    MujocoObjectType,
+    MujocoTidyBotRobotObjectType,
+)
+from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionSpace
+from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
+from kinder_models.dynamic3d.tossing import parameterized_skills as tossing_skills
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    BARRIER_NAME,
+    BIN_NAME_PREFIX,
+    CUBE_NAME_PREFIX,
+    HandEmpty,
+    Holding,
+    MovableInGoalRegion,
+    MovableIsDownX,
+    OnGround,
+    RobotAtThrowPose,
+    Tossing3DStateAbstractor,
+)
+from kinder_models.dynamic3d.utils import PyBulletSim
+from numpy.typing import NDArray
+from relational_structs import (
+    GroundOperator,
+    LiftedAtom,
+    LiftedOperator,
+    Object,
+    ObjectCentricState,
+    Variable,
+)
+from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
+
+
+def create_bilevel_planning_models(
+    observation_space: Space,
+    action_space: Space,
+    num_objects: int = 1,
+) -> SesameModels:
+    """Create the env models for TidyBot Tossing3D."""
+    if num_objects != 1:
+        raise NotImplementedError(
+            f"Tossing3D bilevel planning supports one cube, got {num_objects}. The "
+            "operators name a single held cube, and no operator says which cube a "
+            "throw is aimed at."
+        )
+    assert isinstance(observation_space, ObjectCentricBoxSpace)
+    assert isinstance(action_space, TidyBot3DRobotActionSpace)
+
+    task_config_path = str(
+        Path(kinder.__file__).parent
+        / "envs/dynamic3d/tasks/Tossing3D"
+        / f"Tossing3D-o{num_objects}.json"
+    )
+    sim = ObjectCentricTidyBot3DEnv(
+        task_config_path=task_config_path,
+        num_objects=num_objects,
+        allow_state_access=True,
+    )
+
+    # State and goal abstractors.
+    abstractor = Tossing3DStateAbstractor(sim)
+    state_abstractor = abstractor.state_abstractor
+    goal_deriver = abstractor.goal_deriver
+
+    # Need to call reset to initialize the qpos, qvel.
+    initial_state, _ = sim.reset()
+
+    # Convert observations into states. The important thing is that states are hashable.
+    def observation_to_state(o: NDArray[np.float32]) -> ObjectCentricState:
+        """Convert the vectors back into (hashable) object-centric states."""
+        return observation_space.devectorize(o)
+
+    # Create the transition function.
+    def transition_fn(
+        x: ObjectCentricState,
+        u: NDArray[np.float32],
+    ) -> ObjectCentricState:
+        """Simulate the action."""
+        state = x.copy()
+        sim.set_state(state)
+        obs, _, _, _, _ = sim.step(u)
+        return obs.copy()
+
+    # Types.
+    types = {
+        MujocoTidyBotRobotObjectType,
+        MujocoObjectType,
+        MujocoMovableObjectType,
+    }
+
+    # Create the state space.
+    state_space = ObjectCentricStateSpace(types)
+
+    # Predicates.
+    predicates = {
+        MovableInGoalRegion,
+        OnGround,
+        Holding,
+        HandEmpty,
+        MovableIsDownX,
+        RobotAtThrowPose,
+    }
+
+    # Pick cube operator.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    held = Variable("?held", MujocoMovableObjectType)
+
+    PickCubeOperator = LiftedOperator(
+        "pick_cube",
+        [robot, held],
+        preconditions={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [held]),
+        },
+        add_effects={LiftedAtom(Holding, [robot, held])},
+        delete_effects={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [held]),
+        },
+    )
+
+    # Move to throw pose operator.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    target = Variable("?target", MujocoMovableObjectType)
+    held = Variable("?held", MujocoMovableObjectType)
+
+    MoveToThrowPoseOperator = LiftedOperator(
+        "move_to_throw_pose",
+        [robot, target, held],
+        preconditions={LiftedAtom(Holding, [robot, held])},
+        add_effects={LiftedAtom(RobotAtThrowPose, [robot, target])},
+        delete_effects=set(),
+    )
+
+    # Toss operator. A toss is the environment's only irreversible action, so the
+    # barrier is a parameter purely to express the side change it cannot undo.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    held = Variable("?held", MujocoMovableObjectType)
+    target = Variable("?target", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    TossFromWindupOperator = LiftedOperator(
+        "toss_from_windup",
+        [robot, held, target, barrier],
+        preconditions={
+            LiftedAtom(Holding, [robot, held]),
+            LiftedAtom(RobotAtThrowPose, [robot, target]),
+            LiftedAtom(MovableIsDownX, [held, barrier]),
+        },
+        add_effects={
+            LiftedAtom(MovableInGoalRegion, [held]),
+            LiftedAtom(HandEmpty, [robot]),
+        },
+        delete_effects={
+            LiftedAtom(Holding, [robot, held]),
+            LiftedAtom(MovableIsDownX, [held, barrier]),
+        },
+    )
+
+    # One PyBullet simulator for every controller: a fresh controller is ground per
+    # sampling attempt, and one client connect plus robot reload each time dominates.
+    assert initial_state is not None
+    pybullet_sim = PyBulletSim(initial_state, rendering=False)
+    shelf_controllers = shelf_skills.create_lifted_controllers(
+        action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
+    )
+    tossing_controllers = tossing_skills.create_lifted_controllers(
+        action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
+    )
+
+    # Controllers. The pick is shelf's, which already grasps a cube off the ground.
+    LiftedPickCubeController = _restate_controller_variables(
+        shelf_controllers["pick_shelf"], PickCubeOperator.parameters
+    )
+    LiftedMoveToThrowPoseController = _restate_controller_variables(
+        tossing_controllers["move_to_throw_pose"], MoveToThrowPoseOperator.parameters
+    )
+    LiftedTossFromWindupController = _restate_controller_variables(
+        tossing_controllers["toss_from_windup"], TossFromWindupOperator.parameters
+    )
+
+    # Finalize the skills.
+    skills = {
+        LiftedSkill(PickCubeOperator, LiftedPickCubeController),
+        LiftedSkill(MoveToThrowPoseOperator, LiftedMoveToThrowPoseController),
+        LiftedSkill(TossFromWindupOperator, LiftedTossFromWindupController),
+    }
+
+    # Every scene object is a movable, so lifted typing cannot tell the bin from the
+    # barrier and grounding exhaustively offers the planner throws at the barrier.
+    ground_operators = _create_ground_operators(
+        initial_state,
+        [PickCubeOperator, MoveToThrowPoseOperator, TossFromWindupOperator],
+    )
+
+    # Finalize the models.
+    return SesameModels(
+        observation_space,
+        state_space,
+        action_space,
+        transition_fn,
+        types,
+        predicates,
+        observation_to_state,
+        state_abstractor,
+        goal_deriver,
+        skills,
+        ground_operators=ground_operators,
+    )
+
+
+def _restate_controller_variables(
+    controller: LiftedParameterizedController,
+    variables: Sequence[Variable],
+) -> LiftedParameterizedController:
+    """Re-declare a controller's object signature to match an operator's parameters.
+
+    LiftedSkill requires the two to be equal and Variable compares by name and type, but
+    an operator's effects can only mention its own parameters: the toss changes atoms
+    about the bin and the barrier, and move_to_throw_pose's target is typed too loosely
+    for RobotAtThrowPose to accept. Every controller here reads its objects by leading
+    index, so the extra trailing ones are passed through untouched rather than sliced
+    off -- GroundSkill separately requires the controller to keep all of them.
+    """
+    return LiftedParameterizedController(
+        variables, controller.controller_cls, params_space=controller.params_space
+    )
+
+
+def _create_ground_operators(
+    initial_state: ObjectCentricState,
+    operators: list[LiftedOperator],
+) -> set[GroundOperator]:
+    """Ground operators using known object bindings for this environment."""
+    name_to_obj: dict[str, Object] = {obj.name: obj for obj in initial_state}
+    robots = initial_state.get_objects(MujocoTidyBotRobotObjectType)
+    assert len(robots) == 1, f"Expected one robot, got {robots}"
+    param_to_object = {
+        "?robot": robots[0],
+        "?held": name_to_obj[_get_unique_name(name_to_obj, CUBE_NAME_PREFIX)],
+        "?target": name_to_obj[_get_unique_name(name_to_obj, BIN_NAME_PREFIX)],
+        "?barrier": name_to_obj[BARRIER_NAME],
+    }
+    ground_ops: set[GroundOperator] = set()
+    for operator in operators:
+        objects = tuple(param_to_object[param.name] for param in operator.parameters)
+        ground_ops.add(operator.ground(objects))
+    return ground_ops
+
+
+def _get_unique_name(name_to_obj: dict[str, Object], prefix: str) -> str:
+    """Get the one object name starting with the given prefix."""
+    matches = sorted(n for n in name_to_obj if n.startswith(prefix))
+    assert len(matches) == 1, f"Expected one {prefix!r} object, got {matches}"
+    return matches[0]

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -1,0 +1,105 @@
+"""Tests for tidybot3d_tossing3D.py."""
+
+import kinder
+import pytest
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+from kinder_models.dynamic3d.tossing.state_abstractions import MovableInGoalRegion
+from relational_structs import GroundAtom
+
+from kinder_bilevel_planning.agent import BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+kinder.register_all_environments()
+
+ENV_MODEL_NAME = "tidybot3d_tossing3D"
+
+
+def test_tidybot3d_tossing_bilevel_planning():
+    """Tests for bilevel planning in the Tossing3D environment."""
+    num_objects = 1
+    env = kinder.make(f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array")
+
+    if MAKE_VIDEOS:
+        env = RecordVideo(env, "unit_test_videos", name_prefix="TidyBot3D-tossing3d")
+
+    seed = 125
+    obs, info = env.reset(seed=seed)
+
+    env_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME,
+        env.observation_space,
+        env.action_space,
+        num_objects=num_objects,
+    )
+    agent = BilevelPlanningAgent(
+        env_models,
+        seed=seed,
+        max_abstract_plans=1,
+        samples_per_step=5,
+        planning_timeout=600.0,
+        max_skill_horizon=400,
+    )
+
+    agent.reset(obs, info)
+    for _ in range(4000):
+        action = agent.step()
+        obs, reward, terminated, truncated, info = env.step(action)
+        agent.update(obs, reward, terminated or truncated, info)
+        if (
+            terminated
+            or truncated
+            or len(agent._current_plan) == 0  # pylint: disable=protected-access
+        ):
+            break
+
+    else:
+        assert False, "Did not terminate successfully"
+
+    # The plan is refined in a separate simulator, so executing it is what shows the
+    # model is faithful rather than merely self-consistent.
+    final_state = env_models.observation_to_state(obs)
+    cube = final_state.get_object_from_name("cube_0")
+    final_atoms = env_models.state_abstractor(final_state).atoms
+    assert GroundAtom(MovableInGoalRegion, [cube]) in final_atoms
+
+    env.close()
+
+
+def test_tidybot3d_tossing_skills_ground_with_every_operator_parameter():
+    """The toss and the move name objects their controllers never read.
+
+    Both are given the operator's whole parameter tuple rather than the subset the
+    controller uses, which is what lets GroundSkill pair the two.
+    """
+    env = kinder.make("kinder/Tossing3D-o1-v0")
+    env_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME, env.observation_space, env.action_space, num_objects=1
+    )
+
+    operator_to_skill = {s.operator: s for s in env_models.skills}
+    assert env_models.ground_operators is not None
+    for ground_operator in env_models.ground_operators:
+        assert ground_operator.parent is not None
+        skill = operator_to_skill[ground_operator.parent]
+        ground_skill = skill.ground(tuple(ground_operator.parameters))
+        assert tuple(ground_skill.controller.objects) == tuple(
+            ground_operator.parameters
+        )
+
+    env.close()
+
+
+def test_tidybot3d_tossing_rejects_the_two_cube_variant():
+    """The single-cube limit is reported here, not from inside the abstractor."""
+    env = kinder.make("kinder/Tossing3D-o1-v0")
+
+    with pytest.raises(NotImplementedError):
+        create_bilevel_planning_models(
+            ENV_MODEL_NAME,
+            env.observation_space,
+            env.action_space,
+            num_objects=2,
+        )
+
+    env.close()


### PR DESCRIPTION
Adds `tidybot3d_tossing3D` bilevel planning models — a three-operator pick / move-to-throw-pose / toss decomposition over the Tossing3D state abstractions and parameterized controllers — plus an end-to-end test that plans and executes. Measured at branch head `97ce2f8`: a plan is found **20/20** on seeds 0–19 and **80/80** on seeds 0–79, and the environment reaches the goal on **20/20** and **80/80**. Refinement does real work — **31/93** sampling attempts rejected over seeds 0–19 — and the rejections fall where they should, on the throw *pose* rather than on the throw. One defect survives and is not fixed here: the refiner's simulator and the environment still disagree about where the cube lands by up to **0.100 m**, which currently costs **0/80** seeds, but by a margin thinner than the error itself.

## Question / goal

Can Tossing3D be solved by bilevel planning — a symbolic operator set over the existing predicates, refined into the existing parameterized controllers — and how reliably?

## Background

`kinder-bilevel-planning` carries one env model per environment in `env_models/dynamic3d/`, each a `create_bilevel_planning_models(...) -> SesameModels` factory that the dispatcher loads by filename. Three exist: `tidybot3d_shelf3D`, `tidybot3d_sweep3D`, `tidybot3d_base_motion`. Tossing3D had none, so the environment could only be driven by hand-sequenced controllers — there was no symbolic layer, and therefore nothing for a task planner to search over and nothing for a refiner to backtrack in.

The two pieces a model needs both landed on the branch this stacks on. `kinder_models.dynamic3d.tossing.state_abstractions` supplies `Tossing3DStateAbstractor` and the predicates `MovableInGoalRegion`, `OnGround`, `Holding`, `HandEmpty`, `MovableIsDownX`, `RobotAtThrowPose`; `tossing.parameterized_skills` supplies `move_to_throw_pose` and `toss_from_windup`, and `shelf.parameterized_skills` supplies the `pick_shelf` that already grasps a cube off the ground. What was missing was the operator set joining them.

The mechanism that makes this harder than it looks is `ParameterizedControllerTrajectorySampler`: it accepts a sampled trajectory only when `final_abstract_state == ns` — **exact set equality**, not "the add effects hold". An operator whose effects under- or over-specify the achieved abstract state fails refinement even when the skill physically succeeded.

The second mechanism, which turns out to dominate the numbers, is the relationship between two intervals. `move_to_throw_pose` samples its standoff from `TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45)`, and `RobotAtThrowPose` — the operator's only add effect — accepts a standoff inside `THROW_STANDOFF_BOUNDS`. **If the acceptance band contains the sampling range, that add effect is constant-true and the pose stage cannot reject anything**, so every bad standoff has to be discovered later, by throwing from it. `2f3fc90` (*"kinder-models: measure the standoff band `RobotAtThrowPose` accepts"*), this PR's own base, replaced a nominal band with the measured `(1.09, 1.375)`, which cuts the sampling range rather than containing it. That is the change the figures below are measured under, and the **Provenance** note at the end of Results records what they were before it.

## Hypothesis

Bilevel planning can solve Tossing3D using only the pieces already on the parent branch — no new controllers, no new predicates — with the operator set as the single missing component.

The risk was expected to be symbolic rather than physical: under exact set equality, an operator whose effects do not describe the achieved abstract state *exactly* fails refinement on a skill that physically worked. The specific open question was whether `toss_from_windup` should assert `OnGround`, to be settled by running a toss and reading the resulting abstract state rather than by argument.

## Guidance given

Build this as a new feature rather than resurrecting the earlier `josh/feature/tossing3d-bilevel-model` branch: design the operator set, the padding strategy and the test from the sibling models as the pattern, and read the old branch only at the end as a cross-check. Follow `shelf3D` for overall shape and `sweep3D` for the "typing cannot distinguish two same-typed objects" problem. Settle empirically — by running a toss and printing the resulting abstract state — whether the toss should assert `OnGround`. Measure over at least 10 seeds, report counts as `x/y`, and plot per-seed spread rather than only a mean.

Then, after the rebase onto `2f3fc90`: re-measure the whole Results set at the branch head rather than half-correcting it; use the same 20 seeds so the comparison is like-for-like and report any wider seed set separately; instrument by wrapping `ParameterizedControllerTrajectorySampler.__call__`; and where a figure has stopped being *meaningful* rather than merely changing, say so explicitly instead of publishing a changed value that looks comparable.

## Methods

**Operators.** `pick_cube(?robot, ?held)`, `move_to_throw_pose(?robot, ?target, ?held)`, `toss_from_windup(?robot, ?held, ?target, ?barrier)`. Three design points are worth review:

- **The toss names the bin and the barrier although its controller reads neither.** `toss_from_windup`'s controller declares `(?robot)` alone, but exact set equality means the operator must account for every atom that changes: the toss deletes `MovableIsDownX(?held, ?barrier)` and needs `RobotAtThrowPose(?robot, ?target)` as a precondition. Effects can only mention the operator's own parameters, so both objects become parameters.
- **`_restate_controller_variables` re-declares variables and passes every object through.** `LiftedSkill.__post_init__` requires operator parameters and controller variables to be equal, and `Variable` compares by name *and* type — so `move_to_throw_pose`, whose controller types `?target` as `MujocoObjectType`, cannot be paired directly, because `RobotAtThrowPose` requires the narrower `MujocoMovableObjectType`. The adapter re-declares the variables and hands the ground controller the operator's whole object tuple. It deliberately does **not** slice the extra objects off: every controller here reads its objects by leading index, and `GroundSkill.__post_init__` separately asserts `tuple(operator.parameters) == tuple(controller.objects)`, which a sliced controller fails. `test_tidybot3d_tossing_skills_ground_with_every_operator_parameter` covers that.
- **`ground_operators` pins the bindings.** The cube, the bin and the barrier are all `MujocoMovableObjectType` and there are no fixtures in the state, so lifted typing cannot tell them apart. Grounding exhaustively would offer the planner throws aimed at the barrier, each costing a full simulated base motion to reject. The models therefore ship pre-computed ground operators, as `sweep3D` does, resolving names through the `CUBE_NAME_PREFIX` / `BIN_NAME_PREFIX` / `BARRIER_NAME` constants rather than hardcoding them.

**Whether the toss asserts `OnGround`, settled empirically.** It does not. Running the pick / move / toss sequence and reading the abstract state gives `{HandEmpty, MovableInGoalRegion, RobotAtThrowPose}` — no `OnGround`, because `_check_on_ground` requires the cube to be flat (`|qx|, |qy| <= ON_GROUND_TOLERANCE`) as well as at floor height, and a thrown cube usually tumbles to rest on a corner or a side. Asserting it would fail refinement on most physically successful tosses. Measured across seeds 0–79 at the head, the environment's final abstract state is exactly those three atoms on **78/80** seeds and those three plus `OnGround` on **2/80** — so the non-assertion is right far more often than not, but not always, which is exactly the residual failure mode reported under Results.

**`num_objects != 1` raises `NotImplementedError` at the model boundary**, rather than letting `Tossing3DStateAbstractor.__init__`'s single-cube assertion fire from deep inside.

**Measurement.** Seeds 0–19 and, separately, seeds 0–79; `max_abstract_plans=1`, `samples_per_step=5`, `planning_timeout=300 s`, `max_skill_horizon=400`. Each run plans, then executes the plan in `kinder/Tossing3D-o1-v0` and re-derives the abstract state from the environment's final observation. Every sampling attempt is recorded by wrapping `ParameterizedControllerTrajectorySampler.__call__`; note `TrajectorySamplingFailure` is not an `Exception` subclass, so it has to be caught by name. Because the sampler raises *without* returning the abstract state it rejected, that call also temporarily wraps the sampler's own `_state_abstractor`, which is what makes a failed attempt classifiable rather than merely countable. Runs were executed six-way concurrent; re-running seeds 0–19 serially changes no outcome and no count, with a single seed's landing x differing by 2 × 10⁻⁷ m.

**Cross-check against the prior branch, read only after the above was finished and measured** (`07ac1f4`). It reached the same three-operator decomposition, the same decision not to assert `OnGround` for the same measured reason, the same `ground_operators` pinning and the same shared `PyBulletSim`. Two differences: it is written against an older `state_abstractions` (predicates named `NearBin` / `InGoalRegion` / `Reachable`), so it no longer imports against this branch; and its `_pad_controller` **slices** the trailing objects off before constructing the ground controller, which is exactly what `GroundSkill.__post_init__` rejects — the same slicing was tried here and produced an `AssertionError` from `GroundSkill.__post_init__`, which is why the adapter in this PR passes objects through instead. Nothing in it changed the design shipped here.

## Results

**Plans found 20/20 on seeds 0–19 and 80/80 on seeds 0–79. Goal reached in the environment 20/20 and 80/80.** No seed misses in either set. Refinement is doing real work rather than accepting its first draw: **31/93** sampling attempts rejected over seeds 0–19 (**121/368** over 0–79), with the accepted toss being the first attempt on **18/20** seeds (**75/80**).

| | seeds 0–19 | seeds 0–79 |
| --- | --- | --- |
| plans found | 20/20 | 80/80 |
| goal reached in the environment | 20/20 | 80/80 |
| sampling attempts | 93 | 368 |
| sampling failures | 31/93 | 121/368 |
| accepted toss was the first attempt | 18/20 | 75/80 |
| `pick_cube` rejected | 4/26 | 15/102 |
| `move_to_throw_pose` rejected | 25/45 | 101/181 |
| `toss_from_windup` rejected | 2/22 | 5/85 |
| `move_to_throw_pose` rejected *for a failed `RobotAtThrowPose`* | 22/45 | 88/181 |
| seeds with ≥1 such pose rejection | 12/20 | 40/80 |

**The `RobotAtThrowPose` row is the mechanism, and it is the reason the rest of the table looks the way it does.** With the measured band `(1.09, 1.375)` cutting the sampler's `(1.25, 1.45)`, the pose stage rejects **22/45** attempts on **12/20** seeds (**88/181** on **40/80**). Search pressure therefore lands on the cheap symbolic check instead of on a full simulated throw, and the toss — which used to absorb it — now fails only **2/22** and **5/85**. Total attempts *fell* (133 → 93 over the same 20 seeds) while reliability rose, because rejecting a standoff costs a base motion and rejecting a throw costs a base motion plus a ballistic rollout.

Three panels: per-seed landing x for seeds 0–19 under both bands (paired, same seeds); all 80 seeds at the branch head against the goal region's near edge; and per-operator rejection rates, counts labelled.

TODO: drop kb115-remeasure.png here — http://agni:8765/kb115-remeasure.png

**The toss failure taxonomy is a null result.** Over seeds 0–19 there are **2** toss failures and over 0–79 there are **5**. In both sets, **0** of them are "the throw fell short of the goal region" — every single one is a physically successful throw rejected purely for an unexpected `OnGround`, i.e. a cube that happened to settle flat *and* inside the goal region, putting an atom into the achieved state that the operator does not assert. The barrier sub-count that would sit under "fell short" — how many short throws did not even clear the barrier — therefore has an empty denominator, **0/0**, and is reported as a **null result** rather than as a changed number. The pose stage now rejects the standoffs that used to produce short throws, so they never reach the toss at all. The five affected seeds are 6, 7, 32, 46 and 58, and **0/5** of them went on to miss the goal — the refiner discarded a good throw and found another one.

**The refiner and the environment still disagree, and this has not been fixed.** On every seed the refiner's own recorded final state satisfies the goal — refinement cannot return otherwise — but the environment does not always reproduce the trajectory the refiner accepted. Median |predicted − achieved| landing x is **0.002 m** when the toss was accepted first try and **0.020 m** when it followed a discarded attempt (over 0–79: **0.001 m** and **0.004 m**). The tail is what matters: max |predicted − achieved| is **0.0915 m** over seeds 0–19 and **0.1000 m** over 0–79 (seed 76).

**That this costs 0/80 seeds is not the same as it being harmless.** `Tossing3D-o1.json` declares `blocks_goal_region` over x ∈ [1.9, 2.1], inflated slightly downward at check time (an effective near edge around 1.85). The shortest landing over seeds 0–79 is x = **1.953**, so the whole population sits roughly 0.05–0.10 m clear of failing — the same order as the largest divergence observed. Measured against the effective edge, the closest call is **seed 78**, whose 0.094 m divergence is only **0.012 m** inside its own 0.106 m margin; seeds 52, 75 and 57 are all within 0.02 m of the same crossing. Against the *declared* 1.9 edge the margins are thinner still.

Localising the cause — **carried forward from the first measurement and not re-run at the head**: replaying the refined action sequence through the *same* `transition_fn`, in the *same* model simulator, reproduced the environment rather than the refiner's record, with divergence beginning at the first arm action of the windup while the cube was still held. On that reading the planning-time rollout is the outlier — `sim.set_state(x)` does not restore everything the grasp depends on, and a toss attempt following a discarded one starts from contaminated hidden state. What *is* re-verified at the head is the symptom: the refiner and the environment still disagree, by up to 0.100 m. This is the shared `transition_fn` pattern all three sibling models use, not something specific to this model; Tossing3D is just where it bites, because a throw is ballistic and open-loop.

A related fact, measured rather than assumed: `toss_from_windup` is **not** deterministic given the same state and parameters, because the windup's arm motion planning is randomised. Accepted tosses at the head emit either 33 or 34 actions across the 80 seeds. Retrying the toss is therefore genuine search, not wasted work, even though `sample_parameters` ignores its `rng`.

**Wall-clock is not comparable across measurements and no claim is made about it.** At the head this host gives a median 1.7 s to the first refined plan over seeds 0–19 (min 1.4, max 5.5) and 1.8 s over 0–79 (min 1.4, max 5.5). The first measurement reported 2.7 s (min 1.9, max 11.5) — but re-running the *forced old band* on this host gives 1.9 s (min 1.4, max 8.5) while reproducing every other original count exactly, so the difference is the machine and its warm IKFast cache, not the band or the code. Treat all of these as host-local.

**Local gate**, re-run at branch head, per-file rather than repo-wide (`run_autoformat.sh` rewrites ~28 unrelated files from tool-version drift):

- `pytest tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py` — **3/3** passed
- `black --check`, `isort --check-only`, `docformatter --check` on both new files — clean, at a fixed point
- `mypy .` — **Success: no issues found in 59 source files**
- `pylint --rcfile=.pylintrc` on both new files — **10.00/10**, with the plugin verified loaded (a probe file using `np.random.rand` reports `C9900 np-random-disallowed`, rather than the silent `E0013` pass a wrong `PYTHONPATH` gives)

One caveat on that gate: it was run with this host's tool versions (`pylint` 4.0.7, `pytest` 9.1.1), which are newer than the ones CI resolves — the package pins `pytest<9.1`. The newer `pylint` additionally emits 14 `R0022`/`W0012` option-value warnings against `.pylintrc` itself; those are config drift, not findings in either new file.

**CI on this PR fails, and the reason has moved since this branch was opened.** Current state at `97ce2f8`: `autoformat`, `linting` and `static-type-checking` all **pass**; only `unit-tests` **fails**, and it fails on exactly the three tests in this file, all with `ImportError: cannot import name 'CONTROL_SCHEDULE_TIMESTEP' from 'kinder.envs.dynamic3d.mujoco_utils'`, raised from `kinder_models.dynamic3d.tossing.parameterized_skills` at import time.

The original diagnosis — blocked on `kindergarden` PR #156, with three jobs expected to fail — is out of date in both halves. **#156 is merged** (2026-08-14 12:23 UTC), and so is **#159**, the bump to `kindergarden` 0.2.3 (2026-08-14 18:37 UTC), which is the first version containing the constant. The remaining blocker is distribution, not review: **PyPI still serves 0.2.2**, and `kinder-bilevel-planning` declares `kindergarden>=0.2.2`, so CI resolves 0.2.2 and fails at import. Publishing 0.2.3 to PyPI should turn `unit-tests` green with no change to this branch. Installing `kindergarden` from source at `379f7cd` locally is what makes the same three tests pass here.

### Provenance

This Results section was re-measured at `97ce2f8` after the branch was rebased; the first measurement is superseded and is recorded here rather than left in place, because it describes a configuration the branch no longer has.

The first measurement reported **16/20** goal reached, with misses on seeds **2, 9, 10, 11**, 133 sampling attempts, 62 failures, the accepted toss first-try on 9/20, and `pick_cube` 3/24 / `move_to_throw_pose` 5/35 / `toss_from_windup` 54/74 (52 fell short, 12 of those without clearing the barrier). It was taken with `THROW_STANDOFF_BOUNDS = (1.20, 1.65)`, which strictly contains the sampler's `(1.25, 1.45)` — so `move_to_throw_pose`'s only add effect was constant-true, **0/35** attempts were ever rejected for a failed `RobotAtThrowPose`, and the toss absorbed all the search. The band became the measured `(1.09, 1.375)` in `2f3fc90`, which is **this PR's own base**, authored 2026-08-14 09:47 — roughly 14 hours *after* `97ce2f8` itself (2026-08-13 19:45). The rebase moved the base underneath the measurement and the measurement was not redone at the time.

**Forcing `(1.20, 1.65)` back in and re-running seeds 0–19 with the current instrumentation reproduces every original count exactly** — 16/20, the same four miss seeds, 133 attempts, 62 failures, 9/20 first-attempt tosses, 3/24, 5/35, 54/74 (52 short, 12 not clearing the barrier, 2 on an unexpected `OnGround`), and seed 9's refiner `2.0705` against environment `1.7859`. That is what establishes the difference as the band rather than the instrumentation, and it is why the figures above can be trusted as a like-for-like replacement rather than a second, differently-measured opinion.

Two artefacts of the first measurement have **not** been regenerated: the two videos (seed 0 success, seed 9 failure). Seed 9 is no longer a failure, so they no longer illustrate anything current.

## Recommendation

Merge behind the parent branch, and expect `unit-tests` to stay red until `kindergarden` 0.2.3 reaches PyPI — no change to this branch is needed for that. Three follow-ups, none belonging in this PR:

1. **Fix the `transition_fn` fidelity gap where it lives — the shared pattern, not this model. This is the live defect, and the 80/80 headline makes it easier to overlook, not less real.** It no longer costs a seed, but only because every accepted throw happens to land 0.05–0.10 m clear of the goal region's near edge while the worst observed refiner-to-environment divergence is 0.100 m; seed 78 clears by 0.012 m. That is a coincidence of this scene's geometry, not a property of the model, and it would not survive a tighter goal region, a longer throw, or a scene change. The gap is invisible in `shelf3D` and `sweep3D` only because those tasks are quasi-static; a refiner that accepts trajectories the environment will not reproduce is a problem for any ballistic or contact-rich skill. The obvious directions are making `set_state` restore what the grasp depends on, or re-verifying an accepted trajectory by replay before returning it; both are larger than this PR should carry, and the second is a `bilevel_planning` change rather than a `kinder-baselines` one.
2. **`OnGround`'s flatness clause makes a successful toss unrepresentable some of the time**, and it is now the *only* reason a toss is ever rejected: 2/22 of toss attempts over seeds 0–19 and 5/85 over 0–79, on seeds 6, 7, 32, 46 and 58. None of those five went on to miss, so the current cost is wasted search rather than lost success — but the operator cannot fix it, since it cannot predict the cube's resting orientation. The fix belongs in `_check_on_ground`, or in a predicate that separates "resting at floor height" from "axis-aligned".
3. **`num_objects=2` needs an operator that says which cube a throw is aimed at**, which `state_abstractions` already flags as its own TODO. Until then the model raises rather than mis-planning.
