### PR TITLE
kinder-models: derive RobotAtThrowPose from the scored region, not the sampler's range

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/predicate_checks.py
+++ b/kinder-models/src/kinder_models/dynamic3d/predicate_checks.py
@@ -84,3 +84,30 @@ def check_end_effector_at_object(
 def check_is_down_x(x: float, other_x: float) -> bool:
     """Whether a movable is at lower x than another, read live rather than fixed."""
     return bool(x < other_x)
+
+
+def check_reach_interval_hits_box(
+    base_x: float,
+    reach_min: float,
+    reach_max: float,
+    box_x_min: float,
+    box_x_max: float,
+) -> bool:
+    """Whether a throw from base_x can land inside [box_x_min, box_x_max].
+
+    A throw from a fixed windup displaces the object by a distance set by the toss
+    parameters and not by the scene, so the set of x it can reach from base_x is the
+    interval [base_x + reach_min, base_x + reach_max]. The pose is throwable-from iff
+    that interval meets the box -- iff *some* toss parameterisation scores from here.
+    A controller with a single fixed toss passes reach_min == reach_max, which
+    degenerates to a point and is the same test.
+
+    **Deriving the acceptance band this way, rather than accepting the range the base
+    sampler draws from, is the whole point of the function.** The two are easy to
+    conflate and the failure is silent: if a "robot is at a throw pose" predicate
+    accepts exactly the standoffs the sampler can produce, then the move-to-throw-pose
+    operator's only add effect holds after every attempt by construction. A learner
+    that trains a per-skill success classifier on that label sees a single class and
+    never improves on its uniform prior, and nothing about the run looks wrong.
+    """
+    return bool(base_x + reach_min <= box_x_max and box_x_min <= base_x + reach_max)

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -33,6 +33,7 @@ from kinder_models.dynamic3d.predicate_checks import (
     check_gripper_open,
     check_is_down_x,
     check_on_ground,
+    check_reach_interval_hits_box,
 )
 from kinder_models.dynamic3d.utils import (
     WAYPOINT_TOLERANCE,
@@ -58,8 +59,51 @@ CUBE_NAME_PREFIX = "cube"
 BIN_NAME_PREFIX = "bin"
 BARRIER_NAME = "cuboid_barrier"
 
-# Throwable-from standoffs, not the 0.5 m grasping one. Brackets the test's 1.35 m.
+# Throwable-from standoffs, not the 0.5 m grasping one: the range a base sampler may
+# draw from, which is about where a throw is *possible at all*.
+#
+# **This is the sampler's range only, and RobotAtThrowPose deliberately does not accept
+# it.** The two were the same interval until this predicate was rewritten, and that
+# identity is a defect rather than a convenience: MoveToThrowPose's only add effect is
+# RobotAtThrowPose, so a predicate accepting every standoff the sampler can draw is an
+# add effect satisfied by construction on every attempt. Downstream, hitl-pmp measured
+# what that costs on its port of this domain -- 16/16 attempts labelled success against
+# 0/16 informed draws, versus 7/20 informed for a pick skill in the same run -- because
+# a per-skill success classifier trained on a constant-true label has one class to learn
+# from. Widening this constant must not widen the predicate.
 THROW_STANDOFF_BOUNDS = (1.20, 1.65)
+
+# The distance the shipped toss carries the cube before its first ground contact, in
+# metres. A property of the controller -- the two fixed arm configurations and the
+# cube's mass -- not of the scene, so the band below can be recomputed from live
+# geometry on every call and stays correct when the bin or the goal region moves.
+#
+# Calibrated downstream in hitl-pmp, against where success breaks rather than in free
+# flight, and the difference is a trap: throwing onto open floor and recording where the
+# cube comes to rest gives 1.3499 m (sd 0.0024, n = 12), which is ~0.075 m longer
+# because it includes post-impact roll. The goal-region test needs the *impact* range,
+# since a cube landing inside the region is caught by the bin rather than rolling on.
+# Two independent sweeps bracket the impact range to (1.2608, 1.3090) and, from the two
+# edges of partial solving independently, to 1.2749 from each end.
+#
+# That calibration was taken with the gripper opening on the first control step past
+# release fraction 0.46, which is exactly what TossController does, so it describes this
+# controller rather than approximating it.
+THROW_REACH = 1.275
+
+# **The band is the region's own edges, untrimmed, and the trimming a downstream port
+# applies is deliberately not copied here.** hitl-pmp narrows this box by two margins it
+# measured (0.025 m and 0.05 m), because a 5-seed sweep found the standoffs solving on
+# every seed to be narrower than the geometric prediction at both ends. Those margins
+# were measured against its own hand-composed throw and indexed by *commanded* standoff,
+# and commanded standoff is not what this predicate reads: driving move_to_target to a
+# commanded 1.35 m leaves the base 1.3778 m from the bin, 27.8 mm short, well inside
+# WAYPOINT_TOLERANCE but a third of the width either margin would trim. Transplanting
+# them would import a 28 mm indexing error along with the measurement.
+#
+# The untrimmed band is already what fixes the defect: it is derived from the scored
+# region rather than from the sampler's range, so the add effect can fail. A consumer
+# with its own reliability measurement can pass an already-trimmed box.
 
 # Wider than WAYPOINT_TOLERANCE: the sampler already spends half of it off-axis.
 THROW_POSE_TOLERANCE = 2 * WAYPOINT_TOLERANCE
@@ -161,12 +205,18 @@ class Tossing3DStateAbstractor:
         """Whether a movable is at lower x than another, read live rather than fixed."""
         return check_is_down_x(state.get(movable, "x"), state.get(other, "x"))
 
-    @staticmethod
     def _check_at_throw_pose(
-        state: ObjectCentricState, robot: Object, target: Object
+        self, state: ObjectCentricState, robot: Object, target: Object
     ) -> bool:
-        """Whether the base is at a throwable standoff, on axis, facing the target."""
-        low, high = THROW_STANDOFF_BOUNDS
+        """Whether a throw from the base's pose would land the object in the region.
+
+        A success test, not a reachability test. The standoff conjunct asks whether the
+        throw's own displacement carries the object into the scored box, read live off
+        the goal region, rather than whether the standoff lies in the interval a sampler
+        draws from -- see THROW_STANDOFF_BOUNDS for why the latter cannot be learned
+        from. Move the bin, resize the region or change the ground placement threshold
+        and the band follows on its own.
+        """
         dx = state.get(target, "x") - state.get(robot, "pos_base_x")
         dy = state.get(target, "y") - state.get(robot, "pos_base_y")
         heading_error = abs(
@@ -174,11 +224,35 @@ class Tossing3DStateAbstractor:
                 np.arctan2(dy, dx), state.get(robot, "pos_base_rot")
             )
         )
-        return bool(
-            abs(dy) <= THROW_POSE_TOLERANCE
-            and low - THROW_POSE_TOLERANCE <= dx <= high + THROW_POSE_TOLERANCE
-            and heading_error <= THROW_POSE_TOLERANCE
+        if abs(dy) > THROW_POSE_TOLERANCE or heading_error > THROW_POSE_TOLERANCE:
+            return False
+        x_min, _, _, x_max, _, _ = self._goal_region_bbox()
+        return check_reach_interval_hits_box(
+            state.get(robot, "pos_base_x"), THROW_REACH, THROW_REACH, x_min, x_max
         )
+
+    def _goal_region_bbox(self) -> tuple[float, float, float, float, float, float]:
+        """The live world-frame box _check_goals() scores containment in.
+
+        Region.bbox only reads the site's simulated position when the region carries an
+        env; ground regions are constructed with env=None, so it otherwise falls back to
+        an XML/parent-frame value. check_in_region handles that by swapping env in and
+        back out, and so does this, rather than leaving a sim reference behind on a
+        region that was deliberately left bare.
+        """
+        ground_fixture = self._sim._ground_fixture  # pylint: disable=protected-access
+        assert ground_fixture is not None, "Ground fixture not initialized"
+        found = ground_fixture.region_objects.get(GOAL_REGION_NAME, [])
+        assert len(found) == 1, f"expected one {GOAL_REGION_NAME}, found {len(found)}"
+        region = found[0]
+        original = region.env
+        region.env = self._sim._robot_env  # pylint: disable=protected-access
+        try:
+            bbox = tuple(float(value) for value in region.bbox)
+        finally:
+            region.env = original
+        assert len(bbox) == 6, f"{GOAL_REGION_NAME} is not a single box: {bbox}"
+        return bbox  # type: ignore[return-value]
 
     def goal_deriver(self, state: ObjectCentricState) -> RelationalAbstractGoal:
         """The goal is to toss every cube into the goal region."""

--- a/kinder-models/tests/dynamic3d/test_predicate_checks.py
+++ b/kinder-models/tests/dynamic3d/test_predicate_checks.py
@@ -16,6 +16,7 @@ from kinder_models.dynamic3d.predicate_checks import (
     check_gripper_open,
     check_is_down_x,
     check_on_ground,
+    check_reach_interval_hits_box,
 )
 
 
@@ -83,6 +84,32 @@ def test_end_effector_at_object_is_a_per_axis_box_not_a_sphere():
     assert not check_end_effector_at_object(
         np.array([2 * END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE, 0.0, 0.0]), np.zeros(3)
     )
+
+
+def test_reach_interval_hits_box_is_an_interval_intersection_not_containment():
+    """Reaching *into* the box is enough; the whole interval need not fit inside."""
+    assert check_reach_interval_hits_box(0.0, 0.5, 5.0, 1.0, 2.0)
+    assert check_reach_interval_hits_box(0.0, 1.2, 1.8, 1.0, 2.0)
+    assert not check_reach_interval_hits_box(0.0, 2.5, 3.0, 1.0, 2.0)
+    assert not check_reach_interval_hits_box(0.0, 0.1, 0.9, 1.0, 2.0)
+
+
+def test_reach_interval_hits_box_is_inclusive_at_both_edges():
+    """Touching an edge counts, matching the region test the band has to agree with."""
+    assert check_reach_interval_hits_box(0.0, 2.0, 3.0, 1.0, 2.0)
+    assert check_reach_interval_hits_box(0.0, 0.5, 1.0, 1.0, 2.0)
+
+
+def test_a_single_fixed_throw_is_the_degenerate_interval():
+    """reach_min == reach_max reduces to asking whether one landing point is in box."""
+    assert check_reach_interval_hits_box(0.6, 1.275, 1.275, 1.85, 2.15)
+    assert not check_reach_interval_hits_box(0.4, 1.275, 1.275, 1.85, 2.15)
+
+
+def test_the_band_tracks_the_box_rather_than_the_reach():
+    """Shifting the box shifts exactly which base positions are accepted."""
+    assert check_reach_interval_hits_box(1.6, 1.275, 1.275, 2.85, 3.15)
+    assert not check_reach_interval_hits_box(0.6, 1.275, 1.275, 2.85, 3.15)
 
 
 def test_is_down_x_is_strict_so_equal_positions_do_not_hold():

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -1,5 +1,7 @@
 """Tests for tossing state_abstractions.py."""
 
+from unittest import mock
+
 import kinder
 import numpy as np
 import pytest
@@ -9,10 +11,13 @@ from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
 from relational_structs import GroundAtom, ObjectCentricState
 from relational_structs.spaces import ObjectCentricBoxSpace
 
+from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     create_lifted_controllers,
 )
 from kinder_models.dynamic3d.tossing.state_abstractions import (
+    THROW_REACH,
+    THROW_STANDOFF_BOUNDS,
     HandEmpty,
     Holding,
     MovableInGoalRegion,
@@ -24,6 +29,9 @@ from kinder_models.dynamic3d.tossing.state_abstractions import (
 
 # The standoff the pick-and-toss tests drive to, inside THROW_STANDOFF_BOUNDS.
 THROW_STANDOFF = 1.35
+
+# Also inside THROW_STANDOFF_BOUNDS, and far enough back that the throw falls short.
+UNREACHING_STANDOFF = 1.60
 
 
 def _get_robot_from_state(state: ObjectCentricState):
@@ -180,6 +188,136 @@ def test_robot_at_throw_pose_holds_after_driving_to_a_throw_standoff():
 
     atoms = abstractor.state_abstractor(state).atoms
     assert GroundAtom(RobotAtThrowPose, [robot, target_bin]) in atoms
+    env.close()
+
+
+def test_robot_at_throw_pose_fails_at_a_standoff_the_sampler_can_draw():
+    """The add effect has to be able to fail, or its sampler has nothing to learn.
+
+    1.60 m sits inside THROW_STANDOFF_BOUNDS, so a base sampler drawing from that
+    range can produce it, and the predicate accepted it until the band was derived
+    from the scored region instead. From there the throw lands ~0.175 m short of the
+    region, which is why accepting it made MoveToThrowPose's only add effect
+    constant-true.
+    """
+    env, abstractor, state = _make_env_and_abstractor()
+    robot = _get_robot_from_state(state)
+    target_bin = state.get_object_from_name("bin_0")
+    assert THROW_STANDOFF_BOUNDS[0] <= UNREACHING_STANDOFF <= THROW_STANDOFF_BOUNDS[1]
+    controller = create_lifted_controllers(env.action_space)["move_to_target"].ground(
+        (robot, target_bin)
+    )
+    controller.reset(
+        state,
+        np.array([UNREACHING_STANDOFF, 0.0]),
+        disable_collision_objects=["cube_0"],
+    )
+    for _ in range(300):
+        obs, _, _, _, _ = env.step(controller.step())
+        state = env.observation_space.devectorize(obs)
+        controller.observe(state)
+        if controller.terminated():
+            break
+    else:
+        assert False, "Controller did not terminate"
+
+    atoms = abstractor.state_abstractor(state).atoms
+    assert GroundAtom(RobotAtThrowPose, [robot, target_bin]) not in atoms
+    env.close()
+
+
+def test_the_accepted_band_follows_the_goal_region_rather_than_a_literal():
+    """Move the scored box and the band moves with it, since it is derived from it.
+
+    The band is not written down anywhere: it falls out of the region's own edges and
+    THROW_REACH. Shifting the region 1 m up-x must therefore shift the accepted
+    standoffs by the same metre, which a hard-coded interval would not do.
+    """
+    env, abstractor, state = _make_env_and_abstractor()
+    robot = _get_robot_from_state(state)
+    target_bin = state.get_object_from_name("bin_0")
+    bbox = abstractor._goal_region_bbox()  # pylint: disable=protected-access
+    x_min, y_min, z_min, x_max, y_max, z_max = bbox
+
+    def accepts(base_x: float) -> bool:
+        moved = state.copy()
+        moved.set(robot, "pos_base_x", base_x)
+        moved.set(robot, "pos_base_y", state.get(target_bin, "y"))
+        moved.set(robot, "pos_base_rot", 0.0)
+        return GroundAtom(RobotAtThrowPose, [robot, target_bin]) in (
+            abstractor.state_abstractor(moved).atoms
+        )
+
+    on_axis_hit = (x_min + x_max) / 2 - THROW_REACH
+    assert accepts(on_axis_hit)
+    assert not accepts(on_axis_hit + 1.0)
+
+    shifted = (x_min + 1.0, y_min, z_min, x_max + 1.0, y_max, z_max)
+    with mock.patch.object(abstractor, "_goal_region_bbox", return_value=shifted):
+        assert accepts(on_axis_hit + 1.0)
+        assert not accepts(on_axis_hit)
+    env.close()
+
+
+@pytest.mark.parametrize(
+    ("standoff", "expected"), [(THROW_STANDOFF, True), (UNREACHING_STANDOFF, False)]
+)
+def test_robot_at_throw_pose_agrees_with_whether_the_throw_scores(standoff, expected):
+    """The calibration guard for THROW_REACH, against real episode outcomes.
+
+    Everything else in the band is read from live geometry, so this one constant is
+    the only thing that can go stale -- and it goes stale silently, since a wrong value
+    still yields a plausible-looking band. Changing the toss controller, the windup
+    configuration, the cube's mass or the physics step is what fails here.
+
+    Asserting the predicate against _check_goals() rather than against a recorded
+    number is what makes it a check that the symbolic layer still describes the
+    dynamics: both standoffs are ones a base sampler may draw, and the predicate has to
+    say the same thing the throw does at each.
+    """
+    env, abstractor, state = _make_env_and_abstractor()
+    robot = _get_robot_from_state(state)
+    cube = state.get_object_from_name("cube_0")
+    target_bin = state.get_object_from_name("bin_0")
+    controllers = create_lifted_controllers(env.action_space)
+
+    def run(controller, steps: int) -> None:
+        nonlocal state
+        for _ in range(steps):
+            obs, _, _, _, _ = env.step(controller.step())
+            state = env.observation_space.devectorize(obs)
+            controller.observe(state)
+            if controller.terminated():
+                return
+        assert False, "Controller did not terminate"
+
+    picker = shelf_skills.create_lifted_controllers(env.action_space)[
+        "pick_shelf"
+    ].ground((robot, cube))
+    picker.reset(state, picker.sample_parameters(state, np.random.default_rng(123)))
+    run(picker, 400)
+
+    mover = controllers["move_to_target"].ground((robot, target_bin))
+    mover.reset(state, np.array([standoff, 0.0]), disable_collision_objects=["cube_0"])
+    run(mover, 300)
+
+    at_throw_pose = GroundAtom(RobotAtThrowPose, [robot, target_bin]) in (
+        abstractor.state_abstractor(state).atoms
+    )
+
+    windup = controllers["move_arm_to_conf"].ground((robot,))
+    windup.reset(state, np.deg2rad([0, 50, 180, -110, 0, -100, 90]))
+    run(windup, 200)
+    tosser = controllers["toss"].ground((robot,))
+    tosser.reset(state, np.deg2rad([0, 20, 180, -35, 0, 25, 90]))
+    run(tosser, 200)
+
+    scored = bool(abstractor._sim._check_goals())  # pylint: disable=protected-access
+    assert at_throw_pose == expected
+    assert scored == expected, (
+        f"at standoff {standoff} the throw scored {scored} but the predicate said "
+        f"{at_throw_pose}; THROW_REACH = {THROW_REACH} is no longer calibrated"
+    )
     env.close()
 
 


### PR DESCRIPTION
## Summary

`RobotAtThrowPose` accepted any standoff inside `THROW_STANDOFF_BOUNDS = (1.20, 1.65)`, which is the range a base sampler draws from. On the bilevel-planning branch stacked above this one, `TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45)` sits strictly inside it, and its own comment says as much:

```python
# Not the (0.5, 0.6) grasping range. Sits inside THROW_STANDOFF_BOUNDS, so every draw
# satisfies RobotAtThrowPose.
```

`MoveToThrowPose`'s only add effect is `RobotAtThrowPose`. So that containment makes the add effect hold after every attempt by construction: the label is constant-true, a per-skill success classifier trained on it sees one class, and the sampler never improves on its uniform prior — with nothing about the run looking wrong. This is not hypothetical. A downstream port of this domain (`hitl-pmp`) shipped the same predicate, measured `16/16` attempts labelled success against `0/16` informed draws — versus `7/20` informed for a pick skill in the same run — and spent four PRs removing it.

**The fix is to ask a different question**: not "is this standoff one a sampler could produce", but "does the throw's own displacement carry the object into the scored region". The region is read live off `blocks_goal_region`, so the accepted band follows the bin and the region when either moves, rather than being a literal that goes stale. The interval form (`check_reach_interval_hits_box`) takes a reach *interval* so a controller with tunable toss parameters can ask whether *some* parameterisation scores; the shipped toss is fixed, so it passes the degenerate `reach_min == reach_max`.

`THROW_STANDOFF_BOUNDS` stays, re-commented, as the sampler's range and explicitly *not* the predicate's acceptance interval — the two must not be re-coupled or the tautology returns silently.

**One constant is calibrated rather than derived**: `THROW_REACH = 1.275`, the distance the shipped toss carries the cube before first ground contact. It is a property of the controller (the two fixed arm configurations, the cube's mass), not of the scene. It comes from downstream calibration against *where success breaks*, not from free flight — throwing onto open floor and recording where the cube rests gives 1.3499 m (sd 0.0024, n = 12), ~0.075 m longer because it includes post-impact roll, and the region test needs the impact range. That calibration was taken with the gripper opening on the first control step past release fraction 0.46, which is exactly what `TossController` does here.

**The downstream reliability margins are deliberately not copied.** `hitl-pmp` narrows the box by 0.025 m and 0.05 m, because a 5-seed sweep found the standoffs solving on every seed narrower than the geometric prediction at both ends. Those margins are indexed by *commanded* standoff, and commanded standoff is not what this predicate reads: driving `move_to_target` to a commanded 1.35 m leaves the base 1.3778 m from the bin — 27.8 mm short, comfortably inside `WAYPOINT_TOLERANCE`, but a third of what either margin trims. Transplanting them would import a 28 mm indexing error along with the measurement. Measured on this branch, `seed=125`:

| commanded standoff | achieved base x | achieved standoff | predicted landing x |
| --- | --- | --- | --- |
| 1.35 | 0.6222 | 1.3778 | 1.8972 |
| 1.60 | 0.3727 | 1.6273 | 1.6477 |

**Note for the branch stacked above.** With this landed, `TOSS_TARGET_DISTANCE_BOUNDS = (1.25, 1.45)` is no longer constant-true — draws above ~1.375 are rejected — which is the point, but it does change what that sampler's label distribution looks like. Nothing on that branch is touched here.

## Test plan

All run against a real simulator, `seed=125`.

- [x] `pytest tests/dynamic3d/tossing/test_tossing_state_abstractions.py -q` — 15 passed
- [x] `pytest tests/dynamic3d/tossing tests/dynamic3d/test_predicate_checks.py -q` — 38 passed
- [x] New `test_robot_at_throw_pose_fails_at_a_standoff_the_sampler_can_draw`: drives to 1.60 m, inside `THROW_STANDOFF_BOUNDS`, and asserts the atom is **absent**. Fails against the pre-fix predicate — which is the defect stated as a test.
- [x] New `test_robot_at_throw_pose_agrees_with_whether_the_throw_scores`: full pick → move-to-standoff → windup → toss at 1.35 and 1.60, asserting the predicate and `_check_goals()` give the same verdict at each. This is the calibration guard for `THROW_REACH`, against real episode outcomes rather than a recorded number.
- [x] New `test_the_accepted_band_follows_the_goal_region_rather_than_a_literal`: shifting the region 1 m shifts the accepted base positions by the same metre.
- [x] Existing `test_robot_at_throw_pose_holds_after_driving_to_a_throw_standoff` (1.35 m) still passes, unmodified.
- [x] Both new behavioural tests confirmed **red** against the pre-fix check body before the fix, with the rest of the diff in place.
- [x] `pylint --rcfile=.pylintrc <changed files>` — 10.00/10, plugin load proven as in the PR below.
- [x] `mypy . --no-incremental` — no new errors.

## Followup

- The heading conjunct is unchanged and still uses `THROW_POSE_TOLERANCE`; only the standoff conjunct moved.
- A consumer with its own reliability measurement can pass an already-trimmed box rather than the region's raw edges.
