### PR TITLE
kinder-models: recover from a grasp that closes on nothing

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -1,4 +1,8 @@
-"""Bilevel planning models for the TidyBot3D Tossing3D environment."""
+"""Bilevel planning models for the TidyBot3D Tossing3D environment.
+
+TODO: support Tossing3D-o2. It needs a goal naming each cube and operators that say
+which cube a throw is aimed at; the state abstractor asserts one cube today.
+"""
 
 from collections.abc import Sequence
 from pathlib import Path
@@ -49,8 +53,14 @@ def create_bilevel_planning_models(
     observation_space: Space,
     action_space: Space,
     num_objects: int = 1,
+    task_config_path: str | None = None,
 ) -> SesameModels:
-    """Create the env models for TidyBot Tossing3D."""
+    """Create the env models for TidyBot Tossing3D.
+
+    `task_config_path` defaults to the installed scene. Pass one to plan against a
+    variant, which must be the same scene the caller's env was built from -- the model
+    and the env disagreeing about geometry is silent, not an error.
+    """
     if num_objects != 1:
         raise NotImplementedError(
             f"Tossing3D bilevel planning supports one cube, got {num_objects}. The "
@@ -60,11 +70,12 @@ def create_bilevel_planning_models(
     assert isinstance(observation_space, ObjectCentricBoxSpace)
     assert isinstance(action_space, TidyBot3DRobotActionSpace)
 
-    task_config_path = str(
-        Path(kinder.__file__).parent
-        / "envs/dynamic3d/tasks/Tossing3D"
-        / f"Tossing3D-o{num_objects}.json"
-    )
+    if task_config_path is None:
+        task_config_path = str(
+            Path(kinder.__file__).parent
+            / "envs/dynamic3d/tasks/Tossing3D"
+            / f"Tossing3D-o{num_objects}.json"
+        )
     sim = ObjectCentricTidyBot3DEnv(
         task_config_path=task_config_path,
         num_objects=num_objects,

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -28,6 +28,7 @@ from kinder_models.dynamic3d.tossing.state_abstractions import (
     BARRIER_NAME,
     BIN_NAME_PREFIX,
     CUBE_NAME_PREFIX,
+    GripperCommandedClosed,
     HandEmpty,
     Holding,
     MovableInGoalRegion,
@@ -122,6 +123,7 @@ def create_bilevel_planning_models(
         OnGround,
         Holding,
         HandEmpty,
+        GripperCommandedClosed,
         MovableIsDownX,
         RobotAtThrowPose,
     }
@@ -137,11 +139,35 @@ def create_bilevel_planning_models(
             LiftedAtom(HandEmpty, [robot]),
             LiftedAtom(OnGround, [held]),
         },
-        add_effects={LiftedAtom(Holding, [robot, held])},
+        add_effects={
+            LiftedAtom(Holding, [robot, held]),
+            LiftedAtom(GripperCommandedClosed, [robot]),
+        },
         delete_effects={
             LiftedAtom(HandEmpty, [robot]),
             LiftedAtom(OnGround, [held]),
         },
+    )
+
+    # Open gripper operator, which is what makes a grasp that closed on nothing
+    # recoverable: the command stays shut, so HandEmpty and Holding are false at once
+    # and nothing else is applicable.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    held = Variable("?held", MujocoMovableObjectType)
+
+    # OnGround confines this to the case where the cube is already down, so the
+    # operator asserts nothing about where a released cube would land -- a cube that
+    # comes to rest on any face but its original one is not OnGround, and pick_shelf
+    # cannot grasp it.
+    OpenGripperOperator = LiftedOperator(
+        "open_gripper",
+        [robot, held],
+        preconditions={
+            LiftedAtom(GripperCommandedClosed, [robot]),
+            LiftedAtom(OnGround, [held]),
+        },
+        add_effects={LiftedAtom(HandEmpty, [robot])},
+        delete_effects={LiftedAtom(GripperCommandedClosed, [robot])},
     )
 
     # Move to throw pose operator.
@@ -179,6 +205,7 @@ def create_bilevel_planning_models(
         delete_effects={
             LiftedAtom(Holding, [robot, held]),
             LiftedAtom(MovableIsDownX, [held, barrier]),
+            LiftedAtom(GripperCommandedClosed, [robot]),
         },
     )
 
@@ -203,19 +230,28 @@ def create_bilevel_planning_models(
     LiftedTossFromWindupController = _restate_controller_variables(
         tossing_controllers["toss_from_windup"], TossFromWindupOperator.parameters
     )
+    LiftedOpenGripperController = _restate_controller_variables(
+        tossing_controllers["open_gripper"], OpenGripperOperator.parameters
+    )
 
     # Finalize the skills.
     skills = {
         LiftedSkill(PickCubeOperator, LiftedPickCubeController),
         LiftedSkill(MoveToThrowPoseOperator, LiftedMoveToThrowPoseController),
         LiftedSkill(TossFromWindupOperator, LiftedTossFromWindupController),
+        LiftedSkill(OpenGripperOperator, LiftedOpenGripperController),
     }
 
     # Every scene object is a movable, so lifted typing cannot tell the bin from the
     # barrier and grounding exhaustively offers the planner throws at the barrier.
     ground_operators = _create_ground_operators(
         initial_state,
-        [PickCubeOperator, MoveToThrowPoseOperator, TossFromWindupOperator],
+        [
+            PickCubeOperator,
+            MoveToThrowPoseOperator,
+            TossFromWindupOperator,
+            OpenGripperOperator,
+        ],
     )
 
     # Finalize the models.

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -6,11 +6,12 @@ import kinder
 import pytest
 from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
-from kinder_models.dynamic3d.tossing.state_abstractions import MovableInGoalRegion
-from relational_structs import GroundAtom
-
+from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
 from kinder_bilevel_planning.agent import BilevelPlanningAgent
 from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+from relational_structs import GroundAtom
+
+from kinder_models.dynamic3d.tossing.state_abstractions import MovableInGoalRegion
 
 kinder.register_all_environments()
 
@@ -117,6 +118,52 @@ def test_tidybot3d_tossing_abstracts_against_the_scene_it_was_given():
     in_goal_region = GroundAtom(MovableInGoalRegion, [cube])
     assert in_goal_region in variant_models.state_abstractor(state).atoms
     assert in_goal_region not in default_models.state_abstractor(state).atoms
+
+    env.close()
+
+
+def _shut_on_nothing_atoms(env, env_models):
+    """The abstract state left by a grasp that closed with the cube still on the
+    floor: the command is shut, so neither HandEmpty nor Holding holds."""
+    obs, _ = env.reset(seed=125)
+    state = env_models.observation_to_state(obs)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    shut = state.copy()
+    shut.set(robot, "pos_gripper", 1.0)
+    return env_models.state_abstractor(shut).atoms
+
+
+def test_open_gripper_is_applicable_after_a_grasp_closes_on_nothing():
+    """Without it this state has no applicable operator at all."""
+    env = kinder.make("kinder/Tossing3D-o1-v0")
+    env_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME, env.observation_space, env.action_space, num_objects=1
+    )
+    atoms = _shut_on_nothing_atoms(env, env_models)
+
+    assert env_models.ground_operators is not None
+    applicable = {
+        op.name for op in env_models.ground_operators if op.preconditions <= atoms
+    }
+    assert applicable == {"open_gripper"}
+
+    env.close()
+
+
+def test_open_gripper_is_inapplicable_while_the_gripper_is_already_open():
+    """It must recover the dead end without becoming a free no-op everywhere."""
+    env = kinder.make("kinder/Tossing3D-o1-v0")
+    env_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME, env.observation_space, env.action_space, num_objects=1
+    )
+    obs, _ = env.reset(seed=125)
+    atoms = env_models.state_abstractor(env_models.observation_to_state(obs)).atoms
+
+    assert env_models.ground_operators is not None
+    applicable = {
+        op.name for op in env_models.ground_operators if op.preconditions <= atoms
+    }
+    assert "open_gripper" not in applicable
 
     env.close()
 

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -1,5 +1,7 @@
 """Tests for tidybot3d_tossing3D.py."""
 
+from pathlib import Path
+
 import kinder
 import pytest
 from conftest import MAKE_VIDEOS
@@ -13,6 +15,8 @@ from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 kinder.register_all_environments()
 
 ENV_MODEL_NAME = "tidybot3d_tossing3D"
+
+_TEST_TASKS = Path(__file__).parent.parent.parent / "test_tasks"
 
 
 def test_tidybot3d_tossing_bilevel_planning():
@@ -86,6 +90,33 @@ def test_tidybot3d_tossing_skills_ground_with_every_operator_parameter():
         assert tuple(ground_skill.controller.objects) == tuple(
             ground_operator.parameters
         )
+
+    env.close()
+
+
+def test_tidybot3d_tossing_abstracts_against_the_scene_it_was_given():
+    """A model built from an explicit scene reads that scene's goal region."""
+    env = kinder.make("kinder/Tossing3D-o1-v0")
+    obs, _ = env.reset(seed=125)
+
+    variant_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME,
+        env.observation_space,
+        env.action_space,
+        num_objects=1,
+        task_config_path=str(_TEST_TASKS / "tidybot-tossing3d_near_goal-o1.json"),
+    )
+    default_models = create_bilevel_planning_models(
+        ENV_MODEL_NAME, env.observation_space, env.action_space, num_objects=1
+    )
+
+    # The variant's goal region covers where the cube starts, so an untouched reset
+    # satisfies the goal under it and cannot under the installed scene.
+    state = variant_models.observation_to_state(obs)
+    cube = state.get_object_from_name("cube_0")
+    in_goal_region = GroundAtom(MovableInGoalRegion, [cube])
+    assert in_goal_region in variant_models.state_abstractor(state).atoms
+    assert in_goal_region not in default_models.state_abstractor(state).atoms
 
     env.close()
 

--- a/kinder-bilevel-planning/tests/test_tasks/tidybot-tossing3d_near_goal-o1.json
+++ b/kinder-bilevel-planning/tests/test_tasks/tidybot-tossing3d_near_goal-o1.json
@@ -1,0 +1,210 @@
+{
+    "description": "Tossing3D-o1 with blocks_goal_region moved onto the cube's own start region, so which scene a model was built from is visible in one abstract state.",
+    "variant_description": "Only blocks_goal_region differs from the shipped scene.",
+    "variant_specific_description": "One cube, already in the goal region at reset.",
+    "robots": {
+        "tidybot": {
+            "robot": {}
+        }
+    },
+    "scene": "lab2",
+    "regions": {
+        "bin_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    2.0,
+                    0.0,
+                    2.0,
+                    0.0
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    0,
+                    0
+                ]
+            ]
+        },
+        "blocks_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    0.5,
+                    -0.25,
+                    0.75,
+                    0.25
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    -45,
+                    45
+                ]
+            ],
+            "rgba": [
+                0.2,
+                0.6,
+                0.2,
+                0.0
+            ]
+        },
+        "blocks_goal_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    0.4,
+                    -0.35,
+                    0.0,
+                    0.85,
+                    0.35,
+                    0.1
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    -360,
+                    360
+                ]
+            ],
+            "rgba": [
+                0.2,
+                0.6,
+                0.2,
+                0.0
+            ]
+        },
+        "barrier_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    1.3,
+                    0.0,
+                    1.301,
+                    0.001
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    0,
+                    0
+                ]
+            ]
+        },
+        "robot_init_region": {
+            "target": "ground",
+            "ranges": [
+                [
+                    -0.05,
+                    -0.05,
+                    0.05,
+                    0.05
+                ]
+            ],
+            "yaw_ranges": [
+                [
+                    -5,
+                    5
+                ]
+            ],
+            "rgba": [
+                0.2,
+                0.6,
+                0.2,
+                0.0
+            ]
+        }
+    },
+    "objects": {
+        "cube": {
+            "cube_0": {
+                "size": 0.025,
+                "rgba": [
+                    0.2,
+                    0.6,
+                    0.2,
+                    1
+                ],
+                "mass": 0.1
+            }
+        },
+        "cuboid": {
+            "cuboid_barrier": {
+                "size": [
+                    0.03,
+                    5.0,
+                    0.1
+                ],
+                "rgba": [
+                    0.918,
+                    0.894,
+                    0.835,
+                    1.0
+                ],
+                "mass": 10.0
+            }
+        },
+        "bin": {
+            "bin_0": {
+                "length": 0.3,
+                "width": 0.3,
+                "height": 0.2,
+                "wall_thickness": 0.02,
+                "rgba": [
+                    0.8,
+                    0.8,
+                    0.0,
+                    1.0
+                ]
+            }
+        }
+    },
+    "cameras": {
+        "task_view": {
+            "position": [
+                1,
+                -2,
+                2
+            ],
+            "lookat": [
+                1,
+                0,
+                0
+            ],
+            "fovy": 42,
+            "resolution": [
+                640,
+                480
+            ]
+        }
+    },
+    "initial_state": [
+        [
+            "on",
+            "robot",
+            "robot_init_region"
+        ],
+        [
+            "on",
+            "cube_0",
+            "blocks_init_region"
+        ],
+        [
+            "on",
+            "bin_0",
+            "bin_init_region"
+        ],
+        [
+            "on",
+            "cuboid_barrier",
+            "barrier_init_region"
+        ]
+    ],
+    "goal_state": [
+        [
+            "on",
+            "cube_0",
+            "blocks_goal_region"
+        ]
+    ]
+}

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -42,6 +42,11 @@ MovableInGoalRegion = Predicate("MovableInGoalRegion", [MujocoMovableObjectType]
 OnGround = Predicate("OnGround", [MujocoObjectType])
 Holding = Predicate("Holding", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType])
 HandEmpty = Predicate("HandEmpty", [MujocoTidyBotRobotObjectType])
