### PR TITLE
Add bilevel planning models for VegaPickPlace3D

### DIFF
--- a/kinder-bilevel-planning/pyproject.toml
+++ b/kinder-bilevel-planning/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
    "hydra-core",
    "hydra-joblib-launcher",
    "omegaconf",
-   "kindergarden>=0.2.2",
+   "kindergarden>=0.2.3",
    "prpl_utils>=0.0.7",
    "relational_structs>=0.0.1",
    "tomsgeoms2d>=0.0.1",

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d_v2/vega_pickplace3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d_v2/vega_pickplace3d.py
@@ -1,0 +1,163 @@
+"""Bilevel planning models for the VegaPickPlace3D environment."""
+
+import numpy as np
+from bilevel_planning.structs import (
+    LiftedSkill,
+    SesameModels,
+)
+from gymnasium.spaces import Space
+from kinder.envs.kinematic3d_v2.object_types import (
+    Kinematic3Dv2GraspArmRobotType,
+    Kinematic3Dv2PointType,
+)
+from kinder.envs.kinematic3d_v2.vega_pickplace3d import (
+    BimanualArmJointDeltaGraspActionSpace,
+    ObjectCentricVegaPickPlace3DEnv,
+    VegaPickPlace3DEnvConfig,
+    VegaPickPlace3DObjectCentricState,
+)
+from kinder_models.kinematic3d_v2.vega_pickplace3d.parameterized_skills import (
+    create_lifted_controllers,
+)
+from kinder_models.kinematic3d_v2.vega_pickplace3d.state_abstractions import (
+    PREDICATES,
+    HandEmpty,
+    Holding,
+    NotHeld,
+    On,
+    create_goal_deriver,
+    create_state_abstractor,
+)
+from numpy.typing import NDArray
+from relational_structs import (
+    LiftedAtom,
+    LiftedOperator,
+    ObjectCentricState,
+    Variable,
+)
+from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
+
+
+def create_bilevel_planning_models(
+    observation_space: Space,
+    action_space: Space,
+    config: VegaPickPlace3DEnvConfig | None = None,
+    prefer_ompl: bool = True,
+) -> SesameModels:
+    """Create the env models for VegaPickPlace3D.
+
+    ``config`` overrides the env config of the internal sim. Defaults to
+    ``VegaPickPlace3DEnvConfig()`` if not provided. ``prefer_ompl`` selects the OMPL
+    motion planner when ompl is installed; set it to False to force the BiRRT
+    fallback.
+    """
+    assert isinstance(observation_space, ObjectCentricBoxSpace)
+    assert isinstance(action_space, BimanualArmJointDeltaGraspActionSpace)
+
+    if config is None:
+        config = VegaPickPlace3DEnvConfig()
+    sim = ObjectCentricVegaPickPlace3DEnv(config=config, allow_state_access=True)
+
+    # Convert observations into states. The important thing is that states are hashable.
+    def observation_to_state(o: NDArray[np.float32]) -> ObjectCentricState:
+        """Convert the vectors back into (hashable) object-centric states."""
+        return observation_space.devectorize(o)
+
+    # Create the transition function.
+    def transition_fn(
+        x: ObjectCentricState,
+        u: NDArray[np.float32],
+    ) -> ObjectCentricState:
+        """Simulate the action."""
+        state = x.copy()
+        assert isinstance(state, VegaPickPlace3DObjectCentricState)
+        sim.set_state(state)
+        obs, _, _, _, _ = sim.step(u)
+        return obs.copy()
+
+    # Types.
+    types = {Kinematic3Dv2GraspArmRobotType, Kinematic3Dv2PointType}
+
+    # Create the state space.
+    state_space = ObjectCentricStateSpace(types)
+
+    # Abstractions.
+    state_abstractor = create_state_abstractor(sim)
+    goal_deriver = create_goal_deriver(state_abstractor)
+
+    # Operators. Handing the cube to an arm that already holds it is impossible, and
+    # no reachable abstract state satisfies both Holding(?giver, ?cube) and
+    # HandEmpty(?giver), so the HandEmpty(?receiver) precondition also rules out
+    # groundings where the giver and the receiver are the same arm.
+    arm = Variable("?arm", Kinematic3Dv2GraspArmRobotType)
+    giver = Variable("?giver", Kinematic3Dv2GraspArmRobotType)
+    receiver = Variable("?receiver", Kinematic3Dv2GraspArmRobotType)
+    cube = Variable("?cube", Kinematic3Dv2PointType)
+    target = Variable("?target", Kinematic3Dv2PointType)
+
+    PickOperator = LiftedOperator(
+        "Pick",
+        [arm, cube],
+        preconditions={
+            LiftedAtom(HandEmpty, [arm]),
+            LiftedAtom(NotHeld, [cube]),
+        },
+        add_effects={LiftedAtom(Holding, [arm, cube])},
+        delete_effects={
+            LiftedAtom(HandEmpty, [arm]),
+            LiftedAtom(NotHeld, [cube]),
+        },
+    )
+
+    PlaceOperator = LiftedOperator(
+        "Place",
+        [arm, cube, target],
+        preconditions={LiftedAtom(Holding, [arm, cube])},
+        add_effects={
+            LiftedAtom(On, [cube, target]),
+            LiftedAtom(NotHeld, [cube]),
+            LiftedAtom(HandEmpty, [arm]),
+        },
+        delete_effects={LiftedAtom(Holding, [arm, cube])},
+    )
+
+    HandoverOperator = LiftedOperator(
+        "Handover",
+        [giver, receiver, cube],
+        preconditions={
+            LiftedAtom(Holding, [giver, cube]),
+            LiftedAtom(HandEmpty, [receiver]),
+        },
+        add_effects={
+            LiftedAtom(Holding, [receiver, cube]),
+            LiftedAtom(HandEmpty, [giver]),
+        },
+        delete_effects={
+            LiftedAtom(Holding, [giver, cube]),
+            LiftedAtom(HandEmpty, [receiver]),
+        },
+    )
+
+    # Controllers.
+    controllers = create_lifted_controllers(action_space, sim, prefer_ompl=prefer_ompl)
+
+    # Finalize the skills.
+    skills = {
+        LiftedSkill(PickOperator, controllers["pick"]),
+        LiftedSkill(PlaceOperator, controllers["place"]),
+        LiftedSkill(HandoverOperator, controllers["handover"]),
+    }
+
+    # Finalize the models.
+    return SesameModels(
+        observation_space,
+        state_space,
+        action_space,
+        transition_fn,
+        types,
+        PREDICATES,
+        observation_to_state,
+        state_abstractor,
+        goal_deriver,
+        skills,
+    )

