### PR TITLE
kinder-bilevel-planning: let Tossing3D models plan against a scene variant

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -1,4 +1,8 @@
-"""Bilevel planning models for the TidyBot3D Tossing3D environment."""
+"""Bilevel planning models for the TidyBot3D Tossing3D environment.
+
+TODO: support Tossing3D-o2. It needs a goal naming each cube and operators that say
+which cube a throw is aimed at; the state abstractor asserts one cube today.
+"""
 
 from collections.abc import Sequence
 from pathlib import Path
@@ -49,8 +53,14 @@ def create_bilevel_planning_models(
     observation_space: Space,
     action_space: Space,
     num_objects: int = 1,
+    task_config_path: str | None = None,
 ) -> SesameModels:
-    """Create the env models for TidyBot Tossing3D."""
+    """Create the env models for TidyBot Tossing3D.
+
+    `task_config_path` defaults to the installed scene. Pass one to plan against a
+    variant, which must be the same scene the caller's env was built from -- the model
+    and the env disagreeing about geometry is silent, not an error.
+    """
     if num_objects != 1:
         raise NotImplementedError(
             f"Tossing3D bilevel planning supports one cube, got {num_objects}. The "
@@ -60,11 +70,12 @@ def create_bilevel_planning_models(
     assert isinstance(observation_space, ObjectCentricBoxSpace)
     assert isinstance(action_space, TidyBot3DRobotActionSpace)
 
-    task_config_path = str(
-        Path(kinder.__file__).parent
-        / "envs/dynamic3d/tasks/Tossing3D"
-        / f"Tossing3D-o{num_objects}.json"
-    )
+    if task_config_path is None:
+        task_config_path = str(
+            Path(kinder.__file__).parent
+            / "envs/dynamic3d/tasks/Tossing3D"
+            / f"Tossing3D-o{num_objects}.json"
+        )
     sim = ObjectCentricTidyBot3DEnv(
         task_config_path=task_config_path,
         num_objects=num_objects,

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -1,5 +1,7 @@
 """Tests for tidybot3d_tossing3D.py."""
 
+from pathlib import Path
+
 import kinder
 import pytest
 from conftest import MAKE_VIDEOS
@@ -13,6 +15,8 @@ from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 kinder.register_all_environments()
 
 ENV_MODEL_NAME = "tidybot3d_tossing3D"
+
+_TEST_TASKS = Path(__file__).parent.parent.parent / "test_tasks"
 
 
 def test_tidybot3d_tossing_bilevel_planning():
@@ -86,6 +90,33 @@ def test_tidybot3d_tossing_skills_ground_with_every_operator_parameter():
         assert tuple(ground_skill.controller.objects) == tuple(
             ground_operator.parameters
         )
+
+    env.close()
+
+
+def test_tidybot3d_tossing_abstracts_against_the_scene_it_was_given():
+    """A model built from an explicit scene reads that scene's goal region."""
+    env = kinder.make("kinder/Tossing3D-o1-v0")
+    obs, _ = env.reset(seed=125)
+
+    variant_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME,
+        env.observation_space,
+        env.action_space,
+        num_objects=1,
+        task_config_path=str(_TEST_TASKS / "tidybot-tossing3d_near_goal-o1.json"),
+    )
+    default_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME, env.observation_space, env.action_space, num_objects=1
+    )
+
+    # The variant's goal region covers where the cube starts, so an untouched reset
+    # satisfies the goal under it and cannot under the installed scene.
+    state = variant_models.observation_to_state(obs)
+    cube = state.get_object_from_name("cube_0")
+    in_goal_region = GroundAtom(MovableInGoalRegion, [cube])
+    assert in_goal_region in variant_models.state_abstractor(state).atoms
+    assert in_goal_region not in default_models.state_abstractor(state).atoms
 
     env.close()
 

--- a/kinder-bilevel-planning/tests/test_tasks/tidybot-tossing3d_near_goal-o1.json
+++ b/kinder-bilevel-planning/tests/test_tasks/tidybot-tossing3d_near_goal-o1.json
@@ -1,0 +1,210 @@
+{
+    "description": "Tossing3D-o1 with blocks_goal_region moved onto the cube's own start region, so which scene a model was built from is visible in one abstract state.",
+    "variant_description": "Only blocks_goal_region differs from the shipped scene.",
+    "variant_specific_description": "One cube, already in the goal region at reset.",
+    "robots": {
+        "tidybot": {
+            "robot": {}
+        }
+    },
+    "scene": "lab2",
+    "regions": {
+        "bin_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    2.0,
+                    0.0,
+                    2.0,
+                    0.0
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    0,
+                    0
+                ]
+            ]
+        },
+        "blocks_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    0.5,
+                    -0.25,
+                    0.75,
+                    0.25
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    -45,
+                    45
+                ]
+            ],
+            "rgba": [
+                0.2,
+                0.6,
+                0.2,
+                0.0
+            ]
+        },
+        "blocks_goal_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    0.4,
+                    -0.35,
+                    0.0,
+                    0.85,
+                    0.35,
+                    0.1
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    -360,
+                    360
+                ]
+            ],
+            "rgba": [
+                0.2,
+                0.6,
+                0.2,
+                0.0
+            ]
+        },
+        "barrier_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    1.3,
+                    0.0,
+                    1.301,
+                    0.001
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    0,
+                    0
+                ]
+            ]
+        },
+        "robot_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    -0.05,
+                    -0.05,
+                    0.05,
+                    0.05
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    -5,
+                    5
+                ]
+            ],
+            "rgba": [
+                0.2,
+                0.6,
+                0.2,
+                0.0
+            ]
+        }
+    },
+    "objects": {
+        "cube": {
+            "cube_0": {
+                "size": 0.025,
+                "rgba": [
+                    0.2,
+                    0.6,
+                    0.2,
+                    1
+                ],
+                "mass": 0.1
+            }
+        },
+        "cuboid": {
+            "cuboid_barrier": {
+                "size": [
+                    0.03,
+                    5.0,
+                    0.1
+                ],
+                "rgba": [
+                    0.918,
+                    0.894,
+                    0.835,
+                    1.0
+                ],
+                "mass": 10.0
+            }
+        },
+        "bin": {
+            "bin_0": {
+                "length": 0.3,
+                "width": 0.3,
+                "height": 0.2,
+                "wall_thickness": 0.02,
+                "rgba": [
+                    0.8,
+                    0.8,
+                    0.0,
+                    1.0
+                ]
+            }
+        }
+    },
+    "cameras": {
+        "task_view": {
+            "position": [
+                1,
+                -2,
+                2
+            ],
+            "lookat": [
+                1,
+                0,
+                0
+            ],
+            "fovy": 42,
+            "resolution": [
+                640,
+                480
+            ]
+        }
+    },
+    "initial_state": [
+        [
+            "on",
+            "robot",
+            "robot_init_region"
+        ],
+        [
+            "on",
+            "cube_0",
+            "blocks_init_region"
+        ],
+        [
+            "on",
+            "bin_0",
+            "bin_init_region"
+        ],
+        [
+            "on",
+            "cuboid_barrier",
+            "barrier_init_region"
+        ]
+    ],
+    "goal_state": [
+        [
+            "on",
+            "cube_0",
+            "blocks_goal_region"
+        ]
+    ]
+}