+# Named for the command because that is what it reads: a grasp that closes on nothing
+# leaves this true while Holding stays false.
+GripperCommandedClosed = Predicate(
+    "GripperCommandedClosed", [MujocoTidyBotRobotObjectType]
+)
 MovableIsDownX = Predicate(
     "MovableIsDownX", [MujocoMovableObjectType, MujocoMovableObjectType]
 )
@@ -98,6 +103,8 @@ class Tossing3DStateAbstractor:
 
         if self._check_gripper_open(state, robot):
             atoms.add(GroundAtom(HandEmpty, [robot]))
+        else:
+            atoms.add(GroundAtom(GripperCommandedClosed, [robot]))
 
         for cube in cubes:
             if self._check_on_ground(state, cube):

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -16,6 +16,7 @@ from kinder_models.dynamic3d.tossing.parameterized_skills import (
 )
 from kinder_models.dynamic3d.tossing.state_abstractions import (
     THROW_STANDOFF_BOUNDS,
+    GripperCommandedClosed,
     HandEmpty,
     Holding,
     MovableInGoalRegion,
@@ -81,6 +82,33 @@ def test_on_ground_fails_for_a_tilted_cube_at_the_same_height():
     tilted.set(cube, "qx", 0.5)
     atoms = abstractor.state_abstractor(tilted).atoms
     assert GroundAtom(OnGround, [cube]) not in atoms
+    env.close()
+
+
+def test_gripper_commanded_closed_is_absent_while_the_gripper_is_open():
+    """It is the negation of HandEmpty, so it must not hold at reset."""
+    env, abstractor, state = _make_env_and_abstractor()
+    robot = _get_robot_from_state(state)
+    atoms = abstractor.state_abstractor(state).atoms
+    assert GroundAtom(GripperCommandedClosed, [robot]) not in atoms
+    env.close()
+
+
+def test_gripper_commanded_closed_holds_after_a_grasp_closes_on_nothing():
+    """The command stays shut while the cube stays on the floor.
+
+    HandEmpty and Holding are both false here, which is the dead end this predicate
+    exists to name.
+    """
+    env, abstractor, state = _make_env_and_abstractor()
+    robot = _get_robot_from_state(state)
+    cube = state.get_object_from_name("cube_0")
+    shut = state.copy()
+    shut.set(robot, "pos_gripper", 1.0)
+    atoms = abstractor.state_abstractor(shut).atoms
+    assert GroundAtom(GripperCommandedClosed, [robot]) in atoms
+    assert GroundAtom(HandEmpty, [robot]) not in atoms
+    assert GroundAtom(Holding, [robot, cube]) not in atoms
     env.close()
 
 
@@ -295,7 +323,7 @@ def test_robot_at_throw_pose_agrees_with_whether_the_throw_scores(standoff, expe
 
 
 def test_the_abstractor_rejects_the_two_cube_variant():
-    """o2 is out of scope: no operator says which cube a throw is aimed at."""
+    """O2 is out of scope: no operator says which cube a throw is aimed at."""
     kinder.register_all_environments()
     env = kinder.make("kinder/Tossing3D-o2-v0", render_mode="rgb_array")
     sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access


### PR DESCRIPTION
**Tossing3D has a state the robot can reach and then never leave.** A grasp that closes on nothing leaves the gripper commanded shut with the cube still on the floor — and in that state `HandEmpty` and `Holding` are **both false**, so every operator in the domain is inapplicable. Forever. Measured on `4/10` reset-free EES seeds.

## The bug

The gripper is represented by one number, `pos_gripper`, and that number is the **command**, not the finger pose. Two predicates read it, from opposite ends:

`HandEmpty` requires the command to be ~0 —

https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/blob/b3f0d744de4158833b3fdd93638a3d1b1858fa6d/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py#L116-L128

`Holding` requires the command to be *past* a threshold **and** the cube to be lifted —

https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/blob/b3f0d744de4158833b3fdd93638a3d1b1858fa6d/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py#L145-L162

Close on nothing and you land between them. The command stays at `1.0`, so `HandEmpty` is false. The cube never leaves the floor, so `Holding` is false. And every operator needs one or the other:

| operator | needs |
| --- | --- |
| `pick_cube` | `HandEmpty` |
| `move_to_throw_pose` | `Holding` |
| `toss_from_windup` | `Holding` |

The applicable set is **empty**.

TODO: drop opengripper-dead-end-walkthrough-v2.mp4 here — http://agni:8765/opengripper-dead-end-walkthrough-v2.mp4

Four acts, 322 frames: the grasp missing, the gripper staying shut, all 7 registry skills driven in turn, then recovery. One frame shows `pos_gripper = 1.000`, fingers `[0.787, 0.787]`, `HandEmpty=False Holding=False OnGround=True` together.

### The gripper does not quietly recover — and the obvious test says it does

Driving a missed grasp and then idling for 500 steps:

| idle regime | command | fingers | |
| --- | --- | --- | --- |
| all-zeros action | `0.000` | `[0.0029, 0.0029]` | **misleading** |
| latched, what motion controllers emit | `1.000` | `[0.787, 0.787]` | stays shut indefinitely |

`OpenGripperController.step` returns exactly `np.zeros(11)`, so an all-zeros "do nothing" action **is the open command**. Every motion controller instead latches the gripper forward:

https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/blob/b3f0d744de4158833b3fdd93638a3d1b1858fa6d/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py#L155-L159

So the honest idle is the second row. Of the 7 controllers in the registry, `1/7` reopens the gripper — `open_gripper` — and it had **no operator**, so no planner could ever call it.

## The fix

Add the missing predicate and the missing operator:

- **`GripperCommandedClosed(?robot)`** — makes the between-the-two state nameable at all.
- **`open_gripper(?robot, ?held)`**, driving the controller this repo already ships. Preconditions `GripperCommandedClosed(?robot)`, `OnGround(?held)`; adds `HandEmpty`, deletes `GripperCommandedClosed`.

TODO: drop a before/after applicable-operators diagram here

Before the change, the applicable ground-operator set in that state is empty. After, `test_open_gripper_is_applicable_after_a_grasp_closes_on_nothing` asserts it is exactly `{"open_gripper"}`.

**Why `OnGround` is a precondition.** A downstream draft carried it only to satisfy Fast Downward's `seq-opt-lmcut`, which rejects the conditional effect a `Holding` delete compiles to. **That constraint does not exist here** — this is bilevel planning, not FD. It is kept for a better reason: without it the operator fires while genuinely `Holding` and asserts `HandEmpty` alongside it. The general alternative would claim a released cube lands `OnGround`, and the measurement below shows that is exactly what cannot be assumed.

**`CloseGripper` is not added.** `pick_shelf` closes the gripper internally as part of `pick_cube`, so closing is already reachable. Only opening was missing.

## What this does *not* fix, and why that is the more important finding

Of the `4/10` seeds that end shut-on-nothing, this unblocks **`1/4`**. **Quote the impact as `1/4`, never `4/10`.**

The other `3/4` also have the cube resting on a non-original face. That looked like a second modelling bug — `OnGround` requires `qx ≈ 0 ∧ qy ≈ 0`, a pure-yaw rotation, so it accepts only one of a cube's six faces, and a cube's faces are identical. **It is not a bug.** `pick_shelf` builds its grasp from the object's *full* pose, so the target end-effector orientation rotates with the cube:

https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/blob/b3f0d744de4158833b3fdd93638a3d1b1858fa6d/kinder-models/src/kinder_models/dynamic3d/shelf/parameterized_skills.py#L194-L197

Setting the cube to each of the six face-down rests, letting it settle, then running `pick_shelf`'s sampler for 10 base poses each:

| cube rest | settled `z − bb_z/2` | IK solutions |
| --- | --- | --- |
| identity | −0.0001 | **10/10** |
| yaw 90° about z | −0.0001 | **6/10** (4 sampler misses, not IK) |
| roll 180° about x | −0.0001 | **0/10** |
| roll ±90° about x | −0.0001 | **0/10** |
| pitch ±90° about y | −0.0001 | **0/10** |

All six settle flat, so the geometry reasoning was right; the graspability reasoning was wrong. The only IK-solvable class is near-identity-at-any-yaw — **exactly what `OnGround` already accepts**. The predicate is a correct model of `pick_shelf`'s reachable grasp set, and relaxing it would admit plans through picks that cannot execute.

So those three seeds are a **genuine controller limitation**, not a modelling artefact. `OnGround` is untouched here. This corrects the attribution in a downstream draft that called them an `OnGround` defect; that PR is left unedited.

## Test plan

- [x] `kinder-models` — **72/72 passed**, 1 skipped
- [x] `kinder-bilevel-planning` — **80/80 passed**, 1 skipped
- [x] `test_open_gripper_is_applicable_after_a_grasp_closes_on_nothing`, red-green verified
- [x] black, isort, docformatter, mypy clean; pylint **10.00/10** (`kinder-models`), 9.67/10 vs 8.96/10 on base (`kinder-bilevel-planning`). Plugin load proven — a scratch file using `np.random.rand` trips `C9900`.

Two pre-existing failures, verified identical on the base commit: `test_arm_controller.py` / `test_base_controller.py` fail to collect on `ModuleNotFoundError: ruckig` (optional dev dep absent here), and `E0401` on `from conftest import MAKE_VIDEOS`. CI on this branch fails at *collection*, inherited from #113 being blocked on a PyPI release of `kindergarden` — expected, not addressed here.

## Numbers this makes provisional

Tossing3D `ees` and `random-skills` results: a method now draws from four operators rather than three. That includes the reset-free `12.2/100`, whose headline is partly caused by this dead end. Nothing has been edited or recomputed.

## Followup

- A re-measurement will still show the other `3/4` stranding. That is now understood rather than mysterious.
- `open_gripper` had a controller and no operator for its whole life. Worth checking whether any other registry controller is in the same position.