--- a/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_pickplace3d.py
+++ b/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_pickplace3d.py
@@ -1,0 +1,78 @@
+"""Tests for vega_pickplace3d.py."""
+
+import kinder
+import pytest
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+
+from kinder_bilevel_planning.agent import BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+# VegaPickPlace3D needs prpl_kinematics, which is an optional extra of both kindergarden
+# and this package, and a kindergarden release that contains the environment. Skip the
+# module rather than fail collection when either is missing.
+pytest.importorskip("kinder.envs.kinematic3d_v2.vega_pickplace3d")
+pytest.importorskip(
+    "kinder_models.kinematic3d_v2.vega_pickplace3d.parameterized_skills"
+)
+
+kinder.register_all_environments()
+
+
+def _run_bilevel_planning(env, seed):
+    """Plan and execute one episode; the episode must reach the goal."""
+    env_models = create_bilevel_planning_models(
+        "vega_pickplace3d",
+        env.observation_space,
+        env.action_space,
+        prefer_ompl=False,
+    )
+    agent = BilevelPlanningAgent(
+        env_models,
+        seed=123,
+        max_abstract_plans=10,
+        samples_per_step=2,
+        planning_timeout=600.0,
+        max_skill_horizon=1000,
+    )
+    obs, info = env.reset(seed=seed)
+    agent.reset(obs, info)
+
+    terminated = truncated = False
+    for _ in range(3000):
+        action = agent.step()
+        obs, reward, terminated, truncated, info = env.step(action)
+        agent.update(obs, reward, terminated or truncated, info)
+        if terminated or truncated:
+            break
+    else:
+        assert False, "Did not terminate successfully"
+
+    assert terminated, "Episode truncated rather than reaching the goal"
+
+
+def test_vega_pickplace3d_bilevel_planning():
+    """Bilevel planning solves a single-arm VegaPickPlace3D episode."""
+    env = kinder.make("kinder/VegaPickPlace3D-v0", render_mode="rgb_array")
+    if MAKE_VIDEOS:
+        env = RecordVideo(env, "unit_test_videos", name_prefix="VegaPickPlace3D")
+    # For seed 0 the cube and the target are both on the right side of the table.
+    _run_bilevel_planning(env, seed=0)
+    env.close()
+
+
+def test_vega_pickplace3d_bilevel_planning_handover():
+    """Bilevel planning solves an episode that requires a handover.
+
+    The planner discovers the handover by backtracking: single-arm abstract plans are
+    generated first and die during sampling, because no arm can reach both the cube
+    and the target.
+    """
+    env = kinder.make("kinder/VegaPickPlace3D-v0", render_mode="rgb_array")
+    if MAKE_VIDEOS:
+        env = RecordVideo(
+            env, "unit_test_videos", name_prefix="VegaPickPlace3D-handover"
+        )
+    # For seed 28 the cube is far on the left side and the target far on the right.
+    _run_bilevel_planning(env, seed=28)
+    env.close()

--- a/kinder-models/pyproject.toml
+++ b/kinder-models/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
    "h5py",
    "flask-socketio",
    "opencv-python>=4.9.0",
-   "kindergarden>=0.2.2",
+   "kindergarden>=0.2.3",
    "relational_structs>=0.0.1",
    "bilevel_planning>=0.1.2",
 ]

--- a/kinder-models/pyproject.toml
+++ b/kinder-models/pyproject.toml
@@ -36,7 +36,10 @@ develop = [
     "mypy",
     "pylint>=2.14.5",
     "pytest-pylint>=0.18.0",
-    "pytest>=7.2.2",
+    # pytest 9.1 dropped the `path` arg from the pytest_collect_file hookspec,
+    # which pytest-pylint 0.21.0 still uses -- it crashes the lint job. Temporary
+    # cap; see https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/issues/111
+    "pytest>=7.2.2,<9.1",
     "ruckig>=0.12.2",
 ]
 

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
@@ -89,6 +89,13 @@ GRASP_RADIUS_MARGIN = 0.9
 # patch half extents, so the drop cannot land on the patch boundary.
 PLACE_EXTENT_MARGIN = 0.7
 
+# A released cube drops kinematically to its resting height from wherever it is, so
+# nothing in the environment forces a gentle set-down. The sampler bounds the release
+# height itself: the cube must hang no more than this far above its resting height
+# when the arm lets go, so placements happen near the surface instead of as long
+# drops.
+PLACE_MAX_RELEASE_HEIGHT = 0.10
+
 # The handover region: the holding arm carries the cube to a point sampled here, in
 # front of the robot where both arms can reach. Bounds are on the cube center, with y
 # centered on the robot's sagittal plane and z relative to the table top.
@@ -397,25 +404,53 @@ class GroundPlaceController(_VegaPickPlaceControllerBase):
         half_x, half_y = self._sim.config.target_half_extents
         resting_z = self._sim.cube_resting_z
 
-        def accept(config: Configuration) -> bool:
-            # The cube is attached to this arm's end effector, so its position under a
-            # candidate configuration comes from forward kinematics of its tree node.
-            cube = self._sim.tree.forward_kinematics(CUBE_NODE, config).t
+        def cube_accepted(cube: np.ndarray) -> bool:
             return bool(
                 abs(cube[0] - target[0]) < PLACE_EXTENT_MARGIN * half_x
                 and abs(cube[1] - target[1]) < PLACE_EXTENT_MARGIN * half_y
-                and cube[2] >= resting_z
+                and resting_z <= cube[2] <= resting_z + PLACE_MAX_RELEASE_HEIGHT
             )
 