### PR DESCRIPTION
`create_bilevel_planning_models` for Tossing3D takes an optional `task_config_path`, so a model can be built against a scene variant instead of the installed `Tossing3D-o1.json`. Used to prototype four candidate geometry changes over 30 seeds. **The shipped scene is not a broken benchmark — it is 24/30 — but its scoring box is wrong in two ways at once, and one of them is worth fixing upstream.** The 0.20 m near wall is intended difficulty, and the recommendation is to change the goal region's *definition*, not the geometry.

## Question / goal

Make the scene override a properly tested capability, then use it to answer: is Tossing3D's shipped geometry a defect, or intended difficulty with zero margin?

## Background

`blocks_goal_region` in `Tossing3D-o1.json` is declared as `[[1.90, -0.10, 0.0, 2.10, 0.10, 0.10]]` with `"target": "ground"`. `Ground._create_regions` (`objects/base.py`) then inflates every ground region by `ground_placement_threshold = 0.05` on all three axes, clamping `z_min` at 0 — so the box that actually scores is **x [1.85, 2.15], y [-0.15, 0.15], z [0, 0.15]**.

`bin_0` sits at x = 2.0 with `length` = `width` = 0.3 and `wall_thickness` 0.02, so its outer footprint is **exactly [1.85, 2.15] x [-0.15, 0.15]** and its interior is [1.87, 2.13]. The declared numbers describe the bin's interior; the inflation — a *placement* tolerance, meant for putting objects down — pushes the scoring boundary out onto the outer face of a 0.20 m wall, and 0.15 m up into the air above it.

