### PR TITLE
kinder-models: extract the simulator-free predicate checks into their own module

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/predicate_checks.py
+++ b/kinder-models/src/kinder_models/dynamic3d/predicate_checks.py
@@ -1,0 +1,86 @@
+"""The numeric cores of the dynamic3d state abstractions, free of any simulator import.
+
+Every dynamic3d state abstractor answers most of its predicates with a few lines of
+arithmetic over pose features, and those lines are the part worth sharing: shelf's
+abstractor and tossing's carry the same gripper-open test, the same on-ground test and
+the same grasped-and-lifted test, written out twice.
+
+Two properties, both deliberate, and both the reason this is a module rather than more
+private methods on the abstractors:
+
+- **It takes plain floats, not an `ObjectCentricState`.** An abstractor is the only way
+  to ask upstream whether a predicate holds, it answers for every predicate at once, and
+  it needs a state type a consumer with its own state representation cannot construct.
+  Arithmetic over floats has none of those constraints.
+- **It imports numpy and nothing else**, so importing it pulls in neither `kinder.envs`,
+  PyBullet nor MuJoCo. `utils.py` cannot offer that -- it exports `PyBulletSim` -- which
+  is why the tolerances moved here and are re-exported from there rather than the other
+  way around. `test_predicate_checks.py` asserts the property in a subprocess, so it
+  fails loudly if a future import erodes it.
+
+What is *not* here is anything needing the simulator: the forward kinematics behind
+`Holding` and the goal-region lookup behind `MovableInGoalRegion` both do, so the
+abstractor keeps them and calls in here for the rest.
+"""
+
+from typing import Sequence
+
+import numpy as np
+
+# State-abstraction tolerances, shared by every dynamic3d state_abstractor. They live
+# here rather than in utils.py so that reading a threshold does not cost a PyBullet
+# import; utils.py re-exports them, so its own callers are unaffected.
+GRIPPER_OPEN_COMMAND_TOLERANCE = 1e-3
+ON_GROUND_TOLERANCE = 0.05
+GRIPPER_GRASPING_THRESHOLD = 0.1
+MINIMUM_HOLDING_HEIGHT = 0.1
+END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE = 0.05
+
+
+def check_gripper_open(pos_gripper: float) -> bool:
+    """Whether the gripper is commanded open, which implies an empty hand.
+
+    Reads the command, not finger pose, so this and Holding are not complementary.
+    """
+    return bool(np.isclose(pos_gripper, 0.0, atol=GRIPPER_OPEN_COMMAND_TOLERANCE))
+
+
+def check_on_ground(z: float, bounding_box_height: float, qx: float, qy: float) -> bool:
+    """Whether a movable rests flat on the ground.
+
+    Flat because the bounding box is pose-independent, so the bottom-face arithmetic
+    only holds while axis-aligned. A toss cannot predict this.
+    """
+    return bool(
+        np.isclose(z - bounding_box_height / 2, 0.0, atol=ON_GROUND_TOLERANCE)
+        and np.isclose(qx, 0.0, atol=ON_GROUND_TOLERANCE)
+        and np.isclose(qy, 0.0, atol=ON_GROUND_TOLERANCE)
+    )
+
+
+def check_grasped_and_lifted(pos_gripper: float, z: float) -> bool:
+    """Whether the gripper is closed and the object is off the ground.
+
+    The simulator-free part of Holding. On its own it is weaker than Holding: it admits
+    a closed gripper and an airborne object that are not attached to each other -- a
+    thrown object mid-flight, say. Pair it with check_end_effector_at_object, which
+    needs forward kinematics, for the full test.
+    """
+    return bool(pos_gripper > GRIPPER_GRASPING_THRESHOLD and z > MINIMUM_HOLDING_HEIGHT)
+
+
+def check_end_effector_at_object(
+    end_effector_position: Sequence[float], object_position: Sequence[float]
+) -> bool:
+    """Whether the end effector is at an object, per axis rather than by distance."""
+    return bool(
+        all(
+            abs(float(ee) - float(obj)) < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
+            for ee, obj in zip(end_effector_position, object_position)
+        )
+    )
+
+
+def check_is_down_x(x: float, other_x: float) -> bool:
+    """Whether a movable is at lower x than another, read live rather than fixed."""
+    return bool(x < other_x)

