### PR TITLE
kinder-bilevel-planning: add bilevel planning models for Tossing3D

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -1,0 +1,186 @@
+"""Bilevel planning models for the TidyBot3D Tossing3D environment.
+
+Two operators over five predicates. The base move and the throw are one skill, so no
+predicate has to name the pose between them; the pick takes no continuous parameters,
+so refinement backtracks over the throw alone.
+
+TODO: only Tossing3D-o1 is supported; no operator says which cube a throw is aimed at.
+"""
+
+from pathlib import Path
+
+import kinder
+import numpy as np
+from bilevel_planning.structs import (
+    LiftedSkill,
+    SesameModels,
+)
+from gymnasium.spaces import Space
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoFixtureObjectType,
+    MujocoMovableObjectType,
+    MujocoObjectType,
+    MujocoTidyBotRobotObjectType,
+)
+from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionSpace
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    PyBulletSim,
+    create_lifted_controllers,
+)
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    HandEmpty,
+    Holding,
+    MovableInGoalRegion,
+    MovableIsDownX,
+    OnGround,
+    Tossing3DStateAbstractor,
+)
+from numpy.typing import NDArray
+from relational_structs import (
+    LiftedAtom,
+    LiftedOperator,
+    ObjectCentricState,
+    Variable,
+)
+from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
+
+
+def create_bilevel_planning_models(
+    observation_space: Space,
+    action_space: Space,
+    num_objects: int = 1,
+) -> SesameModels:
+    """Create the env models for TidyBot Tossing3D."""
+    assert isinstance(observation_space, ObjectCentricBoxSpace)
+    assert isinstance(action_space, TidyBot3DRobotActionSpace)
+    if num_objects != 1:
+        raise NotImplementedError(
+            f"Tossing3D bilevel planning supports one cube, got {num_objects}. The "
+            "operators do not say which cube a throw is aimed at."
+        )
+
+    task_config_path = str(
+        Path(kinder.__file__).parent
+        / "envs"
+        / "dynamic3d"
+        / "tasks"
+        / "Tossing3D"
+        / f"Tossing3D-o{num_objects}.json"
+    )
+    sim = ObjectCentricTidyBot3DEnv(
+        task_config_path=task_config_path,
+        num_objects=num_objects,
+        allow_state_access=True,
+    )
+
+    # State and goal abstractors.
+    abstractor = Tossing3DStateAbstractor(sim)
+    state_abstractor = abstractor.state_abstractor
+    goal_deriver = abstractor.goal_deriver
+
+    # Need to call reset to initialize the qpos, qvel.
+    initial_state, _ = sim.reset()
+
+    def observation_to_state(o: NDArray[np.float32]) -> ObjectCentricState:
+        """Convert the vectors back into (hashable) object-centric states."""
+        return observation_space.devectorize(o)
+
+    def transition_fn(
+        x: ObjectCentricState,
+        u: NDArray[np.float32],
+    ) -> ObjectCentricState:
+        """Simulate the action."""
+        state = x.copy()
+        sim.set_state(state)
+        obs, _, _, _, _ = sim.step(u)
+        return obs.copy()
+
+    types = {
+        MujocoTidyBotRobotObjectType,
+        MujocoObjectType,
+        MujocoFixtureObjectType,
+        MujocoMovableObjectType,
+    }
+
+    state_space = ObjectCentricStateSpace(types)
+
+    predicates = {
+        HandEmpty,
+        Holding,
+        MovableInGoalRegion,
+        MovableIsDownX,
+        OnGround,
+    }
+
+    # Pick the cube up off the ground.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    cube = Variable("?cube", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    PickCubeOperator = LiftedOperator(
+        "pick_cube",
+        [robot, cube, barrier],
+        preconditions={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [cube]),
+            # Only a cube still on this side of the barrier can be reached.
+            LiftedAtom(MovableIsDownX, [cube, barrier]),
+        },
+        add_effects={LiftedAtom(Holding, [robot, cube])},
+        delete_effects={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [cube]),
+        },
+    )
+
+    # Drive to a pose to throw from, and throw.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    target = Variable("?target", MujocoObjectType)
+    held = Variable("?held", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    MoveToTossLocationAndTossOperator = LiftedOperator(
+        "move_to_toss_location_and_toss",
+        [robot, target, held, barrier],
+        preconditions={LiftedAtom(Holding, [robot, held])},
+        add_effects={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(MovableInGoalRegion, [held]),
+            # Measured on 20 throws: 15/15 that scored left the cube resting on a face.
+            LiftedAtom(OnGround, [held]),
+        },
+        delete_effects={
+            LiftedAtom(Holding, [robot, held]),
+            # The one-way door: past the barrier the cube cannot be picked again.
+            LiftedAtom(MovableIsDownX, [held, barrier]),
+        },
+    )
+
+    # Controllers.
+    assert initial_state is not None
+    pybullet_sim = PyBulletSim(initial_state, rendering=False)
+    controllers = create_lifted_controllers(
+        action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
+    )
+
+    skills = {
+        LiftedSkill(PickCubeOperator, controllers["pick_cube"]),
+        LiftedSkill(
+            MoveToTossLocationAndTossOperator,
+            controllers["move_to_toss_location_and_toss"],
+        ),
+    }
+
+    return SesameModels(
+        observation_space,
+        state_space,
+        action_space,
+        transition_fn,
+        types,
+        predicates,
+        observation_to_state,
+        state_abstractor,
+        goal_deriver,
+        skills,
+    )

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -31,6 +31,7 @@ from kinder_models.dynamic3d.tossing.parameterized_skills import (
 from kinder_models.dynamic3d.tossing.state_abstractions import (
     HandEmpty,
     Holding,
+    IsThrowTarget,
     MovableInGoalRegion,
     MovableIsDownX,
     OnGround,
@@ -108,6 +109,7 @@ def create_bilevel_planning_models(
     predicates = {
         HandEmpty,
         Holding,
+        IsThrowTarget,
         MovableInGoalRegion,
         MovableIsDownX,
         OnGround,
@@ -143,7 +145,22 @@ def create_bilevel_planning_models(
     MoveToTossLocationAndTossOperator = LiftedOperator(
         "move_to_toss_location_and_toss",
         [robot, target, held, barrier],
-        preconditions={LiftedAtom(Holding, [robot, held])},
+        preconditions={
+            LiftedAtom(Holding, [robot, held]),
+            # Upstream gives the bin the same type as the cube and the barrier, so
+            # without this the grounder is free to bind ?target to either of those --
+            # a discrete mistake no amount of continuous sampling can recover from.
+            LiftedAtom(IsThrowTarget, [target]),
+            # ?barrier is unconstrained the same way: without this, the grounder can
+            # bind it to an object the held cube was never down-x of (e.g. the bin
+            # itself). The delete effect below would then target an atom that was
+            # never true, so the real, physical "cube crossed the barrier" fact
+            # would survive refinement's exact-state-equality check unexpectedly,
+            # and every sample would fail regardless of how the throw itself lands.
+            # Still true here: pick_cube's own precondition requires it and no
+            # effect between pick and this operator touches it.
+            LiftedAtom(MovableIsDownX, [held, barrier]),
+        },
         add_effects={
             LiftedAtom(HandEmpty, [robot]),
             LiftedAtom(MovableInGoalRegion, [held]),

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -1,0 +1,56 @@
+"""Tests for tidybot3d_tossing3D.py."""
+
+import kinder
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+
+from kinder_bilevel_planning.agent import BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+kinder.register_all_environments()
+
+
+def test_tidybot3d_tossing3d_bilevel_planning():
+    """Plan and execute a pick and a throw in the Tossing3D environment."""
+
+    num_objects = 1
+    env = kinder.make(f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array")
+
+    if MAKE_VIDEOS:
+        env = RecordVideo(env, "unit_test_videos", name_prefix="TidyBot3D-tossing3d")
+
+    seed = 125
+    obs, info = env.reset(seed=seed)
+
+    env_models = create_bilevel_planning_models(
+        "tidybot3d_tossing3D",
+        env.observation_space,
+        env.action_space,
+        num_objects=num_objects,
+    )
+    agent = BilevelPlanningAgent(
+        env_models,
+        seed=seed,
+        max_abstract_plans=1,
+        samples_per_step=5,
+        planning_timeout=300.0,
+        max_skill_horizon=400,
+    )
+
+    agent.reset(obs, info)
+    for _ in range(4000):
+        action = agent.step()
+        obs, reward, terminated, truncated, info = env.step(action)
+        agent.update(obs, reward, terminated or truncated, info)
+        if (
+            terminated
+            or truncated
+            or len(agent._current_plan) == 0  # pylint: disable=protected-access
+        ):
+            break
+    else:
+        assert False, "Did not terminate successfully"
+
+    sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
+    assert sim._check_goals(), "Planned and executed, but the cube did not score"
+    env.close()

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -52,5 +52,7 @@ def test_tidybot3d_tossing3d_bilevel_planning():
         assert False, "Did not terminate successfully"
 
     sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
-    assert sim._check_goals(), "Planned and executed, but the cube did not score"
+    assert (
+        sim._check_goals()  # pylint: disable=protected-access
+    ), "Planned and executed, but the cube did not score"
     env.close()


### PR DESCRIPTION
# DRAFT — not reviewed by a human

**This description was written by an agent and has not been checked by Josh Roy. Any claim
in it may be wrong. Please do not act on it or reply to it until he has reviewed it.**

---

Adds `tidybot3d_tossing3D` bilevel planning models: two operators over the five Tossing3D
predicates, paired with the two skills this branch's parent adds. Measured end to end on
`Tossing3D-o1` seeds 100–139: **40/40 scored, 40/40 honest, 0/40 `plan_not_found`**.

Stacked on kb#113
(https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/113),
which reduces Tossing3D to the two skills these operators are paired to. Review that one
first. Also depends on `kindergarden` `josh/fix/set-state-restores-gripper-joints`
(`e02cdb8`) — without it, the honesty column below is not measurable.

> **This replaces kb#122, which was merged into kb#113's branch by accident.** Nothing is
> lost: that merge's content is here unchanged, and kb#113 is back to `kinder-models` only.
> Four commits that #122 carried were `kinder-models` changes and did **not** belong to it
> — the `?barrier` skill variable, the `TrajectorySamplingFailure` raise, `IsThrowTarget`,
> and the narrowed sampling bounds. Those now sit in kb#113 where they belong, so this PR
> is `kinder-bilevel-planning` only: two files, the env model and its test.

## Question / goal

Give Tossing3D a symbolic layer a bilevel planner can refine against — the operator models
KINDER ships for `Shelf3D`, `Sweep3D` and base motion but not for Tossing3D — and then
measure what fraction of seeds it plans for, and of those, what fraction actually score.

## Background

`kinder-bilevel-planning` refines an abstract plan by grounding each operator to a
parameterized controller and sampling its continuous parameters, accepting a sample only
when the achieved abstract state equals the operator's effects **exactly** —
`ParameterizedControllerTrajectorySampler` requires set equality, not "the add effects
hold". So an effect set that is wrong in *either* direction rejects throws that physically
worked. There was no such model for Tossing3D at all, so the domain could not be planned
for; `tidybot3d_shelf3D.py` is the shape this follows, where a `LiftedOperator` is paired
to one of upstream's controllers.

The parent branch is what makes two operators sufficient. Under the old three-skill
decomposition the middle rung (drive to a throw pose) needed a predicate describing
"somewhere the throw can work from", calibrated by measurement. kb#113 composes the drive
and the throw, so no operator names the pose between them — the skill does not stop there.

```
pick_cube(?robot, ?cube, ?barrier)
  pre  HandEmpty(?robot), OnGround(?cube), MovableIsDownX(?cube, ?barrier)
  add  Holding(?robot, ?cube)
  del  HandEmpty(?robot), OnGround(?cube)

move_to_toss_location_and_toss(?robot, ?target, ?held, ?barrier)
  pre  Holding(?robot, ?held)
  add  HandEmpty(?robot), MovableInGoalRegion(?held), OnGround(?held)
  del  Holding(?robot, ?held), MovableIsDownX(?held, ?barrier)
```

## Hypothesis

**None — implementation task, not an experiment.** The one open empirical question inside
it (does the throw *delete* `OnGround` or *add* it?) was settled by measurement rather than
argument; see *Methods*.

## Guidance given

Follow `tidybot3d_shelf3D.py`'s shape. Do not let an operator name the intermediate throw
pose. Settle the `OnGround` effect by running throws and reading the resulting abstract
state, not by reasoning about it. Raise rather than assert on a planning failure inside a
controller, so the refiner can back-track instead of the process dying. Then measure
plans-found and goal-reached across seeds, and report how many of the plans refinement
claimed to solve actually scored.

## Methods

Four commits:

- **`1da208c`** the two operators and the env-model dispatcher entry, plus its test.
- **`9d4e34b`** `TossController` raises `TrajectorySamplingFailure` instead of asserting
  when its toss fails to plan, so a failed sample is a rejected sample rather than a dead
  process. Worth knowing when reading the refiner: `TrajectorySamplingFailure` is **not**
  an `Exception` subclass, so `except Exception` misses every sampling failure — this
  measurement catches `BaseException` throughout.
- **`32d5259`** constrains the toss operator's `?target` and `?barrier` grounding, so the
  planner does not enumerate bindings the controllers cannot honour.
- **`a1adebd`** narrows the toss's speed and gripper-release-millisecond sampling bounds to
  the ranges measured to score.

Three design points a reviewer should look at:

**`?barrier` is an object parameter the controllers ignore.** `LiftedSkill` asserts the
operator's parameters equal the controller's variables exactly, so expressing
`MovableIsDownX` as a precondition means carrying the barrier through the controller.
`move_to_target_from_other_target` already carries `?prev_target` the same way. Deleting
`MovableIsDownX` on the throw is the one-way door: past the barrier, the cube cannot be
picked again.

**The throw adds `OnGround` rather than deleting it.** Settled by running 20 throws and
reading the resulting abstract state: **15/15** that scored left the cube resting on a
face. This is only sound because kb#113 makes `OnGround` face-interchangeable — under the
old "flat on the face it started on" test the add effect would have been dishonest for a
cube that landed on a different face.

**One cube only.** `num_objects != 1` raises rather than planning something the operators
cannot express, matching the state abstractor's own assertion.

**Measurement.** `kinder/Tossing3D-o1-v0`, seeds 100–139 (40 seeds), `samples_per_step=5`,
`max_abstract_plans=1`, `max_skill_horizon=250`, driven through this package's own
`BilevelPlanningAgent`. Outcomes are `scored` (`_check_goals()` after executing the refined
plan), `planned_not_scored` (refinement returned a plan, execution did not score) and
`plan_not_found`. **"honest"** is `scored / (scored + planned_not_scored)` — of the plans
refinement claimed to solve, how many actually scored. That column is the one worth
watching: a planner that reports a plan for a seed it cannot actually solve is worse than
one that reports no plan.

## Results

### End state of the stack, seeds 100–139

| configuration | scored | planned_not_scored | plan_not_found | honest |
| --- | --- | --- | --- | --- |
| these models, on the pre-fix trees | 15/40 | 19/40 | 6/40 | 15/34 |
| + `kindergarden` gripper-joint `set_state` fix | 15/40 | 0/40 | 25/40 | 15/15 |
| + kb#113's centre grasp | 33/40 | 0/40 | 7/40 | 33/33 |
| **+ kb#113's approach settling (final)** | **40/40** | **0/40** | **0/40** | **40/40** |

Every number in that table was produced *through these models* — they are what makes the
domain plannable at all — but the movement in it belongs to the fixes below the stack, not
to this branch. Stated plainly so the credit is not misread: **this branch is what makes
Tossing3D refinable; kb#113 and the `kindergarden` fix are what make refinement correct.**

TODO — drag in `2026-08-16-tossing3d-grasp-height-results.png`:
http://agni:8765/2026-08-16-tossing3d-grasp-height-results.png

### Refinement is not search-limited

`samples_per_step=25` gives the identical result to `samples_per_step=5`. And with kb#113's
approach fix in place, four different fixed `pick_cube` standoffs — `(0.55, 0.00)`,
`(0.50, 0.00)`, `(0.55, −0.35)`, `(0.58, +0.20)` — all score 40/40, where before the fix
they gave 33/40, 40/40, 40/40 and 22/40. So the refiner is not hunting for something rare
in the continuous space; it was being handed unrecoverable grasps.

TODO — drag in `standoff_vs_approach.png`: http://agni:8765/standoff_vs_approach.png

## Recommendation

Merge after kb#113.

- **Review order is kb#113 then this.** The two operators are meaningless without the two
  skills they are paired to, and `LiftedSkill`'s exact-parameter assertion means the two
  cannot be split further.
- The `kindergarden` fix (`josh/fix/set-state-restores-gripper-joints`, `e02cdb8`) is a
  prerequisite for the honesty column being meaningful. Before it, `planned_not_scored` was
  19/40.
- **`TOSS_RELEASE_MS_BOUNDS`'s window is narrowed to the measured-to-score range** rather
  than derived. It is a starting range, and the speed bounds are the better-grounded of the
  two (the upper edge is the profile's own clamp, with a test asserting no draw is silently
  rescaled).
- Composing the drive and the throw means a standoff that cannot score is only discovered
  by throwing from it. That was worth watching in the rejection counts, and on the final
  tree it does not bind — 0/40 `plan_not_found`.