This follows `kindergarden` PR #126, which moved the bin back inside `blocks_goal_region` after upstream commit `1183de7` had left it 23 cm downrange of the box that scores. That fix established the intent: the bin *is* the goal. What it did not touch is the coincidence between the scoring box and the bin's outer shell.

The prompt for looking again is #115's result: on 20 seeds the refiner's own simulator recorded a successful throw on 20/20 while the environment delivered 16/20, and every miss came to rest at x ~ 1.786 — the rest position of a cube that strikes the near wall and rebounds.

Until this PR there was no way to ask the question, because the model hardcoded the installed task JSON.

## Hypothesis

The 0.20 m near wall standing exactly on the scoring boundary is what converts near-miss throws into failures; if so, holding the throw fixed and lowering only the wall should turn those failures into successes.

## Guidance given

Add a fixture scene and a behavioural test proving the override is honoured — cheap, not a full planning episode — and confirm it fails without the parameter first. Verify the override is *faithful*: re-running the shipped scene through `task_config_path` must reproduce the default-path numbers (seed 11 -> 1.7860, seed 0 -> 2.0450, seed 5 -> 1.9137), re-derived rather than trusted. Then prototype variants — low rim, goal region pulled in, bin nudged downrange — over at least 10 seeds, reported as `x/y` with per-seed spread plotted, and **do not repeat the confound**: the planner replans per scene and aims shorter when a low rim makes short throws safe, so design a comparison that holds the throw fixed. Check what the inflation actually does rather than assuming +0.05. Do not modify the `kindergarden` submodule; if upstream must change, say so. A later addition: prototype a fourth variant, `blocks_goal_region` with `"target": "bin_0"`, and verify two things not taken on trust — whether object-targeted ranges are local, and whether a region attached to a *movable* follows it.

## Methods

**What ships.** `task_config_path: str | None = None`, defaulting to the installed scene; a fixture scene `tests/test_tasks/tidybot-tossing3d_near_goal-o1.json` differing from the shipped one only in `blocks_goal_region`, which it moves onto the cube's own start region; and one test asserting the contrast — the untouched reset state satisfies `MovableInGoalRegion` under a model built from the variant and not under one built from the installed scene. None of the geometry variants below are committed; they are prototypes.

**Faithfulness.** All 30 seeds were re-run with the *shipped* JSON passed explicitly through `task_config_path`, against `TidyBot3DEnv(task_config_path=...)` rather than `kinder.make`. On the 20 seeds shared with #115's run, the final cube x is identical to within 1e-6 and the goal outcome matches on **20/20**; the refiner's `predicted_x` agrees to within 9e-7 on 20/20 (exactly on 17/20, the rest float noise in the model's own rollout). Seeds 11 / 0 / 5 reproduce `1.7860149`, `2.0450487`, `1.9137335`.

**Variants.** All differ from the shipped JSON in exactly one field.

| variant | change | rationale |
| --- | --- | --- |
| shipped | — | control |
| low rim | `bin_0.height` 0.20 -> 0.03 | isolates the wall; not proposed as a fix |
| goal region pulled in | `ranges` -> `[[1.93, -0.10, 0.0, 2.07, 0.10, 0.10]]` | after +0.05 inflation this is [1.88, 2.12], inside the walls |
| bin nudged | `bin_init_region` x 2.0 -> 2.03 | near wall inside the region instead of on its edge |
| bin-anchored region | `"target": "bin_0"`, local `[[-0.13, -0.13, 0.13, 0.13]]` | the interior by construction, and it tracks the bin |
| bin at x = 4.0 | `bin_init_region` x 2.0 -> 4.0 | diagnostic only: the throw with nothing in its way |

30 seeds (0–29) each, `max_abstract_plans=1`, `samples_per_step=5`, `planning_timeout=300 s`, `max_skill_horizon=400`. The initial cube pose is identical to the shipped scene's on **30/30** seeds for every variant, so no variant disturbs the RNG stream.