--- a/kinder-models/src/kinder_models/dynamic3d/shelf/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/shelf/parameterized_skills.py
@@ -33,6 +33,9 @@ from relational_structs import (
 )
 from spatialmath import SE2
 
+from kinder_models.dynamic3d.predicate_checks import (
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
+)
 from kinder_models.dynamic3d.utils import (
     _ARM_MAX_ACCELERATION,
     _ARM_MAX_VELOCITY,
@@ -41,7 +44,6 @@ from kinder_models.dynamic3d.utils import (
     BASE_TO_CUPBOARD_ROTATION,
     GRASP_CLOSE_THRESHOLD,
     GRASP_TRANSFORM_TO_OBJECT,
-    GRIPPER_OPEN_COMMAND_TOLERANCE,
     MAX_SAMPLER_ATTEMPTS,
     MOVE_TO_TARGET_DISTANCE_BOUNDS,
     MOVE_TO_TARGET_ROT_BOUNDS,

--- a/kinder-models/src/kinder_models/dynamic3d/shelf/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/shelf/state_abstractions.py
@@ -18,14 +18,14 @@ from relational_structs import (
     Predicate,
 )
 
-from kinder_models.dynamic3d.shelf.parameterized_skills import PyBulletSim
-from kinder_models.dynamic3d.utils import (
+from kinder_models.dynamic3d.predicate_checks import (
     END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
     GRIPPER_GRASPING_THRESHOLD,
     GRIPPER_OPEN_COMMAND_TOLERANCE,
     MINIMUM_HOLDING_HEIGHT,
     ON_GROUND_TOLERANCE,
 )
+from kinder_models.dynamic3d.shelf.parameterized_skills import PyBulletSim
 
 # Predicates.
 OnFixture = Predicate("OnFixture", [MujocoObjectType, MujocoFixtureObjectType])

--- a/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/sweep3D/parameterized_skills.py
@@ -39,13 +39,15 @@ from relational_structs import (
 )
 from spatialmath import SE2
 
+from kinder_models.dynamic3d.predicate_checks import (
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
+)
 from kinder_models.dynamic3d.utils import (
     _ARM_MAX_ACCELERATION,
     _ARM_MAX_VELOCITY,
     DRAWER_TRANSFORM_TO_OBJECT,
     DRAWER_TRANSFORM_TO_OBJECT_END,
     GRASP_CLOSE_THRESHOLD,
-    GRIPPER_OPEN_COMMAND_TOLERANCE,
     OPEN_DRAWER_DISTANCE_BOUNDS,
     OPEN_DRAWER_ROT_BOUNDS,
     PICK_WIPER_DISTANCE_BOUNDS,

--- a/kinder-models/src/kinder_models/dynamic3d/sweep3D/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/sweep3D/state_abstractions.py
@@ -18,8 +18,8 @@ from relational_structs import (
     Predicate,
 )
 
+from kinder_models.dynamic3d.predicate_checks import GRIPPER_OPEN_COMMAND_TOLERANCE
 from kinder_models.dynamic3d.shelf.parameterized_skills import PyBulletSim
-from kinder_models.dynamic3d.utils import GRIPPER_OPEN_COMMAND_TOLERANCE
 
 # Predicates.
 DrawerOpen = Predicate("DrawerOpen", [MujocoDrawerObjectType])

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -30,13 +30,15 @@ from relational_structs import (
 )
 from spatialmath import SE2
 
+from kinder_models.dynamic3d.predicate_checks import (
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
+)
 from kinder_models.dynamic3d.utils import (
     _ARM_MAX_ACCELERATION,
     _ARM_MAX_VELOCITY,
     _CONTROL_TIMESTEP,
     GRASP_CLOSE_THRESHOLD,
     GRIPPER_CLOSED_THRESHOLD,
-    GRIPPER_OPEN_COMMAND_TOLERANCE,
     WAYPOINT_TOLERANCE,
     WORLD_X_BOUNDS,
     WORLD_Y_BOUNDS,

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -27,12 +27,14 @@ from relational_structs import (
     Predicate,
 )
 
+from kinder_models.dynamic3d.predicate_checks import (
+    check_end_effector_at_object,
+    check_grasped_and_lifted,
+    check_gripper_open,
+    check_is_down_x,
+    check_on_ground,
+)
 from kinder_models.dynamic3d.utils import (
-    END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
-    GRIPPER_GRASPING_THRESHOLD,
-    GRIPPER_OPEN_COMMAND_TOLERANCE,
-    MINIMUM_HOLDING_HEIGHT,
-    ON_GROUND_TOLERANCE,
     WAYPOINT_TOLERANCE,
     PyBulletSim,
 )
@@ -116,50 +118,40 @@ class Tossing3DStateAbstractor:
 
     @staticmethod
     def _check_gripper_open(state: ObjectCentricState, robot: Object) -> bool:
-        """Whether the gripper is commanded open, which implies an empty hand.
-
-        Reads the command, not finger pose, so this and Holding are not complementary.
-        """
-        return bool(
-            np.isclose(
-                state.get(robot, "pos_gripper"),
-                0.0,
-                atol=GRIPPER_OPEN_COMMAND_TOLERANCE,
-            )
-        )
+        """Whether the gripper is commanded open, which implies an empty hand."""
+        return check_gripper_open(state.get(robot, "pos_gripper"))
 
     @staticmethod
     def _check_on_ground(state: ObjectCentricState, movable: Object) -> bool:
-        """Whether a movable rests flat on the ground.
-
-        Flat because the bounding box is pose-independent, so the bottom-face
-        arithmetic only holds while axis-aligned. A toss cannot predict this.
-        """
-        z = state.get(movable, "z")
-        bounding_box_height = state.get(movable, "bb_z")
-        return bool(
-            np.isclose(z - bounding_box_height / 2, 0.0, atol=ON_GROUND_TOLERANCE)
-            and np.isclose(state.get(movable, "qx"), 0.0, atol=ON_GROUND_TOLERANCE)
-            and np.isclose(state.get(movable, "qy"), 0.0, atol=ON_GROUND_TOLERANCE)
+        """Whether a movable rests flat on the ground."""
+        return check_on_ground(
+            state.get(movable, "z"),
+            state.get(movable, "bb_z"),
+            state.get(movable, "qx"),
+            state.get(movable, "qy"),
         )
 
     def _check_holding(
         self, state: ObjectCentricState, robot: Object, movable: Object
     ) -> bool:
-        """Whether the gripper is closed on this movable and lifting it."""
-        z = state.get(movable, "z")
-        if (
-            state.get(robot, "pos_gripper") <= GRIPPER_GRASPING_THRESHOLD
-            or z <= MINIMUM_HOLDING_HEIGHT
+        """Whether the gripper is closed on this movable and lifting it.
+
+        The forward kinematics is why this one is not entirely in predicate_checks:
+        the end-effector pose comes from the PyBullet mirror of the state, so only the
+        comparison against it is simulator-free.
+        """
+        if not check_grasped_and_lifted(
+            state.get(robot, "pos_gripper"), state.get(movable, "z")
         ):
             return False
         ee_pose = self._pybullet_sim.get_ee_pose()
-        return bool(
-            abs(ee_pose.position[0] - state.get(movable, "x"))
-            < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
-            and abs(ee_pose.position[1] - state.get(movable, "y"))
-            < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
-            and abs(ee_pose.position[2] - z) < END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
+        return check_end_effector_at_object(
+            ee_pose.position,
+            (
+                state.get(movable, "x"),
+                state.get(movable, "y"),
+                state.get(movable, "z"),
+            ),
         )
 
     @staticmethod
@@ -167,7 +159,7 @@ class Tossing3DStateAbstractor:
         state: ObjectCentricState, movable: Object, other: Object
     ) -> bool:
         """Whether a movable is at lower x than another, read live rather than fixed."""
-        return state.get(movable, "x") < state.get(other, "x")
+        return check_is_down_x(state.get(movable, "x"), state.get(other, "x"))
 
     @staticmethod
     def _check_at_throw_pose(

--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -55,12 +55,9 @@ GRIPPER_CLOSED_THRESHOLD = 0.02
 # Waypoint tolerance for arm configuration convergence.
 WAYPOINT_TOLERANCE = 4 * 1e-2
 
-# State-abstraction tolerances, shared by every dynamic3d state_abstractor.
-GRIPPER_OPEN_COMMAND_TOLERANCE = 1e-3
-ON_GROUND_TOLERANCE = 0.05
-GRIPPER_GRASPING_THRESHOLD = 0.1
-MINIMUM_HOLDING_HEIGHT = 0.1
-END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE = 0.05
+# The state-abstraction tolerances moved to predicate_checks.py, which imports numpy and
+# nothing else. Reading one should not cost a PyBullet import, and importing them from
+# here would have kept that cost while hiding it.
 
 # Base navigation sampling bounds.
 MOVE_TO_TARGET_DISTANCE_BOUNDS = (0.5, 0.6)

--- a/kinder-models/tests/dynamic3d/test_predicate_checks.py
+++ b/kinder-models/tests/dynamic3d/test_predicate_checks.py
@@ -1,0 +1,92 @@
+"""Tests for dynamic3d predicate_checks.py."""
+
+import subprocess
+import sys
+
+import numpy as np
+
+from kinder_models.dynamic3d.predicate_checks import (
+    END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
+    GRIPPER_GRASPING_THRESHOLD,
+    GRIPPER_OPEN_COMMAND_TOLERANCE,
+    MINIMUM_HOLDING_HEIGHT,
+    ON_GROUND_TOLERANCE,
+    check_end_effector_at_object,
+    check_grasped_and_lifted,
+    check_gripper_open,
+    check_is_down_x,
+    check_on_ground,
+)
+
+
+def test_importing_this_module_pulls_in_no_simulator():
+    """The point of the module: arithmetic a consumer can import without KINDER.
+
+    Checked in a subprocess because the rest of this file's imports would otherwise
+    have loaded the simulator into this interpreter already.
+    """
+    program = (
+        "import sys\n"
+        "import kinder_models.dynamic3d.predicate_checks\n"
+        "loaded = [m for m in sys.modules if m.split('.')[0] in "
+        "('kinder', 'pybullet', 'mujoco', 'relational_structs', 'bilevel_planning')]\n"
+        "assert not loaded, loaded\n"
+    )
+    subprocess.run([sys.executable, "-c", program], check=True)
+
+
+def test_gripper_open_reads_the_command_at_upstream_tolerance():
+    """Open is a commanded zero, not a finger pose, so the tolerance is tiny."""
+    assert check_gripper_open(0.0)
+    assert check_gripper_open(GRIPPER_OPEN_COMMAND_TOLERANCE / 2)
+    assert not check_gripper_open(10 * GRIPPER_OPEN_COMMAND_TOLERANCE)
+
+
+def test_on_ground_needs_floor_height_and_flatness_together():
+    """Flatness is what keeps the bottom-face arithmetic valid, so it is required."""
+    assert check_on_ground(0.025, 0.05, 0.0, 0.0)
+    assert not check_on_ground(0.5, 0.05, 0.0, 0.0)
+    assert not check_on_ground(0.025, 0.05, 0.5, 0.0)
+    assert not check_on_ground(0.025, 0.05, 0.0, 0.5)
+
+
+def test_on_ground_is_inclusive_out_to_the_tolerance():
+    """The bottom face may sit a tolerance off the floor and still count."""
+    height = 0.05
+    assert check_on_ground(height / 2 + ON_GROUND_TOLERANCE / 2, height, 0.0, 0.0)
+    assert not check_on_ground(height / 2 + 2 * ON_GROUND_TOLERANCE, height, 0.0, 0.0)
+
+
+def test_grasped_and_lifted_needs_both_conjuncts():
+    """Neither a closed gripper nor a raised object is enough on its own."""
+    closed = 2 * GRIPPER_GRASPING_THRESHOLD
+    lifted = 2 * MINIMUM_HOLDING_HEIGHT
+    assert check_grasped_and_lifted(closed, lifted)
+    assert not check_grasped_and_lifted(GRIPPER_GRASPING_THRESHOLD / 2, lifted)
+    assert not check_grasped_and_lifted(closed, MINIMUM_HOLDING_HEIGHT / 2)
+
+
+def test_grasped_and_lifted_excludes_its_own_thresholds():
+    """Strict comparisons, so a value sitting exactly on a threshold does not hold."""
+    assert not check_grasped_and_lifted(
+        GRIPPER_GRASPING_THRESHOLD, 2 * MINIMUM_HOLDING_HEIGHT
+    )
+    assert not check_grasped_and_lifted(
+        2 * GRIPPER_GRASPING_THRESHOLD, MINIMUM_HOLDING_HEIGHT
+    )
+
+
+def test_end_effector_at_object_is_a_per_axis_box_not_a_sphere():
+    """Three independent axis tests, which admits the box's corners."""
+    offset = 0.9 * END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE
+    assert check_end_effector_at_object(np.array([offset, offset, offset]), np.zeros(3))
+    assert not check_end_effector_at_object(
+        np.array([2 * END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE, 0.0, 0.0]), np.zeros(3)
+    )
+
+
+def test_is_down_x_is_strict_so_equal_positions_do_not_hold():
+    """A cube exactly at the barrier is not yet past it, and not yet short of it."""
+    assert check_is_down_x(0.5, 1.3)
+    assert not check_is_down_x(1.3, 1.3)
+    assert not check_is_down_x(2.0, 1.3)


### PR DESCRIPTION
## Summary

The dynamic3d state abstractors answer most of their predicates with a few lines of arithmetic over pose features, but there is no way to ask for one of them. The only entry point is `Tossing3DStateAbstractor(sim).state_abstractor(state)`: a stateful class whose `__init__` calls `sim.reset()` and constructs a `PyBulletSim`, which answers for every predicate at once, and which needs an `ObjectCentricState` a consumer with its own state representation cannot construct. So consumers reimplement the arithmetic instead, and then it drifts.

This moves that arithmetic, and the five tolerances it reads, into `kinder_models/dynamic3d/predicate_checks.py`. Two properties, both deliberate:

- **It takes plain floats**, not an `ObjectCentricState`, so a caller holding some other state representation can use it.
- **It imports numpy and nothing else**, so importing it pulls in neither `kinder.envs`, PyBullet nor MuJoCo. `test_importing_this_module_pulls_in_no_simulator` asserts that in a subprocess — necessarily, since the test file's own other imports would otherwise have loaded the simulator into the interpreter already.

The tolerances **move** rather than being re-exported from `utils.py`. `utils.py` exports `PyBulletSim`, so importing a threshold from there costs a PyBullet import; re-exporting would have kept that cost while hiding it. Every importer moves with them (`shelf`, `sweep3D` and `tossing` skills and abstractors) — five files, import lines only.

Behaviour is unchanged. The Tossing3D abstractor now calls in here for four of its six checks and keeps the two that genuinely need the simulator: the forward kinematics behind `Holding`, and the goal-region lookup behind `MovableInGoalRegion`. `_check_holding` is split accordingly — `check_grasped_and_lifted` is the simulator-free pair of conjuncts, `check_end_effector_at_object` is the comparison against an end-effector pose the caller supplies.

Not done here, and worth a separate look: `shelf/state_abstractions.py` still writes the same on-ground and grasped-and-lifted arithmetic out by hand. It is behaviour-identical to what moved, but refactoring it touches Shelf3D, so it is left out of a PR that is otherwise additive.

## Test plan

- [x] `pytest tests/dynamic3d/test_predicate_checks.py -q` — 8 passed (new file)
- [x] `pytest tests/dynamic3d/tossing/test_tossing_state_abstractions.py -q` — 11 passed, unchanged from before this PR
- [x] `pytest tests/dynamic3d/shelf tests/dynamic3d/sweep3D tests/dynamic3d/test_dynamic3d_utils.py -q` — 13 passed, covering the five files whose imports moved
- [x] `pylint --rcfile=.pylintrc <changed files>` — 10.00/10, with `PYTHONPATH` set to the package directory so `pylint_plugins.no_np_random` actually loads (verified by probing a file containing `np.random.rand()` and seeing `C9900` fire; without the plugin pylint reports `E0013` and still scores 10.00)
- [x] `mypy . --no-incremental` — no new errors; the 3 reported are pre-existing `import-not-found` for `astroid`/`pylint` stubs in `pylint_plugins/`, absent from the environment used
- [x] `black`, `isort`, `docformatter` via the package's own `run_autoformat.sh` tooling, on the changed files only

## Followup

- `shelf/state_abstractions.py` and `sweep3D/state_abstractions.py` can call the same helpers.
- CI on this branch currently fails at collection, inherited from the open stack below it being blocked on a `kindergarden` PyPI release. Expected, and unrelated to this change.