-        joints = self._sample_arm_configuration(
-            side, accept, rng, self._num_goal_candidates
+        # The bounded release height makes the acceptance region a thin slab just
+        # above the patch, so raw draws are refined like grasp reaches: aim the cube
+        # (via the end effector, which carries it at a fixed offset) at the slab
+        # center and re-check. The cube is attached to this arm's end effector, so its
+        # position under a candidate configuration comes from forward kinematics of
+        # its tree node.
+        place_point = np.array(
+            [target[0], target[1], resting_z + PLACE_MAX_RELEASE_HEIGHT / 2]
         )
-        if joints is None:
-            raise TrajectorySamplingFailure(
-                f"No place configuration found for the {side} arm over target "
-                f"{tuple(target)} after {self._num_goal_candidates} samples"
+        space = self._arm_space(side)
+        lower, upper = space.bounds()
+        base = dict(self._sim.configuration)
+        ee_frame = self._sim.robot.manipulators[side].ee_frame
+        refiner = self._ik_refiners[side]
+        for _ in range(self._num_goal_candidates):
+            joints = rng.uniform(lower, upper)
+            config = base | space.to_configuration(joints)
+            cube = self._sim.tree.forward_kinematics(CUBE_NODE, config).t
+            if np.linalg.norm(cube - place_point) >= LOOSE_REACH_RADIUS:
+                continue
+            if cube_accepted(cube) and not self._collision_fn(config):
+                return joints
+            # The end-effector target that carries the cube to the place point,
+            # assuming the refinement preserves the draw's orientation.
+            ee_pose = self._sim.tree.forward_kinematics(ee_frame, config)
+            refined = refiner.solve(
+                SE3.Rt(ee_pose.R, place_point - (cube - ee_pose.t)), config
             )
-        return joints
+            if refined is None:
+                continue
+            refined_cube = self._sim.tree.forward_kinematics(CUBE_NODE, refined).t
+            if not cube_accepted(refined_cube):
+                continue
+            if self._collision_fn(refined):
+                continue
+            return space.to_vector(refined)
+        raise TrajectorySamplingFailure(
+            f"No place configuration found for the {side} arm over target "
+            f"{tuple(target)} after {self._num_goal_candidates} samples"
+        )
 
     def _create_motion_segments(
         self, params: np.ndarray

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
@@ -1,0 +1,574 @@
+"""Parameterized skills for the VegaPickPlace3D environment.
+
+There are three skills: picking up the cube with one arm, placing a held cube onto the
+target patch, and handing the cube from one arm to the other. Each one samples a goal
+configuration by rejection, drawing arm configurations uniformly within the joint limits
+and accepting ones that satisfy the skill's end-effector condition (grasp-range reaches
+additionally refine near misses with differential IK). It then plans a collision-free
+joint path per arm and emits the path as bounded joint deltas with the grasp commands
+held so that the cube stays where it is; the final action of each skill toggles one
+grasp command to grasp, release, or take the cube.
+
+The handover skill moves both arms in sequence: the holding arm carries the cube into a
+region in front of the robot that both arms can reach, and the receiving arm then
+reaches to the cube and takes it.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+import numpy as np
+import pybullet as p
+from bilevel_planning.structs import (
+    GroundParameterizedController,
+    LiftedParameterizedController,
+)
+from bilevel_planning.trajectory_samplers.trajectory_sampler import (
+    TrajectorySamplingFailure,
+)
+from gymnasium.spaces import Box
+from kinder.envs.kinematic3d_v2.object_types import (
+    ARM_NUM_JOINTS,
+    Kinematic3Dv2GraspArmRobotType,
+    Kinematic3Dv2PointType,
+)
+from kinder.envs.kinematic3d_v2.vega_pickplace3d import (
+    ARM_SIDES,
+    CUBE_NODE,
+    BimanualArmJointDeltaGraspActionSpace,
+    ObjectCentricVegaPickPlace3DEnv,
+    VegaPickPlace3DObjectCentricState,
+)
+from prpl_kinematics.collision import PyBulletCollisionChecker
+from prpl_kinematics.ik import NumericalIK
+from prpl_kinematics.planning.configuration_space import ConfigurationSpace
+from prpl_kinematics.planning.joint_space import JointSpace
+from prpl_kinematics.planning.motion_planner import MotionPlanner
+from prpl_kinematics.tree.kinematic_tree import Configuration
+from relational_structs import Object, ObjectCentricState, Variable
+from spatialmath import SE3
+
+from kinder_models.kinematic3d_v2.vega_motion3d.parameterized_skills import (
+    create_motion_planner,
+)
+
+# Goal configurations are drawn uniformly within the joint limits and accepted when the
+# skill's end-effector condition holds, at ~0.3 ms per forward-kinematics call. A
+# successful sample costs a fraction of a second; an exhausted budget (which raises
+# TrajectorySamplingFailure, e.g. when the cube is out of the arm's reach) costs a few
+# seconds. Bilevel planning relies on that failure to discard abstract plans that use
+# the wrong arm.
+DEFAULT_NUM_GOAL_CANDIDATES = 10_000
+
+# Reaching a point with the end effector uses a two-stage sampler: a draw whose end
+# effector lands within the loose radius of the point is refined with differential IK
+# (keeping its orientation) and re-checked against the strict condition. Hitting the
+# grasp ball directly is a ~0.05% event for a reachable cube and gets much rarer near
+# the table edges, so a pure rejection sampler exhausts its budget on cubes that the
+# arm can in fact reach; the loose pass is ~20x more likely per draw and the
+# refinement almost always closes the remaining distance.
+LOOSE_REACH_RADIUS = 0.25
+
+# The refinement solver aims at a point this far above the reached point and stops
+# within the position tolerance of it. Aiming above matters when the point is a cube
+# resting on the table: an end effector driven to the cube center itself sits at table
+# height and the gripper geometry collides with the table, whereas an end effector
+# hovering above the cube grasps just as well (grasping is by distance alone) and
+# clears the table. The strict reach distance must exceed the offset plus the
+# tolerance, so a converged refinement always satisfies the strict condition.
+REFINE_TARGET_Z_OFFSET = 0.04
+REFINE_POSITION_TOLERANCE = 0.04
+REFINE_MAX_ITERS = 50
+
+# Sampled grasp (and take-over) configurations put the end effector within this
+# fraction of the environment's grasp radius, so the grasp cannot sit on the boundary.
+GRASP_RADIUS_MARGIN = 0.9
+
+# Sampled place configurations put the cube center within this fraction of the target
+# patch half extents, so the drop cannot land on the patch boundary.
+PLACE_EXTENT_MARGIN = 0.7
+
+# The handover region: the holding arm carries the cube to a point sampled here, in
+# front of the robot where both arms can reach. Bounds are on the cube center, with y
+# centered on the robot's sagittal plane and z relative to the table top.
+HANDOVER_Y_BOUNDS = (-0.15, 0.15)
+HANDOVER_Z_ABOVE_TABLE_BOUNDS = (0.15, 0.40)
+
+# How many carry configurations to try per handover sample: for each one, the receiving
+# arm gets a fraction of the candidate budget to find a matching take-over
+# configuration.
+HANDOVER_NUM_CARRY_ATTEMPTS = 5
+
+
+def create_collision_fn(
+    sim: ObjectCentricVegaPickPlace3DEnv,
+) -> Callable[[Configuration], bool]:
+    """A collision check for the robot and the table in ``sim``.
+
+    This builds a checker over the environment's kinematic tree rather than reusing the
+    environment's own, which is not exposed. The tree is shared, so the two stay in
+    agreement; the cost is one extra PyBullet client held for the process lifetime.
+    """
+    physics_client_id = p.connect(p.DIRECT)
+    collision_checker = PyBulletCollisionChecker(physics_client_id)
+    collision_checker.load(sim.tree)
+    collision_checker.ignore(sim.robot.allowed_collision_pairs)
+    return collision_checker.in_collision
+
+
+def _side_of(arm: Object) -> str:
+    """The side ("left" or "right") of an arm object named ``<side>_arm``."""
+    side = arm.name.split("_", maxsplit=1)[0]
+    assert side in ARM_SIDES, f"Not an arm object: {arm.name}"
+    return side
+
+
+class _VegaPickPlaceControllerBase(
+    GroundParameterizedController[ObjectCentricState, np.ndarray]
+):
+    """Shared machinery for the VegaPickPlace3D skills.
+
+    Subclasses sample goal configurations and define a sequence of arm motions followed
+    by one grasp-command toggle. Motions are planned lazily during execution, one arm at
+    a time, from the state observed when the arm starts moving.
+    """
+
+    def __init__(
+        self,
+        objects: Sequence[Object],
+        sim: ObjectCentricVegaPickPlace3DEnv,
+        planners: dict[str, MotionPlanner],
+        collision_fn: Callable[[Configuration], bool],
+        num_goal_candidates: int = DEFAULT_NUM_GOAL_CANDIDATES,
+    ) -> None:
+        super().__init__(objects)
+        self._sim = sim
+        self._planners = planners
+        self._collision_fn = collision_fn
+        self._num_goal_candidates = num_goal_candidates
+        self._ik_refiners = {
+            side: NumericalIK(
+                sim.tree,
+                self._joint_space(side),
+                sim.robot.manipulators[side].ee_frame,
+                position_tolerance=REFINE_POSITION_TOLERANCE,
+                orientation_tolerance=float("inf"),
+                max_iters=REFINE_MAX_ITERS,
+            )
+            for side in ARM_SIDES
+        }
+        self._current_state: ObjectCentricState | None = None
+        self._current_params: np.ndarray | None = None
+        # (side, goal joints) for each arm motion, in execution order.
+        self._motion_segments: list[tuple[str, np.ndarray]] = []
+        # The plan for the segment currently executing, or None before planning.
+        self._current_plan: list[np.ndarray] | None = None
+        # (side, command) for the single grasp toggle that ends the skill.
+        self._final_command: tuple[str, float] | None = None
+        self._final_command_issued = False
+
+    def _arm_space(self, side: str) -> ConfigurationSpace:
+        manipulator = self._sim.robot.manipulators[side]
+        return self._sim.robot.groups[manipulator.group]
+
+    def _joint_space(self, side: str) -> JointSpace:
+        space = self._arm_space(side)
+        assert isinstance(space, JointSpace)
+        return space
+
+    def _sample_arm_configuration(
+        self,
+        side: str,
+        accept: Callable[[Configuration], bool],
+        rng: np.random.Generator,
+        num_candidates: int,
+    ) -> np.ndarray | None:
+        """A collision-free configuration for ``side`` accepted by ``accept``.
+
+        The sim must already be at the state to sample around; all other joints keep
+        their current values. Returns None when the budget is exhausted.
+        """
+        space = self._arm_space(side)
+        lower, upper = space.bounds()
+        base = dict(self._sim.configuration)
+        for _ in range(num_candidates):
+            joints = rng.uniform(lower, upper)
+            config = base | space.to_configuration(joints)
+            if not accept(config):
+                continue
+            if self._collision_fn(config):
+                continue
+            return joints
+        return None
+
+    def _sample_ee_reach_configuration(
+        self,
+        side: str,
+        position: np.ndarray,
+        distance: float,
+        rng: np.random.Generator,
+        num_candidates: int,
+    ) -> np.ndarray | None:
+        """A collision-free configuration with ``side``'s end effector in range.
+
+        Draws configurations uniformly within the joint limits. A draw whose end
+        effector already satisfies the strict condition is accepted as is; a draw within
+        the loose radius of ``position`` is refined with differential IK toward a point
+        just above ``position``, keeping the draw's orientation, and re-checked. The sim
+        must already be at the state to sample around. Returns None when the budget is
+        exhausted.
+        """
+        assert distance > REFINE_POSITION_TOLERANCE + REFINE_TARGET_Z_OFFSET
+        space = self._arm_space(side)
+        lower, upper = space.bounds()
+        base = dict(self._sim.configuration)
+        ee_frame = self._sim.robot.manipulators[side].ee_frame
+        refiner = self._ik_refiners[side]
+        refine_target = position + np.array([0.0, 0.0, REFINE_TARGET_Z_OFFSET])
+        for _ in range(num_candidates):
+            joints = rng.uniform(lower, upper)
+            config = base | space.to_configuration(joints)
+            ee_pose = self._sim.tree.forward_kinematics(ee_frame, config)
+            reach = float(np.linalg.norm(ee_pose.t - position))
+            if reach >= LOOSE_REACH_RADIUS:
+                continue
+            if reach < distance and not self._collision_fn(config):
+                return joints
+            refined = refiner.solve(SE3.Rt(ee_pose.R, refine_target), config)
+            if refined is None:
+                continue
+            ee_position = self._sim.tree.forward_kinematics(ee_frame, refined).t
+            if np.linalg.norm(ee_position - position) >= distance:
+                continue
+            if self._collision_fn(refined):
+                continue
+            return space.to_vector(refined)
+        return None
+
+    def reset(self, x: ObjectCentricState, params: np.ndarray) -> None:
+        self._current_state = x
+        self._current_params = params
+        self._motion_segments = self._create_motion_segments(params)
+        self._current_plan = None
+        self._final_command = self._create_final_command()
+        self._final_command_issued = False
+
+    def _create_motion_segments(
+        self, params: np.ndarray
+    ) -> list[tuple[str, np.ndarray]]:
+        """The arm motions for this skill, as (side, goal joints) in order."""
+        raise NotImplementedError
+
+    def _create_final_command(self) -> tuple[str, float]:
+        """The (side, grasp command) toggle that ends this skill."""
+        raise NotImplementedError
+
+    def terminated(self) -> bool:
+        return self._final_command_issued
+
+    def observe(self, x: ObjectCentricState) -> None:
+        self._current_state = x
+
+    def _assemble_action(
+        self,
+        moving_side: str | None,
+        delta: np.ndarray | None,
+        grasp_overrides: dict[str, float] | None = None,
+    ) -> np.ndarray:
+        """An action moving one arm (or none), holding every grasp as it is.
+
+        By default each arm's grasp command re-asserts its current grasping state, so a
+        held cube stays held and a free cube stays free; ``grasp_overrides`` changes
+        individual commands.
+        """
+        state = self._current_state
+        assert isinstance(state, VegaPickPlace3DObjectCentricState)
+        action = np.zeros(2 * ARM_NUM_JOINTS + 2, dtype=np.float32)
+        for i, side in enumerate(ARM_SIDES):
+            if side == moving_side:
+                assert delta is not None
+                action[i * ARM_NUM_JOINTS : (i + 1) * ARM_NUM_JOINTS] = delta
+            command = 1.0 if state.grasping(side) else -1.0
+            if grasp_overrides and side in grasp_overrides:
+                command = grasp_overrides[side]
+            action[2 * ARM_NUM_JOINTS + i] = command
+        return action
+
+    def _plan_current_segment(self) -> list[np.ndarray]:
+        """Plan the first pending motion segment from the current state."""
+        state = self._current_state
+        assert isinstance(state, VegaPickPlace3DObjectCentricState)
+        self._sim.set_state(state)
+        side, goal_joints = self._motion_segments[0]
+        space = self._arm_space(side)
+        start = self._sim.configuration
+        goal = dict(start)
+        goal.update(space.to_configuration(goal_joints))
+        path = self._planners[side].plan(start, goal)
+        if path is None:
+            raise TrajectorySamplingFailure(f"Motion planning failed for {side} arm")
+
+        # Densify so that consecutive waypoints are within one action of each other.
+        # Planners return waypoints at whatever spacing search produced, which can
+        # exceed what a single action can cover.
+        max_step = self._sim.config.max_action_mag / 2
+        vectors = [space.to_vector(config) for config in path]
+        plan: list[np.ndarray] = []
+        for previous, following in zip(vectors[:-1], vectors[1:], strict=True):
+            plan.extend(space.interpolate(previous, following, max_step))
+        return plan
+
+    def step(self) -> np.ndarray:
+        state = self._current_state
+        assert isinstance(state, VegaPickPlace3DObjectCentricState)
+
+        # Advance through the motion segments, planning each lazily when it starts.
+        while self._motion_segments:
+            if self._current_plan is None:
+                self._current_plan = self._plan_current_segment()
+            if not self._current_plan:
+                self._motion_segments.pop(0)
+                self._current_plan = None
+                continue
+            side, _ = self._motion_segments[0]
+            target_joints = self._current_plan.pop(0)
+            # Every Vega arm joint is bounded, so a plain difference is the correct
+            # delta; no wrapping is possible on these joints.
+            current_joints = np.asarray(state.arm_joint_positions(side))
+            max_magnitude = self._sim.config.max_action_mag
+            delta = np.clip(
+                target_joints - current_joints, -max_magnitude, max_magnitude
+            )
+            return self._assemble_action(side, delta.astype(np.float32))
+
+        # All motions done: issue the single grasp toggle.
+        assert self._final_command is not None
+        assert not self._final_command_issued
+        side, command = self._final_command
+        self._final_command_issued = True
+        return self._assemble_action(None, None, grasp_overrides={side: command})
+
+
+class GroundPickController(_VegaPickPlaceControllerBase):
+    """Move one arm's end effector to the (free) cube and grasp it."""
+
+    def sample_parameters(
+        self, x: ObjectCentricState, rng: np.random.Generator
+    ) -> np.ndarray:
+        assert isinstance(x, VegaPickPlace3DObjectCentricState)
+        self._sim.set_state(x)
+        side = _side_of(self.objects[0])
+        cube = np.asarray(x.cube_position)
+        joints = self._sample_ee_reach_configuration(
+            side,
+            cube,
+            GRASP_RADIUS_MARGIN * self._sim.config.grasp_radius,
+            rng,
+            self._num_goal_candidates,
+        )
+        if joints is None:
+            raise TrajectorySamplingFailure(
+                f"No grasp configuration found for the {side} arm at cube "
+                f"{tuple(cube)} after {self._num_goal_candidates} samples"
+            )
+        return joints
+
+    def _create_motion_segments(
+        self, params: np.ndarray
+    ) -> list[tuple[str, np.ndarray]]:
+        return [(_side_of(self.objects[0]), params)]
+
+    def _create_final_command(self) -> tuple[str, float]:
+        return (_side_of(self.objects[0]), 1.0)
+
+
+class GroundPlaceController(_VegaPickPlaceControllerBase):
+    """Carry the held cube over the target patch and release it."""
+
+    def sample_parameters(
+        self, x: ObjectCentricState, rng: np.random.Generator
+    ) -> np.ndarray:
+        assert isinstance(x, VegaPickPlace3DObjectCentricState)
+        self._sim.set_state(x)
+        side = _side_of(self.objects[0])
+        assert x.holder == side, "Place requires this arm to hold the cube"
+        target = np.asarray(x.target_position)
+        half_x, half_y = self._sim.config.target_half_extents
+        resting_z = self._sim.cube_resting_z
+
+        def accept(config: Configuration) -> bool:
+            # The cube is attached to this arm's end effector, so its position under a
+            # candidate configuration comes from forward kinematics of its tree node.
+            cube = self._sim.tree.forward_kinematics(CUBE_NODE, config).t
+            return bool(
+                abs(cube[0] - target[0]) < PLACE_EXTENT_MARGIN * half_x
+                and abs(cube[1] - target[1]) < PLACE_EXTENT_MARGIN * half_y
+                and cube[2] >= resting_z
+            )
+
+        joints = self._sample_arm_configuration(
+            side, accept, rng, self._num_goal_candidates
+        )
+        if joints is None:
+            raise TrajectorySamplingFailure(
+                f"No place configuration found for the {side} arm over target "
+                f"{tuple(target)} after {self._num_goal_candidates} samples"
+            )
+        return joints
+
+    def _create_motion_segments(
+        self, params: np.ndarray
+    ) -> list[tuple[str, np.ndarray]]:
+        return [(_side_of(self.objects[0]), params)]
+
+    def _create_final_command(self) -> tuple[str, float]:
+        return (_side_of(self.objects[0]), -1.0)
+
+
+class GroundHandoverController(_VegaPickPlaceControllerBase):
+    """Carry the cube to a shared region, then take it with the other arm.
+
+    Parameters are the goal configurations of both arms, holding arm first. The holding
+    arm moves first, carrying the cube; the receiving arm then reaches to the carried
+    cube and the final action grasps it, which re-parents the cube onto the receiving
+    arm.
+    """
+
+    def sample_parameters(
+        self, x: ObjectCentricState, rng: np.random.Generator
+    ) -> np.ndarray:
+        assert isinstance(x, VegaPickPlace3DObjectCentricState)
+        giver, receiver = _side_of(self.objects[0]), _side_of(self.objects[1])
+        assert x.holder == giver, "Handover requires the first arm to hold the cube"
+        self._sim.set_state(x)
+        config = self._sim.config
+        low = np.array(
+            [
+                config.sample_x_bounds[0],
+                HANDOVER_Y_BOUNDS[0],
+                config.table_height + HANDOVER_Z_ABOVE_TABLE_BOUNDS[0],
+            ]
+        )
+        high = np.array(
+            [
+                config.sample_x_bounds[1],
+                HANDOVER_Y_BOUNDS[1],
+                config.table_height + HANDOVER_Z_ABOVE_TABLE_BOUNDS[1],
+            ]
+        )
+        cube_frame = CUBE_NODE
+        grasp_distance = GRASP_RADIUS_MARGIN * config.grasp_radius
+        carry_budget = self._num_goal_candidates // HANDOVER_NUM_CARRY_ATTEMPTS
+        base = dict(self._sim.configuration)
+        giver_space = self._arm_space(giver)
+
+        def carry_accept(candidate: Configuration) -> bool:
+            cube = self._sim.tree.forward_kinematics(cube_frame, candidate).t
+            return bool(np.all(cube >= low) and np.all(cube <= high))
+
+        for _ in range(HANDOVER_NUM_CARRY_ATTEMPTS):
+            giver_joints = self._sample_arm_configuration(
+                giver, carry_accept, rng, carry_budget
+            )
+            if giver_joints is None:
+                continue
+            # Where the cube ends up under the carry configuration; the receiving
+            # arm must reach within grasp range of this point while the giver is
+            # at that configuration (so the arms cannot collide at the handover).
+            carry_config = base | giver_space.to_configuration(giver_joints)
+            cube = self._sim.tree.forward_kinematics(cube_frame, carry_config).t
+            self._sim.set_arm_joint_positions(giver, giver_joints)
+            receiver_joints = self._sample_ee_reach_configuration(
+                receiver, cube, grasp_distance, rng, self._num_goal_candidates
+            )
+            self._sim.set_state(x)  # restore after moving the giver arm
+            if receiver_joints is not None:
+                return np.concatenate([giver_joints, receiver_joints])
+        raise TrajectorySamplingFailure(
+            f"No handover configurations found from the {giver} arm to the "
+            f"{receiver} arm after {HANDOVER_NUM_CARRY_ATTEMPTS} carry attempts"
+        )
+
+    def _create_motion_segments(
+        self, params: np.ndarray
+    ) -> list[tuple[str, np.ndarray]]:
+        giver, receiver = _side_of(self.objects[0]), _side_of(self.objects[1])
+        return [
+            (giver, params[:ARM_NUM_JOINTS]),
+            (receiver, params[ARM_NUM_JOINTS:]),
+        ]
+
+    def _create_final_command(self) -> tuple[str, float]:
+        # The receiving arm requests a grasp; the environment re-parents the cube from
+        # the holder to the requesting arm when it is within grasp range.
+        return (_side_of(self.objects[1]), 1.0)
+
+
+def create_lifted_controllers(
+    action_space: BimanualArmJointDeltaGraspActionSpace,
+    sim: ObjectCentricVegaPickPlace3DEnv,
+    rng: np.random.Generator | None = None,
+    prefer_ompl: bool = True,
+) -> dict[str, LiftedParameterizedController]:
+    """Create lifted parameterized controllers for VegaPickPlace3D."""
+    del action_space  # the action space is implied by the environment
+
+    if rng is None:
+        rng = np.random.default_rng(0)
+    collision_fn = create_collision_fn(sim)
+    planners = {
+        side: create_motion_planner(
+            sim.robot.groups[sim.robot.manipulators[side].group],
+            collision_fn,
+            rng,
+            prefer_ompl=prefer_ompl,
+        )
+        for side in ARM_SIDES
+    }
+
+    class PickController(GroundPickController):
+        """Pick up the cube with one arm."""
+
+        def __init__(self, objects):
+            super().__init__(objects, sim, planners, collision_fn)
+
+    class PlaceController(GroundPlaceController):
+        """Place the held cube onto the target patch."""
+
+        def __init__(self, objects):
+            super().__init__(objects, sim, planners, collision_fn)
+
+    class HandoverController(GroundHandoverController):
+        """Pass the cube from one arm to the other."""
+
+        def __init__(self, objects):
+            super().__init__(objects, sim, planners, collision_fn)
+
+    # Create variables for lifted controllers.
+    arm = Variable("?arm", Kinematic3Dv2GraspArmRobotType)
+    giver = Variable("?giver", Kinematic3Dv2GraspArmRobotType)
+    receiver = Variable("?receiver", Kinematic3Dv2GraspArmRobotType)
+    cube = Variable("?cube", Kinematic3Dv2PointType)
+    target = Variable("?target", Kinematic3Dv2PointType)
+
+    pick_controller: LiftedParameterizedController = LiftedParameterizedController(
+        [arm, cube],
+        PickController,
+        Box(-np.inf, np.inf, (ARM_NUM_JOINTS,)),
+    )
+    place_controller: LiftedParameterizedController = LiftedParameterizedController(
+        [arm, cube, target],
+        PlaceController,
+        Box(-np.inf, np.inf, (ARM_NUM_JOINTS,)),
+    )
+    handover_controller: LiftedParameterizedController = LiftedParameterizedController(
+        [giver, receiver, cube],
+        HandoverController,
+        Box(-np.inf, np.inf, (2 * ARM_NUM_JOINTS,)),
+    )
+    return {
+        "pick": pick_controller,
+        "place": place_controller,
+        "handover": handover_controller,
+    }

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/state_abstractions.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/state_abstractions.py
@@ -1,0 +1,91 @@
+"""State abstractions for the VegaPickPlace3D environment."""
+
+from typing import Callable
+
+from bilevel_planning.structs import (
+    RelationalAbstractGoal,
+    RelationalAbstractState,
+)
+from kinder.envs.kinematic3d_v2.object_types import (
+    Kinematic3Dv2GraspArmRobotType,
+    Kinematic3Dv2PointType,
+)
+from kinder.envs.kinematic3d_v2.vega_pickplace3d import (
+    ARM_SIDES,
+    CUBE_NODE,
+    TARGET_NODE,
+    ObjectCentricVegaPickPlace3DEnv,
+    VegaPickPlace3DObjectCentricState,
+)
+from relational_structs import (
+    GroundAtom,
+    Object,
+    ObjectCentricState,
+    Predicate,
+)
+
+# Predicates. Holding and HandEmpty partition the arms in every state; NotHeld marks
+# the cube while neither arm holds it. On holds when the environment's own goal is
+# reached, i.e., the cube rests on the table inside the target patch.
+Holding = Predicate("Holding", [Kinematic3Dv2GraspArmRobotType, Kinematic3Dv2PointType])
+HandEmpty = Predicate("HandEmpty", [Kinematic3Dv2GraspArmRobotType])
+NotHeld = Predicate("NotHeld", [Kinematic3Dv2PointType])
+On = Predicate("On", [Kinematic3Dv2PointType, Kinematic3Dv2PointType])
+
+PREDICATES = {Holding, HandEmpty, NotHeld, On}
+
+StateAbstractor = Callable[[ObjectCentricState], RelationalAbstractState]
+GoalDeriver = Callable[[ObjectCentricState], RelationalAbstractGoal]
+
+
+def get_scene_objects(
+    state: ObjectCentricState,
+) -> tuple[dict[str, Object], Object, Object]:
+    """The arm objects (keyed by side), the cube, and the target in the state."""
+    arms = {side: state.get_object_from_name(f"{side}_arm") for side in ARM_SIDES}
+    cube = state.get_object_from_name(CUBE_NODE)
+    target = state.get_object_from_name(TARGET_NODE)
+    return arms, cube, target
+
+
+def create_state_abstractor(
+    sim: ObjectCentricVegaPickPlace3DEnv,
+) -> StateAbstractor:
+    """Create a state abstractor backed by ``sim``.
+
+    Whether the cube is on the target is a function of forward kinematics, not of the
+    state features alone, so this defers to the environment's own goal check rather than
+    recomputing the containment test and risking drift from it.
+    """
+
+    def state_abstractor(state: ObjectCentricState) -> RelationalAbstractState:
+        """Get the abstract state for the current state."""
+        assert isinstance(state, VegaPickPlace3DObjectCentricState)
+        arms, cube, target = get_scene_objects(state)
+        atoms: set[GroundAtom] = set()
+        for side in ARM_SIDES:
+            if state.grasping(side):
+                atoms.add(GroundAtom(Holding, [arms[side], cube]))
+            else:
+                atoms.add(GroundAtom(HandEmpty, [arms[side]]))
+        if state.holder is None:
+            atoms.add(GroundAtom(NotHeld, [cube]))
+        sim.set_state(state)
+        if sim.goal_reached():
+            atoms.add(GroundAtom(On, [cube, target]))
+        objects = set(arms.values()) | {cube, target}
+        return RelationalAbstractState(atoms, objects)
+
+    return state_abstractor
+
+
+def create_goal_deriver(state_abstractor: StateAbstractor) -> GoalDeriver:
+    """Create a goal deriver that pairs with ``state_abstractor``."""
+
+    def goal_deriver(state: ObjectCentricState) -> RelationalAbstractGoal:
+        """The goal is to have the cube resting on the target patch."""
+        _, cube, target = get_scene_objects(state)
+        atoms = {GroundAtom(On, [cube, target])}
+        return RelationalAbstractGoal(atoms, state_abstractor)
+
+    return goal_deriver

--- a/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
@@ -1,0 +1,172 @@
+"""Tests for VegaPickPlace3D parameterized skills."""
+
+import kinder
+import numpy as np
+import pytest
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+from relational_structs.spaces import ObjectCentricBoxSpace
+
+# VegaPickPlace3D needs prpl_kinematics, which is an optional extra of both kindergarden
+# and this package, and a kindergarden release that contains the environment. Skip the
+# module rather than fail collection when either is missing.
+vega_pickplace3d = pytest.importorskip("kinder.envs.kinematic3d_v2.vega_pickplace3d")
+skills = pytest.importorskip(
+    "kinder_models.kinematic3d_v2.vega_pickplace3d.parameterized_skills"
+)
+pytest.importorskip("prpl_kinematics.planning")
+
+TrajectorySamplingFailure = pytest.importorskip(
+    "bilevel_planning.trajectory_samplers.trajectory_sampler"
+).TrajectorySamplingFailure
+
+ObjectCentricVegaPickPlace3DEnv = vega_pickplace3d.ObjectCentricVegaPickPlace3DEnv
+create_lifted_controllers = skills.create_lifted_controllers
+
+kinder.register_all_environments()
+
+
+def _make_env_and_state(seed, name_prefix=""):
+    """A wrapped environment reset to ``seed`` and its devectorized state."""
+    env = kinder.make("kinder/VegaPickPlace3D-v0", render_mode="rgb_array")
+    if MAKE_VIDEOS:
+        env = RecordVideo(env, "unit_test_videos", name_prefix=name_prefix)
+    obs, _ = env.reset(seed=seed)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    return env, state
+
+
+def _scene_objects(state):
+    arms = {
+        side: state.get_object_from_name(f"{side}_arm") for side in ("left", "right")
+    }
+    cube = state.get_object_from_name("cube")
+    target = state.get_object_from_name("target")
+    return arms, cube, target
+
+
+def _run_controller(env, controller, state, max_steps=900):
+    """Run a ground controller in ``env`` until it terminates."""
+    for _ in range(max_steps):
+        if controller.terminated():
+            return state
+        obs, _, _, _, _ = env.step(controller.step())
+        state = env.observation_space.devectorize(obs)
+        controller.observe(state)
+    assert False, "Controller did not terminate"
+
+
+@pytest.mark.parametrize("prefer_ompl", [True, False])
+def test_pick_and_place_controllers(prefer_ompl):
+    """Picking and then placing with one arm should reach the environment goal.
+
+    Parameterized over both planners so the BiRRT fallback is covered even when ompl is
+    installed.
+    """
+    # For seed 0 the cube and the target are both on the right side of the table.
+    env, state = _make_env_and_state(
+        0, name_prefix=f"VegaPickPlace3D-ompl{prefer_ompl}"
+    )
+    arms, cube, target = _scene_objects(state)
+    sim = ObjectCentricVegaPickPlace3DEnv(allow_state_access=True)
+    controllers = create_lifted_controllers(
+        env.action_space, sim, prefer_ompl=prefer_ompl
+    )
+    rng = np.random.default_rng(123)
+
+    pick = controllers["pick"].ground((arms["right"], cube))
+    params = pick.sample_parameters(state, rng)
+    assert params.shape == (7,)
+    pick.reset(state, params)
+    state = _run_controller(env, pick, state)
+    assert state.holder == "right"
+
+    place = controllers["place"].ground((arms["right"], cube, target))
+    params = place.sample_parameters(state, rng)
+    assert params.shape == (7,)
+    place.reset(state, params)
+    state = _run_controller(env, place, state)
+    assert state.holder is None
+
+    sim.set_state(state)
+    assert sim.goal_reached()
+
+    sim.close()
+    env.close()
+
+
+def test_handover_controller():
+    """Passing the cube between the arms should let the other arm place it."""
+    # For seed 19 the cube is far on the left side and the target far on the right, so
+    # the left arm picks, hands over, and the right arm places.
+    env, state = _make_env_and_state(19, name_prefix="VegaPickPlace3D-handover")
+    arms, cube, target = _scene_objects(state)
+    sim = ObjectCentricVegaPickPlace3DEnv(allow_state_access=True)
+    controllers = create_lifted_controllers(env.action_space, sim, prefer_ompl=False)
+    rng = np.random.default_rng(123)
+
+    pick = controllers["pick"].ground((arms["left"], cube))
+    pick.reset(state, pick.sample_parameters(state, rng))
+    state = _run_controller(env, pick, state)
+    assert state.holder == "left"
+
+    handover = controllers["handover"].ground((arms["left"], arms["right"], cube))
+    params = handover.sample_parameters(state, rng)
+    assert params.shape == (14,)
+    handover.reset(state, params)
+    state = _run_controller(env, handover, state)
+    assert state.holder == "right"
+
+    place = controllers["place"].ground((arms["right"], cube, target))
+    place.reset(state, place.sample_parameters(state, rng))
+    state = _run_controller(env, place, state)
+
+    sim.set_state(state)
+    assert sim.goal_reached()
+
+    sim.close()
+    env.close()
+
+
+def test_sampled_pick_parameters_reach_the_cube():
+    """Sampled pick parameters should put the end effector within grasp range."""
+    env, state = _make_env_and_state(0)
+    arms, cube, _ = _scene_objects(state)
+    sim = ObjectCentricVegaPickPlace3DEnv(allow_state_access=True)
+    controllers = create_lifted_controllers(env.action_space, sim, prefer_ompl=False)
+    rng = np.random.default_rng(0)
+
+    pick = controllers["pick"].ground((arms["right"], cube))
+    params = pick.sample_parameters(state, rng)
+
+    sim.set_state(state)
+    sim.set_arm_joint_positions("right", params)
+    distance = np.linalg.norm(
+        sim.end_effector_pose("right").t - np.array(state.cube_position)
+    )
+    assert distance < sim.config.grasp_radius
+
+    sim.close()
+    env.close()
+
+
+def test_pick_sampling_fails_for_out_of_reach_arm():
+    """Sampling a grasp with an arm that cannot reach the cube should fail.
+
+    Bilevel planning relies on this failure to discard abstract plans that use the wrong
+    arm and fall back to the other arm or to a handover.
+    """
+    # For seed 19 the cube is far on the left side, out of the right arm's reach.
+    env, state = _make_env_and_state(19)
+    arms, cube, _ = _scene_objects(state)
+    sim = ObjectCentricVegaPickPlace3DEnv(allow_state_access=True)
+    controllers = create_lifted_controllers(env.action_space, sim, prefer_ompl=False)
+    rng = np.random.default_rng(0)
+
+    pick = controllers["pick"].ground((arms["right"], cube))
+    with pytest.raises(TrajectorySamplingFailure):
+        pick.sample_parameters(state, rng)
+
+    sim.close()
+    env.close()


### PR DESCRIPTION
Adds bilevel planning models for **VegaPickPlace3D**, the bimanual cube-transfer environment from Princeton-Robot-Planning-and-Learning/kindergarden#157. The structure mirrors the VegaMotion3D models (#106): parameterized skills and state abstractions in kinder-models, operators and `SesameModels` wiring in kinder-bilevel-planning.

## Skills

Three skills, each of which samples a goal arm configuration, motion-plans a collision-free joint path per arm (OMPL when installed, BiRRT otherwise, as in #106), and ends with a single grasp-command toggle:

- **Pick(arm, cube)**: move the arm's end effector into grasp range of the cube, then grasp.
- **Place(arm, cube, target)**: carry the cube to a configuration where it hangs over the target patch no more than 0.10 m above its resting height, then release. The environment drops a released cube straight down to rest from any height, so the sampler bounds the release height itself to keep placements near the surface instead of long drops.
- **Handover(giver, receiver, cube)**: the holding arm carries the cube to a sampled point in a region in front of the robot that both arms can reach, the other arm reaches into grasp range, and the final grasp command re-parents the cube onto it.

During motions, every arm's grasp command re-asserts its current grasping state each step, so a held cube stays held and a free cube is not grasped in passing.

## Goal-configuration sampling

Goal configurations are drawn uniformly within the joint limits and accepted when the skill's condition holds. Two details matter:

- **Differential-IK refinement for grasp reaches and placements.** Directly hitting the 0.10 m grasp ball is a ~0.05% event per draw for a reachable cube and gets much rarer near the table edges, so a pure rejection sampler exhausts its budget on cubes the arm can in fact reach; the bounded-height place region is a similarly thin slab above the patch. Draws that land within 0.25 m are refined with `prpl_kinematics` `NumericalIK` (keeping the draw's orientation) and re-checked, which makes budget exhaustion actually mean "out of reach".
- **Refine toward a point above the cube, not the cube center.** The cube center sits 3 cm above the table top. An end effector driven to the center itself puts the gripper geometry inside the table and fails the collision check (44/44 refined samples rejected when I first tried it); grasping is by distance alone, so aiming 4 cm above grasps equally well and clears the table.

A sampler that exhausts its budget raises `TrajectorySamplingFailure`, which is what lets the planner discard abstract plans that use the wrong arm and fall back to the other arm or to a handover. Exhaustion costs a few seconds; that cost is what prices the abstract-plan backtracking below.

## Abstractions and operators

Predicates are `Holding(arm, cube)`, `HandEmpty(arm)`, `NotHeld(cube)`, and `On(cube, target)`. `On` defers to the environment's own `goal_reached()` (the containment test depends on forward kinematics, and duplicating the threshold invites drift), matching how VegaMotion3D's `AtTarget` works. Operators are `Pick`, `Place`, and `Handover`; the `HandEmpty(receiver)` precondition on `Handover` also rules out groundings where the giver and receiver are the same arm, because no reachable abstract state satisfies both `Holding(a, cube)` and `HandEmpty(a)`.

The planner is not told which arm can reach what. Single-arm plans are enumerated first, die during sampling when no arm reaches both the cube and the target, and the handover plan is then refined — the handover is discovered by backtracking, not encoded.

## Results

All 16 seeds (0–15) solve end-to-end through `BilevelPlanningAgent` against the kindergarden#157 branch (BiRRT, `max_abstract_plans=10`, `samples_per_step=2`):

| Seeds | Outcome |
| --- | --- |
| 0–15 | 16/16 solved; planning 7–93 s, episodes 144–409 steps |

Seeds 19 and 28 were verified to genuinely require a handover (only the left arm reaches the cube, only the right arm reaches the target); seed 28 solves end-to-end through the planner (93 s) and seed 19's skill chain (pick left → handover → place right) is exercised directly in the unit tests.

## CI and sequencing

- kindergarden 0.2.3 ships the environment — its `vega_pickplace3d.py` is byte-identical to the #157 branch these results were produced against — and both packages now pin `kindergarden>=0.2.3`, so the PR is self-contained and ready to merge. The tests still `importorskip` `prpl_kinematics`, which remains an optional extra.
- Also re-verified against prpl-mono#533 (the Dexgripper S sync): all skill and end-to-end tests pass with the new gripper meshes. The end-effector frames are unchanged upstream and grasping here is distance-based, so no model changes were needed.
- Drive-by: kinder-models gets the same `pytest>=7.2.2,<9.1` cap kinder-bilevel-planning already has — without it pytest-pylint crashes the lint job (kindergarden#111).

## Not addressed

- The two arms move sequentially within a skill (carry, then reach). Simultaneous motion would shorten episodes but needs coordinated collision-checked planning for both arms at once.
- Handover motion quality: the carry and take-over configurations come from uniform sampling, so the motions reach the cube but are not graceful. Refining them is deferred until the real robot is in the loop; hardware runs will start with the single-arm (no-handover) episodes.
- The handover region (|y| ≤ 0.15, 0.15–0.40 m above the table, x within the environment's sampling bounds) is a hand-chosen constant. It worked for every seed tried; a principled shared-workspace computation is left for later.
- Sampling budgets and margins (10k candidates, 0.9× grasp radius, 0.7× patch half-extents) are constants tuned for reliability, not speed. Planning takes ~10–90 s per episode depending on how many wrong plans are priced first.
- No environment changes were needed in kindergarden#157 — the models work against it as is. One mechanic worth knowing: the environment lets an arm release the cube from any height and snaps it to its resting pose (kinematic drop). The place skill bounds its own release height to 0.10 m above resting, so an env-side cap of at least that would not affect these models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