**The confound, and the design that removes it.** Replanning per scene changes the throw: with a low rim the planner aims ~1.90–1.92 where the shipped scene aims ~2.06–2.08, so a low-rim success is not evidence about the wall. The causal measurement is therefore a **replay**: plan under the shipped scene, then execute that identical refined action sequence — the same 109–118 raw actions, open-loop — under the other geometries. The environment is deterministic, so shipped-replay reproduces shipped exactly.

**Two readings are recorded per run**: at the end of the action sequence (what #115 and every prior number used) and after 300 further hold actions. They matter because the plan ends the instant the toss is over: on 5/30 seeds the cube was above the bin floor when the goal was checked, and on 3 of those (5, 6, 22) it was **airborne** at z = 0.148 / 0.118 / 0.131 — scored because the inflated region is 0.15 m tall. All three settled inside the bin anyway, so no outcome turned on it; successes were 24/30 under both readings.

## Results

**Is the wall the cause? Yes, and it is unambiguous.** Holding the refined throw fixed:

| geometry | throw | cube in goal region |
| --- | --- | --- |
| shipped | shipped plan | **24/30** |
| low rim | *same actions replayed* | **30/30** |
| bin at x = 4.0 | *same actions replayed* | **30/30** |

On each of the 6 shipped failures the identical throw lands well inside the scoring box once the wall is gone:

| seed | shipped | low rim (replay) | no bin (replay) |
| --- | --- | --- | --- |
| 2 | 1.7855 | 1.8945 | 1.9025 |
| 9 | 1.7859 | 1.9123 | 1.9204 |
| 10 | 1.7747 | 1.9184 | 1.9264 |
| 11 | 1.7860 | 1.9106 | 1.9187 |
| 21 | 1.7894 | 1.9072 | 1.9131 |
| 29 | 1.7736 | 1.9270 | 1.9350 |

Low-rim and no-bin resting positions agree to within 10 mm, so the low rim barely perturbs the flight — it is specifically the 0.20 m wall that intercepts these throws.

TODO: drop tossing3d-scene-replay.png here

**Seeing it.** Neither defect is visible in an ordinary recording, because the goal region renders as nothing: `blocks_goal_region` carries `"rgba": [0.2, 0.6, 0.2, 0.0]` — alpha 0.0. Both clips below are therefore rendered from scene copies loaded through this PR's own `task_config_path`, with two **visualisation-only** edits: the goal region's alpha raised 0.00 -> 0.34, so the scoring volume shows as the cyan box, and `bin_0`'s alpha 1.00 -> 0.50, because the scoring volume sits entirely inside the bin's outer surface and an opaque bin hides the very coincidence the clips exist to show. A region is a MuJoCo **site**, which carries no collision geometry, and a geom's alpha is not part of the physics either — replaying the same refined action sequence against the alpha-raised copy and against the installed `Tossing3D-o1.json` gives a **bit-identical** final cube pose (max absolute difference 0.0 across x, y, z and all four quaternion components). Nothing in either clip is an artefact of being able to see the region.

The region's full 3D extent renders, not just a footprint: `Ground._create_regions` emits it as a box `site`, so the cyan box in the clips *is* the scoring volume, 0.15 m tall. Each clip also pairs the rendered view with a to-scale side elevation in the x-z plane, rebuilt per frame from the same recorded state as the caption beneath it, so a paused frame is self-explanatory. Both slow the toss down: one env step is 0.1 s of simulated time and 200 MuJoCo ticks, so the entire flight is about 7 env steps and the collision that decides the outcome happens *between* two consecutive env-step frames. The flight is rendered inside the tick loop instead, at one frame per 5 ms of simulated time.

**1. What blocks the throw.** Seed 10, one refined action sequence — planned once, in the shipped scene — replayed side by side in the shipped scene and in the low-rim diagnostic. The two throws are identical up to the instant of contact. In the shipped scene the cube's centre gets no further than x = 1.8317 with its leading face against the near wall, and it rebounds to rest at **1.7747, outside**; with the rim lowered the identical throw drops past the boundary and rests at **1.9228, inside**. The elevation makes the coincidence measurable: the bin's near wall stands exactly on x = 1.85, which is the scoring boundary, so a cube resting against the outside of that wall has its centre at x = 1.825 — 25 mm short of scoring, however well it was aimed. The **low-rim scene is a diagnostic, not a proposed fix**, for the reason given under Recommendation: it changes the dynamics, and adopting it would make every committed Tossing3D number a re-run.

TODO: drop scene-goalregion-wall-blocks-throw-20260814a.mp4 here

http://agni:8765/scene-goalregion-wall-blocks-throw-20260814a.mp4

**2. What the score actually measures.** Seed 5, shipped geometry, nothing moved. The cyan volume is anchored to the ground and inflated to z [0.0000, 0.1500] — 0.15 m tall — and `_is_terminated` returns `_check_goals()`, so the episode ends the instant the predicate holds. Here it first holds at **z = 0.148 m with the cube still falling**, and the episode is over at env step 105, in mid-air. This one does go on to settle in the bin, as all 3/30 airborne scores did, so no outcome turned on it; what the clip shows is that the measurement stopped on a transient state and never looked at where the cube came to rest. That is what the recommended re-anchoring fixes, and it is a fix to the *measurement*, not to the robot.

TODO: drop scene-goalregion-airborne-scoring-20260814a.mp4 here

http://agni:8765/scene-goalregion-airborne-scoring-20260814a.mp4

**Replanning per scene**, which is what a benchmark change would actually produce:

| variant | goal reached | notes |
| --- | --- | --- |
| shipped | **24/30** | failures 2, 9, 10, 11, 21, 29 |
| low rim | **29/30** | the one miss (seed 4) lands short at 1.818, no wall involved |
| goal region pulled in | **24/30** | *identical* failures, and identical `predicted_x` on 24/30 |
| bin nudged to x = 2.03 | **25/30** | |
| bin-anchored region | **0/30** | no plan found on any seed; see below |

TODO: drop tossing3d-scene-replan.png here

**The bin-anchored region is the right shape and does not work today.** Both things the addition asked me to verify came out in its favour, and a third killed it:

- **Ranges are local.** Declaring `[[-0.13, -0.13, 0.13, 0.13]]` on `bin_0` produces a world bbox of `[1.86, -0.14, 2.14, 0.14]` with the bin at x = 2.0 — local, and inflated by 0.01 rather than the ground's 0.05.
- **It does follow a movable.** Moving `bin_0` to (2.5, 0.3) moves the bbox to `[2.36, 0.16, 2.64, 0.44]`. The site is a child of the object's body and `Region.bbox` reads `sim.data.get_site_xpos`, so tracking is real, not a construction-time snapshot.
- **But z cannot be expressed.** `MujocoObject._create_regions` unpacks `x_start, y_start, x_end, y_end = region_range` — a 6-value range raises `ValueError: too many values to unpack (expected 4)` — and hardcodes the z half-height to `placement_threshold = 0.01` about the object's own origin. For `bin_0` that origin is the centre of its bottom surface, so the scoring slab is z in [-0.01, +0.01] while **a cube resting on the bin floor sits at z = 0.039**. Nothing can ever score. Measured: 0/30, and it fails at planning time rather than execution — the refiner cannot reach a satisfying state, so `run_sesame` returns nothing after ~27–48 s of sampling per seed.

TODO: drop tossing3d-scene-geometry.png here

Two further notes on that variant: `Tossing3DStateAbstractor._check_in_goal_region` hardcodes `self._sim._ground_fixture`, which raises `ValueError: Region blocks_goal_region not found in ground regions` for an object-targeted region — the measurement above used a monkeypatched abstractor. And `_check_goals` handles `["on", "in"]` together, printing *"Warning: Found 'in' predicate for success check, which is not supported. Falling back to 'on' predicate."* — so `in` is in the vocabulary but unimplemented. A bin-anchored region makes it unnecessary.

**How far the bin can move**, since a nudge is one of the candidates (5 seeds each):

| bin x | plans found |
| --- | --- |
| 2.03, 2.10, 2.20, 2.25 | 5/5 |
| 2.30 | 3/5 |
| 2.35, 2.40, 2.60, 2.80, 4.00 | 0/5 |

The limit is ~2.30, and the failure is `assert base_motion_plan is not None` in `run_move_to_throw_pose`: the standoff is computed from the bin (`THROW_STANDOFF_BOUNDS = (1.20, 1.65)`), so past ~2.3 every sampled base pose lands on the barrier at x = 1.3.

**Model-vs-environment divergence** (`|predicted_x - settled x|`, 30 seeds):

| variant | median | max |
| --- | --- | --- |
| shipped | 28.5 mm | 302 mm |
| low rim | 0.5 mm | 91 mm |

The wall does not cause this divergence — #115 localised it to `transition_fn`'s per-step `sim.set_state` — but it *amplifies* it, because a contact event sitting exactly where every throw is aimed turns a millimetre of state-restore error into a 300 mm outcome error. One correction to the figure quoted when this work was briefed: over 30 seeds the low-rim divergence maxes at 91 mm, not <= 7 mm, which held only on the 6-seed subset.

## Recommendation

**The geometry is not the defect; the scoring box is — and fixing the box does not change the score.** The bin's position and its 0.20 m wall are the benchmark: a cube must clear the rim and drop into a 0.26 m mouth, and 24/30 is what that difficulty honestly costs. The 6 failures fail under *every* redefinition tested, because they never cleared the rim — they would have landed at 1.90–1.93 unobstructed, but they arrived at x = 1.85 already below 0.20 m, struck the wall and rebounded to 1.786. No scoring box changes where a cube comes to rest.

What is wrong is that the box that scores is the bin's *outer shell*: 2 cm wider than its mouth on the near side, 0.15 m tall, and anchored to the ground rather than the bin. That is what lets a cube score while still in flight, and it is a metric that can be right for the wrong reason rather than one that is currently wrong.

**Do not change the shipped geometry.** Neither the low rim nor the bin nudge should be adopted: both change the dynamics, so every committed Tossing3D number — the oracle's 10/10, the throw-band sweeps, tonight's reset-policy experiment — becomes a **re-run, not a restatement**, and neither fixes the definition. The low rim in particular buys 29/30 by deleting the difficulty the benchmark exists to pose.

**The fix worth making upstream, in `kindergarden`, is the bin-anchored region — and it needs a small code change first.** It cannot stack on this PR. Two commits, in order:

1. **`MujocoObject._create_regions` should accept 6-value ranges**, exactly as `Ground._create_regions` already does ten lines away in the same file. This is the blocker: without it an object region's z is locked to +/-0.01 about the object's origin.
2. **Then `Tossing3D-o1.json`**: `blocks_goal_region` becomes `"target": "bin_0"` with local ranges `[[-0.11, -0.11, 0.0, 0.11, 0.11, 0.10]]`. After the object inflation of 0.01 that is x [1.88, 2.12] and z [-0.01, 0.11] in the bin's frame — inside the walls, tall enough to contain a cube resting on the bin floor at 0.039, and short enough that a cube 0.15 m in the air no longer scores. It also makes the region **move with the bin**, which is impossible while it is ground-anchored and which no amount of editing the world coordinates achieves.

`kinder_models`' `Tossing3DStateAbstractor._check_in_goal_region` would then need to dispatch on the region's target rather than assuming the ground fixture. That is ours and belongs in a follow-up here.

**The staleness cost of that route is measured, and it is zero.** It changes only the goal test, not the dynamics, so no run has to be repeated to know what it would have done — recorded trajectories can be re-scored. Applying the proposed box (bin-local x [1.88, 2.12], z [-0.01, 0.11]) to the 30 settled states here gives **24/30, with zero disagreements against the shipped box, seed for seed**. Pulling the ground region in to [1.88, 2.12] likewise changes 0 of 30 outcomes. So the committed Tossing3D numbers are not made stale by this fix; only their *definition* is tightened.

That cuts both ways, and it is the honest counter-argument: the measured benefit today is 0/30 changed outcomes. The case for doing it is that the region tracking the bin is already on the plan and is unreachable while it is ground-anchored, and that a 0.15 m-tall box will eventually score a cube in flight on a seed where it does not then land — the three airborne scores here were luck, not margin.

**If upstream will not take the code change**, the fallback is variant 3 alone — `ranges` -> `[[1.93, -0.10, 0.0, 2.07, 0.10, 0.10]]` in `Tossing3D-o1.json`. It fixes x honestly for zero measured cost (24/30, identical seeds), but leaves the region 0.15 m tall and still ground-anchored, so a cube in flight still scores and the region still does not follow the bin. It is worth less than it looks.

**Note on CI**: this PR's checks fail at collection, inherited from the parent stack being blocked on `kindergarden` #156. Locally the whole suite collects (79 tests) and `tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py` is 4/4.

