### PR TITLE
kinder-bilevel-planning: add bilevel planning models for Tossing3D

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -1,0 +1,203 @@
+"""Bilevel planning models for the TidyBot3D Tossing3D environment.
+
+Two operators over five predicates. The base move and the throw are one skill, so no
+predicate has to name the pose between them; the pick takes no continuous parameters,
+so refinement backtracks over the throw alone.
+
+TODO: only Tossing3D-o1 is supported; no operator says which cube a throw is aimed at.
+"""
+
+from pathlib import Path
+
+import kinder
+import numpy as np
+from bilevel_planning.structs import (
+    LiftedSkill,
+    SesameModels,
+)
+from gymnasium.spaces import Space
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoFixtureObjectType,
+    MujocoMovableObjectType,
+    MujocoObjectType,
+    MujocoTidyBotRobotObjectType,
+)
+from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionSpace
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    PyBulletSim,
+    create_lifted_controllers,
+)
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    HandEmpty,
+    Holding,
+    IsThrowTarget,
+    MovableInGoalRegion,
+    MovableIsDownX,
+    OnGround,
+    Tossing3DStateAbstractor,
+)
+from numpy.typing import NDArray
+from relational_structs import (
+    LiftedAtom,
+    LiftedOperator,
+    ObjectCentricState,
+    Variable,
+)
+from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateSpace
+
+
+def create_bilevel_planning_models(
+    observation_space: Space,
+    action_space: Space,
+    num_objects: int = 1,
+) -> SesameModels:
+    """Create the env models for TidyBot Tossing3D."""
+    assert isinstance(observation_space, ObjectCentricBoxSpace)
+    assert isinstance(action_space, TidyBot3DRobotActionSpace)
+    if num_objects != 1:
+        raise NotImplementedError(
+            f"Tossing3D bilevel planning supports one cube, got {num_objects}. The "
+            "operators do not say which cube a throw is aimed at."
+        )
+
+    task_config_path = str(
+        Path(kinder.__file__).parent
+        / "envs"
+        / "dynamic3d"
+        / "tasks"
+        / "Tossing3D"
+        / f"Tossing3D-o{num_objects}.json"
+    )
+    sim = ObjectCentricTidyBot3DEnv(
+        task_config_path=task_config_path,
+        num_objects=num_objects,
+        allow_state_access=True,
+    )
+
+    # State and goal abstractors.
+    abstractor = Tossing3DStateAbstractor(sim)
+    state_abstractor = abstractor.state_abstractor
+    goal_deriver = abstractor.goal_deriver
+
+    # Need to call reset to initialize the qpos, qvel.
+    initial_state, _ = sim.reset()
+
+    def observation_to_state(o: NDArray[np.float32]) -> ObjectCentricState:
+        """Convert the vectors back into (hashable) object-centric states."""
+        return observation_space.devectorize(o)
+
+    def transition_fn(
+        x: ObjectCentricState,
+        u: NDArray[np.float32],
+    ) -> ObjectCentricState:
+        """Simulate the action."""
+        state = x.copy()
+        sim.set_state(state)
+        obs, _, _, _, _ = sim.step(u)
+        return obs.copy()
+
+    types = {
+        MujocoTidyBotRobotObjectType,
+        MujocoObjectType,
+        MujocoFixtureObjectType,
+        MujocoMovableObjectType,
+    }
+
+    state_space = ObjectCentricStateSpace(types)
+
+    predicates = {
+        HandEmpty,
+        Holding,
+        IsThrowTarget,
+        MovableInGoalRegion,
+        MovableIsDownX,
+        OnGround,
+    }
+
+    # Pick the cube up off the ground.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    cube = Variable("?cube", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    PickCubeOperator = LiftedOperator(
+        "pick_cube",
+        [robot, cube, barrier],
+        preconditions={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [cube]),
+            # Only a cube still on this side of the barrier can be reached.
+            LiftedAtom(MovableIsDownX, [cube, barrier]),
+        },
+        add_effects={LiftedAtom(Holding, [robot, cube])},
+        delete_effects={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [cube]),
+        },
+    )
+
+    # Drive to a pose to throw from, and throw.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    target = Variable("?target", MujocoObjectType)
+    held = Variable("?held", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    MoveToTossLocationAndTossOperator = LiftedOperator(
+        "move_to_toss_location_and_toss",
+        [robot, target, held, barrier],
+        preconditions={
+            LiftedAtom(Holding, [robot, held]),
+            # Upstream gives the bin the same type as the cube and the barrier, so
+            # without this the grounder is free to bind ?target to either of those --
+            # a discrete mistake no amount of continuous sampling can recover from.
+            LiftedAtom(IsThrowTarget, [target]),
+            # ?barrier is unconstrained the same way: without this, the grounder can
+            # bind it to an object the held cube was never down-x of (e.g. the bin
+            # itself). The delete effect below would then target an atom that was
+            # never true, so the real, physical "cube crossed the barrier" fact
+            # would survive refinement's exact-state-equality check unexpectedly,
+            # and every sample would fail regardless of how the throw itself lands.
+            # Still true here: pick_cube's own precondition requires it and no
+            # effect between pick and this operator touches it.
+            LiftedAtom(MovableIsDownX, [held, barrier]),
+        },
+        add_effects={
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(MovableInGoalRegion, [held]),
+            # Measured on 20 throws: 15/15 that scored left the cube resting on a face.
+            LiftedAtom(OnGround, [held]),
+        },
+        delete_effects={
+            LiftedAtom(Holding, [robot, held]),
+            # The one-way door: past the barrier the cube cannot be picked again.
+            LiftedAtom(MovableIsDownX, [held, barrier]),
+        },
+    )
+
+    # Controllers.
+    assert initial_state is not None
+    pybullet_sim = PyBulletSim(initial_state, rendering=False)
+    controllers = create_lifted_controllers(
+        action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
+    )
+
+    skills = {
+        LiftedSkill(PickCubeOperator, controllers["pick_cube"]),
+        LiftedSkill(
+            MoveToTossLocationAndTossOperator,
+            controllers["move_to_toss_location_and_toss"],
+        ),
+    }
+
+    return SesameModels(
+        observation_space,
+        state_space,
+        action_space,
+        transition_fn,
+        types,
+        predicates,
+        observation_to_state,
+        state_abstractor,
+        goal_deriver,
+        skills,
+    )

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tidybot3d_tossing3d.py
@@ -1,0 +1,58 @@
+"""Tests for tidybot3d_tossing3D.py."""
+
+import kinder
+from conftest import MAKE_VIDEOS
+from gymnasium.wrappers import RecordVideo
+
+from kinder_bilevel_planning.agent import BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+kinder.register_all_environments()
+
+
+def test_tidybot3d_tossing3d_bilevel_planning():
+    """Plan and execute a pick and a throw in the Tossing3D environment."""
+
+    num_objects = 1
+    env = kinder.make(f"kinder/Tossing3D-o{num_objects}-v0", render_mode="rgb_array")
+
+    if MAKE_VIDEOS:
+        env = RecordVideo(env, "unit_test_videos", name_prefix="TidyBot3D-tossing3d")
+
+    seed = 125
+    obs, info = env.reset(seed=seed)
+
+    env_models = create_bilevel_planning_models(
+        "tidybot3d_tossing3D",
+        env.observation_space,
+        env.action_space,
+        num_objects=num_objects,
+    )
+    agent = BilevelPlanningAgent(
+        env_models,
+        seed=seed,
+        max_abstract_plans=1,
+        samples_per_step=5,
+        planning_timeout=300.0,
+        max_skill_horizon=400,
+    )
+
+    agent.reset(obs, info)
+    for _ in range(4000):
+        action = agent.step()
+        obs, reward, terminated, truncated, info = env.step(action)
+        agent.update(obs, reward, terminated or truncated, info)
+        if (
+            terminated
+            or truncated
+            or len(agent._current_plan) == 0  # pylint: disable=protected-access
+        ):
+            break
+    else:
+        assert False, "Did not terminate successfully"
+
+    sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
+    assert (
+        sim._check_goals()  # pylint: disable=protected-access
+    ), "Planned and executed, but the cube did not score"
+    env.close()

--- a/kinder-models/pyproject.toml
+++ b/kinder-models/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
    "matplotlib",
    "numpy",
+   "scipy",
    "spatialmath-python",
    "h5py",
    "flask-socketio",

--- a/kinder-models/src/kinder_models/dynamic3d/cube_symmetry.py
+++ b/kinder-models/src/kinder_models/dynamic3d/cube_symmetry.py
@@ -1,0 +1,65 @@
+"""The rotations that map a cube onto itself, and what follows from them.
+
+A cube resting on any of its faces is the same cube in the same place, so its roll and
+pitch carry no information and only its yaw does. Anything deriving a grasp or a resting
+test from a cube's measured rotation has to say so explicitly, or it ends up
+distinguishing poses that are physically identical.
+
+Rotations cross this module's boundary as `Quaternion`, which is pybullet_helpers' own
+alias for an (x, y, z, w) tuple -- the order the dynamic3d state features are in
+(`qx`, `qy`, `qz`, `qw`) and the order `Pose.orientation` is in, so a caller never
+converts. Note that Mujoco's native qpos order is (w, x, y, z), which this is not.
+`Rotation` is the computation type only, constructed and discarded inside a function.
+"""
+
+import numpy as np
+from pybullet_helpers.geometry import Quaternion
+from scipy.spatial.transform import Rotation  # type: ignore[import-untyped]
+
+# The 24 rotations mapping a cube onto itself: 6 faces down, each at 4 yaws.
+CUBE_ROTATION_SYMMETRIES: tuple[Quaternion, ...] = tuple(
+    (float(q[0]), float(q[1]), float(q[2]), float(q[3]))
+    for q in Rotation.create_group("O").as_quat()
+)
+_CUBE_ROTATION_SYMMETRY_GROUP = Rotation.from_quat(np.array(CUBE_ROTATION_SYMMETRIES))
+_CUBE_ROTATION_SYMMETRY_ANGLES = _CUBE_ROTATION_SYMMETRY_GROUP.magnitude()
+
+
+def cube_tilt_from_upright(rotation: Quaternion) -> float:
+    """How far a cube is from resting flat on one of its faces.
+
+    Zero for any face-down rest at any yaw, and larger the closer the cube is to
+    balancing on an edge or a corner.
+    """
+    composed = (Rotation.from_quat(rotation) * _CUBE_ROTATION_SYMMETRY_GROUP).as_quat()
+    return float(np.min(composed[:, 0] ** 2 + composed[:, 1] ** 2))
+
+
+def upright_grasp_rotations(rotation: Quaternion) -> tuple[Quaternion, ...]:
+    """Every upright rotation the cube could equally be grasped at, nearest yaw first.
+
+    Deriving a grasp from the measured rotation asks the gripper to approach along
+    whichever face happens to be up, from underneath the floor for a cube on its top.
+    Resting on a face a cube is also four-fold symmetric about the vertical, so all four
+    yaws are the same grasp and a caller can fall through when the arm cannot reach one.
+    """
+    composed = (Rotation.from_quat(rotation) * _CUBE_ROTATION_SYMMETRY_GROUP).as_quat()
+    x, y, z, w = composed[:, 0], composed[:, 1], composed[:, 2], composed[:, 3]
+    tilt = x * x + y * y
+    # Every minimal-tilt family is at least a tied 180-degree pair, so the tilt alone
+    # never picks a unique winner. Break the tie toward the symmetry closest to
+    # identity, so an already-near-upright cube keeps its own measured yaw instead of
+    # jumping to an arbitrary tied alternative -- which the real robot cannot always
+    # reach from the same standoff.
+    tied = np.flatnonzero(tilt < tilt.min() + 1e-12)
+    nearest = int(tied[np.argmin(_CUBE_ROTATION_SYMMETRY_ANGLES[tied])])
+    yaw = float(
+        np.arctan2(
+            2 * (w[nearest] * z[nearest] + x[nearest] * y[nearest]),
+            1 - 2 * (y[nearest] ** 2 + z[nearest] ** 2),
+        )
+    )
+    return tuple(
+        (0.0, 0.0, float(np.sin(angle / 2)), float(np.cos(angle / 2)))
+        for angle in (yaw, yaw + np.pi / 2, yaw - np.pi / 2, yaw + np.pi)
+    )

--- a/kinder-models/src/kinder_models/dynamic3d/tidybot_pick_controller.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tidybot_pick_controller.py
@@ -63,6 +63,32 @@ class TidyBotPickController(GroundParameterizedController[ObjectCentricState, Ar
         object: The target object.
     """
 
+    # Where the end effector aims, in the target's own frame. The default is the shared
+    # module constant: a small approach offset and a height 10 mm above the object's
+    # own origin, which suits an object whose origin sits at its base. A class attribute
+    # rather than the bare constant so a subclass picking a differently-shaped object
+    # can aim elsewhere without moving anyone else's grasp.
+    GRASP_TRANSFORM = GRASP_TRANSFORM_TO_OBJECT
+
+    # How long the approach may keep tracking after its trapezoidal profile runs out.
+    # Zero -- the base behaviour -- makes the profile's last index the last step taken,
+    # arrived or not, and closes the gripper immediately after it. That is enough
+    # wherever the residual joint error at the end of the profile is small against the
+    # grasp's own tolerance. A subclass reaching for a shape that has to be gripped
+    # squarely can wait instead. A class attribute for the same reason GRASP_TRANSFORM
+    # is one: the difference belongs to the subclass, not to this controller.
+    APPROACH_SETTLE_STEPS = 0
+    # A one-shot feedforward added to the arm command while settling, and how many
+    # settling steps to wait before measuring it. The proportional command alone leaves
+    # a standing joint error and has to: holding the arm against gravity needs a
+    # non-zero command, and the only thing producing one is the error itself. Adding
+    # `gain` times that error to the command shifts the steady state by gain/kp of it,
+    # so a gain of kp nulls it. Zero -- the base behaviour -- adds nothing, and the
+    # block is unreachable at zero settle steps anyway, so a subclass that wants the
+    # cancellation has to raise APPROACH_SETTLE_STEPS as well.
+    APPROACH_FEEDFORWARD_GAIN = 0.0
+    APPROACH_FEEDFORWARD_DELAY = 0
+
     def __init__(
         self, *args, pybullet_sim: PyBulletSim | None = None, **kwargs
     ) -> None:
@@ -86,6 +112,7 @@ class TidyBotPickController(GroundParameterizedController[ObjectCentricState, Ar
         self._approach_traj_dir: np.ndarray = np.zeros(7)
         self._approach_start_joints: np.ndarray = np.zeros(7)
         self._approach_step_idx: int = 0
+        self._approach_command_offset: np.ndarray = np.zeros(7)
         self._retract_trajectory: np.ndarray = np.array([])
         self._retract_traj_dir: np.ndarray = np.zeros(7)
         self._retract_start_joints: np.ndarray = np.zeros(7)
@@ -188,7 +215,7 @@ class TidyBotPickController(GroundParameterizedController[ObjectCentricState, Ar
 
         target_end_effector_pose = multiply_poses(
             target_grasp_pose_world,
-            GRASP_TRANSFORM_TO_OBJECT,
+            self.GRASP_TRANSFORM,
         )
 
         self._pybullet_sim.base_link_to_held_obj = multiply_poses(
@@ -256,6 +283,7 @@ class TidyBotPickController(GroundParameterizedController[ObjectCentricState, Ar
         )
         self._approach_start_joints = curr.copy()
         self._approach_step_idx = 0
+        self._approach_command_offset = np.zeros(7)
         # Compute trapezoidal velocity profile for retract (grasp conf → home).
         self._retract_trajectory, self._retract_traj_dir = _compute_per_joint_profile(
             final, self.home_joints[:7], _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
@@ -269,6 +297,26 @@ class TidyBotPickController(GroundParameterizedController[ObjectCentricState, Ar
             and self._current_retract_plan is not None
         )
         return self._lifted
+
+    def _approach_has_settled(self) -> bool:
+        """Whether the approach is finished and the gripper may close.
+
+        The trapezoidal profile says when the *commanded* path ends; it says nothing
+        about where the arm actually is, because each step commands a proportional
+        correction (kp times the remaining joint error) rather than a position. So the
+        arm reaches the last profile index still trailing the target, and holding that
+        final command for APPROACH_SETTLE_STEPS more steps is what closes the gap.
+
+        The residual plateaus rather than converging -- proportional velocity control
+        against gravity needs a non-zero command to hold a pose, and the only thing
+        producing one is the error itself. Measured over six seeds it settles at
+        0.72-1.04 degrees, so this waits a fixed number of steps rather than for a
+        tolerance it would never reach.
+        """
+        if self._approach_step_idx < len(self._approach_trajectory):
+            return False
+        overrun = self._approach_step_idx - len(self._approach_trajectory)
+        return overrun >= self.APPROACH_SETTLE_STEPS
 
     def step(self) -> Array:
         assert self._current_arm_joint_plan is not None
@@ -296,15 +344,22 @@ class TidyBotPickController(GroundParameterizedController[ObjectCentricState, Ar
             action[-1] = self._get_current_robot_gripper_pose()
             return action
         if self._navigated and not self._pre_grasp and not self._closed_gripper:
-            if self._approach_step_idx >= len(self._approach_trajectory):
+            if self._approach_has_settled():
                 self._pre_grasp = True
             idx = min(self._approach_step_idx, len(self._approach_trajectory) - 1)
             s = float(self._approach_trajectory[idx])
             kp = 2.0
             curr = np.array(self._get_current_robot_arm_conf()[:7])
             target = self._approach_start_joints + self._approach_traj_dir * s
+            if (
+                self._approach_step_idx - len(self._approach_trajectory)
+                == self.APPROACH_FEEDFORWARD_DELAY
+            ):
+                self._approach_command_offset = self.APPROACH_FEEDFORWARD_GAIN * (
+                    target - curr
+                )
             action = np.zeros(11, dtype=np.float32)
-            action[3:10] = kp * (target - curr)
+            action[3:10] = kp * (target - curr) + self._approach_command_offset
             action[-1] = self._get_current_robot_gripper_pose()
             self._approach_step_idx += 1
             return action

--- a/kinder-models/src/kinder_models/dynamic3d/tidybot_pick_controller.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tidybot_pick_controller.py
@@ -1,23 +1,27 @@
-"""Parameterized skills for the TidyBot3D shelf environment."""
+"""The TidyBot arm's pick: drive to the object, grasp it, retract to home.
+
+Nothing here is specific to a scene or a task. What the controller does is base
+navigation, IK and motion planning through :mod:`kinder_models.dynamic3d.utils`'s
+``PyBulletSim``, a trapezoidal approach profile, a gripper close, and a trapezoidal
+retract to the arm's home configuration -- TidyBot-arm logic, all of it, over the
+shared constants in that same module.
+
+It lived in ``shelf/parameterized_skills.py`` until now only because shelf was the
+first domain that needed it, which left the tossing domain subclassing across a domain
+boundary to reuse an arm. It sits beside ``utils.py`` and ``ik_solver.py`` instead, so
+every domain reaches for it as a peer.
+
+Domains specialise it by subclassing and overriding the class attributes below --
+where the end effector aims, and how the approach settles before the gripper closes.
+"""
 
 from typing import Any
 
 import numpy as np
-from bilevel_planning.structs import (
-    GroundParameterizedController,
-    LiftedParameterizedController,
-)
-from gymnasium.spaces import Box
-from kinder.envs.dynamic3d.object_types import (
-    MujocoFixtureObjectType,
-    MujocoMovableObjectType,
-    MujocoTidyBotRobotObjectType,
-)
-from kinder.envs.dynamic3d.robots.tidybot_robot_env import (
-    TidyBot3DRobotActionSpace,
-)
+from bilevel_planning.structs import GroundParameterizedController
+from kinder.envs.dynamic3d.object_types import MujocoMovableObjectType
 from prpl_utils.utils import get_signed_angle_distance
-from pybullet_helpers.geometry import multiply_poses
+from pybullet_helpers.geometry import Pose, multiply_poses
 from pybullet_helpers.inverse_kinematics import (
     JointPositions,
     inverse_kinematics,
@@ -29,26 +33,17 @@ from pybullet_helpers.motion_planning import (
 from relational_structs import (
     Array,
     ObjectCentricState,
-    Variable,
 )
 from spatialmath import SE2
 
-from kinder_models.dynamic3d.tidybot_pick_controller import TidyBotPickController
 from kinder_models.dynamic3d.utils import (
     _ARM_MAX_ACCELERATION,
     _ARM_MAX_VELOCITY,
-    ARM_MOVEMENT_CUPBOARD,
-    BASE_DISTANCE_TO_CUPBOARD,
-    BASE_TO_CUPBOARD_ROTATION,
     GRASP_CLOSE_THRESHOLD,
-    GRIPPER_OPEN_COMMAND_TOLERANCE,
+    GRASP_TRANSFORM_TO_OBJECT,
     MAX_SAMPLER_ATTEMPTS,
     MOVE_TO_TARGET_DISTANCE_BOUNDS,
     MOVE_TO_TARGET_ROT_BOUNDS,
-    PLACE_SAMPLER_COLLISION_THRESHOLD,
-    PLACE_SAMPLER_X_OFFSET_BOUNDS,
-    PLACE_SAMPLER_Y_OFFSET_BOUNDS,
-    ROBOT_ARM_POSE_TO_BASE,
     WAYPOINT_TOLERANCE,
     WORLD_X_BOUNDS,
     WORLD_Y_BOUNDS,
@@ -60,8 +55,8 @@ from kinder_models.dynamic3d.utils import (
 )
 
 
-class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Array]):
-    """Controller for motion planning to place a target.
+class TidyBotPickController(GroundParameterizedController[ObjectCentricState, Array]):
+    """Controller for motion planning to pick up a target.
 
     The object parameters are:
         robot: The robot itself.
@@ -79,9 +74,9 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
         self._current_base_motion_plan: list[SE2] | None = None
         self._pybullet_sim: PyBulletSim | None = pybullet_sim
         self._navigated: bool = False
-        self._pre_place: bool = False
-        self._open_gripper: bool = False
-        self._returned: bool = False
+        self._pre_grasp: bool = False
+        self._closed_gripper: bool = False
+        self._lifted: bool = False
         self._last_gripper_state: float = 0.0
         self.home_joints = np.deg2rad(
             [0, -20, 180, -146, 0, -50, 90, 0, 0, 0, 0, 0, 0]
@@ -97,42 +92,36 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
         self._retract_step_idx: int = 0
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
-        cupboard_obj = x.get_object_from_name("cupboard_1")
-        cupboard_pose = get_overhead_object_se2_pose(x, cupboard_obj)
-        rot = BASE_TO_CUPBOARD_ROTATION
-        # sample placements
+        target_object = self.objects[1]
+        target_object_pose = get_overhead_object_se2_pose(x, target_object)
+
         for _ in range(MAX_SAMPLER_ATTEMPTS):
-            pose_x_offset = rng.uniform(*PLACE_SAMPLER_X_OFFSET_BOUNDS)
-            pose_y_offset = rng.uniform(*PLACE_SAMPLER_Y_OFFSET_BOUNDS)
+            distance = rng.uniform(*MOVE_TO_TARGET_DISTANCE_BOUNDS)  # type: ignore
+            rot = rng.uniform(*MOVE_TO_TARGET_ROT_BOUNDS)
+            target_base_pose = get_target_robot_pose_from_parameters(
+                target_object_pose, distance, rot
+            )
             collision = False
-            for other_obj in x.get_objects(MujocoMovableObjectType):
-                if other_obj.name == self.objects[1].name:
-                    continue
-                other_object_pose = get_overhead_object_se2_pose(x, other_obj)
+            for other_object in x.get_objects(MujocoMovableObjectType):
                 if (
-                    np.linalg.norm(
-                        np.array(
+                    "cube" in other_object.name
+                    and other_object.name != target_object.name
+                ):
+                    other_object_pose = get_overhead_object_se2_pose(x, other_object)
+                    collision_distance = float(
+                        np.linalg.norm(
                             [
-                                pose_x_offset
-                                + cupboard_pose.x
-                                + (
-                                    ARM_MOVEMENT_CUPBOARD.position[0]
-                                    + ROBOT_ARM_POSE_TO_BASE.position[0]
-                                    - BASE_DISTANCE_TO_CUPBOARD
-                                ),  # the offset of the cupboard from the cubes.
-                                pose_y_offset + cupboard_pose.y,
+                                target_base_pose.x - other_object_pose.x,
+                                target_base_pose.y - other_object_pose.y,
                             ]
                         )
-                        - np.array([other_object_pose.x, other_object_pose.y])
                     )
-                    < PLACE_SAMPLER_COLLISION_THRESHOLD
-                ):
-                    collision = True
-                    break
+                    if collision_distance < 0.6:
+                        collision = True
+                        break
             if not collision:
-                return np.array(
-                    [BASE_DISTANCE_TO_CUPBOARD + pose_x_offset, pose_y_offset, rot]
-                )
+                return np.array([distance, rot])
+
         raise ValueError("No valid parameters found")
 
     def reset(
@@ -151,14 +140,9 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
         # Convert params to ndarray for compatibility (accepts tuple or array)
         self._current_params = np.asarray(params, dtype=np.float32)
         # Derive the target pose for the robot.
-        target_distance, target_offset, target_rot = self._current_params
-        target_object = self.objects[2]
-        target_object_pose_temp = get_overhead_object_se2_pose(x, target_object)
-        target_object_pose = SE2(
-            target_object_pose_temp.x,
-            target_object_pose_temp.y + target_offset,
-            target_object_pose_temp.theta(),
-        )
+        target_distance, target_rot = self._current_params
+        target_object = self.objects[1]
+        target_object_pose = get_overhead_object_se2_pose(x, target_object)
         target_base_pose = get_target_robot_pose_from_parameters(
             target_object_pose, target_distance, target_rot
         )
@@ -171,7 +155,6 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
             seed=0,  # use a constant seed to effectively make this "deterministic"
             extend_xy_magnitude=extend_xy_magnitude,
             extend_rot_magnitude=extend_rot_magnitude,
-            disable_collision_objects=[self.objects[1].name],
         )
         assert base_motion_plan is not None
         self._current_base_motion_plan = base_motion_plan
@@ -179,22 +162,38 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
         plan_x = x.copy()
         robot = self.objects[0]  # Robot is first parameter
         target_base_pose = self._current_base_motion_plan[-1]
-        plan_x.set(robot, "pos_base_x", target_base_pose.x)
-        plan_x.set(robot, "pos_base_y", target_base_pose.y)
-        plan_x.set(robot, "pos_base_rot", target_base_pose.theta())
+        if not self._navigated:
+            plan_x.set(robot, "pos_base_x", target_base_pose.x)
+            plan_x.set(robot, "pos_base_y", target_base_pose.y)
+            plan_x.set(robot, "pos_base_rot", target_base_pose.theta())
 
-        target_object_place = self.objects[1]
-
-        assert target_object_place is not None
         # Reset PyBullet given the current state.
-        self._pybullet_sim.set_state(plan_x, target_object_place)
+        self._pybullet_sim.set_state(plan_x)
 
-        current_arm_base_pose = self._pybullet_sim.robot.get_base_pose()
+        target_object = self.objects[1]
 
-        target_end_effector_pose = ARM_MOVEMENT_CUPBOARD
+        target_grasp_pose_world = Pose(
+            (
+                plan_x.get(target_object, "x"),
+                plan_x.get(target_object, "y"),
+                plan_x.get(target_object, "z"),
+            ),
+            (
+                plan_x.get(target_object, "qx"),
+                plan_x.get(target_object, "qy"),
+                plan_x.get(target_object, "qz"),
+                plan_x.get(target_object, "qw"),
+            ),
+        )
 
         target_end_effector_pose = multiply_poses(
-            current_arm_base_pose, target_end_effector_pose
+            target_grasp_pose_world,
+            GRASP_TRANSFORM_TO_OBJECT,
+        )
+
+        self._pybullet_sim.base_link_to_held_obj = multiply_poses(
+            target_end_effector_pose.invert(),
+            target_grasp_pose_world,
         )
 
         target_joints = inverse_kinematics(
@@ -208,16 +207,8 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
             self._pybullet_sim.robot,
             self._pybullet_sim.get_robot_joints(),
             target_joints,
-            collision_bodies=self._pybullet_sim.get_collision_bodies(
-                held_object=self._pybullet_sim._cubes[  # pylint: disable=protected-access
-                    target_object_place.name
-                ]
-            ),
+            collision_bodies=self._pybullet_sim.get_collision_bodies(),
             seed=0,  # use a constant seed to make this effectively deterministic
-            held_object=self._pybullet_sim._cubes[  # pylint: disable=protected-access
-                target_object_place.name
-            ],
-            base_link_to_held_obj=self._pybullet_sim.base_link_to_held_obj,
             physics_client_id=self._pybullet_sim.physics_client_id,
         )
 
@@ -225,7 +216,15 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
             self._pybullet_sim.robot,
             target_joints,
             self.home_joints.tolist(),
-            collision_bodies=self._pybullet_sim.get_collision_bodies(),
+            collision_bodies=self._pybullet_sim.get_collision_bodies(  # pylint: disable=protected-access
+                held_object=self._pybullet_sim._cubes[  # pylint: disable=protected-access
+                    target_object.name
+                ]
+            ),
+            held_object=self._pybullet_sim._cubes[  # pylint: disable=protected-access
+                target_object.name
+            ],
+            base_link_to_held_obj=self._pybullet_sim.base_link_to_held_obj,  # pylint: disable=protected-access
             seed=0,  # use a constant seed to make this effectively deterministic
             physics_client_id=self._pybullet_sim.physics_client_id,
         )
@@ -249,7 +248,7 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
 
         self._current_arm_joint_plan = plan
         self._current_retract_plan = retract_plan
-        # Compute trapezoidal velocity profile for approach (current → place conf).
+        # Compute trapezoidal velocity profile for approach (current → grasp conf).
         curr = np.array(self._get_current_robot_arm_conf()[:7])
         final = np.array(plan[-1][:7])
         self._approach_trajectory, self._approach_traj_dir = _compute_per_joint_profile(
@@ -257,7 +256,7 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
         )
         self._approach_start_joints = curr.copy()
         self._approach_step_idx = 0
-        # Compute trapezoidal velocity profile for retract (place conf → home).
+        # Compute trapezoidal velocity profile for retract (grasp conf → home).
         self._retract_trajectory, self._retract_traj_dir = _compute_per_joint_profile(
             final, self.home_joints[:7], _ARM_MAX_VELOCITY, _ARM_MAX_ACCELERATION
         )
@@ -269,7 +268,7 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
             self._current_arm_joint_plan is not None
             and self._current_retract_plan is not None
         )
-        return self._returned
+        return self._lifted
 
     def step(self) -> Array:
         assert self._current_arm_joint_plan is not None
@@ -296,9 +295,9 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
             action[2] = drot
             action[-1] = self._get_current_robot_gripper_pose()
             return action
-        if self._navigated and not self._pre_place and not self._open_gripper:
+        if self._navigated and not self._pre_grasp and not self._closed_gripper:
             if self._approach_step_idx >= len(self._approach_trajectory):
-                self._pre_place = True
+                self._pre_grasp = True
             idx = min(self._approach_step_idx, len(self._approach_trajectory) - 1)
             s = float(self._approach_trajectory[idx])
             kp = 2.0
@@ -309,16 +308,20 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
             action[-1] = self._get_current_robot_gripper_pose()
             self._approach_step_idx += 1
             return action
-        if self._pre_place and not self._open_gripper:
-            if self._get_current_robot_gripper_pose() < GRIPPER_OPEN_COMMAND_TOLERANCE:
-                self._open_gripper = True
+        if self._pre_grasp and not self._closed_gripper:
+            if self._get_current_robot_gripper_pose() > 0.2 and np.isclose(
+                self._get_current_robot_gripper_pose(),
+                self._last_gripper_state,
+                atol=0.02,
+            ):
+                self._closed_gripper = True
             action = np.zeros(11, dtype=np.float32)
-            action[-1] = 0
+            action[-1] = 1
             self._last_gripper_state = self._get_current_robot_gripper_pose()
             return action
-        if self._pre_place and self._open_gripper:
+        if self._pre_grasp and self._closed_gripper:
             if self._retract_step_idx >= len(self._retract_trajectory):
-                self._returned = True
+                self._lifted = True
             idx = min(self._retract_step_idx, len(self._retract_trajectory) - 1)
             s = float(self._retract_trajectory[idx])
             kp = 2.0
@@ -393,90 +396,3 @@ class PlaceShelfController(GroundParameterizedController[ObjectCentricState, Arr
                 atol=atol,
             )
         )
-
-
-def create_lifted_controllers(
-    action_space: TidyBot3DRobotActionSpace,
-    init_constant_state: ObjectCentricState | None = None,
-    pybullet_sim: PyBulletSim | None = None,
-) -> dict[str, LiftedParameterizedController]:
-    """Create lifted parameterized controllers for the TidyBot3D ground environment."""
-
-    del action_space, init_constant_state  # not used
-
-    # Create wrapper class that captures pybullet_sim
-    class PickController(TidyBotPickController):
-        """Pick controller with pre-configured PyBullet sim."""
-
-        def __init__(self, objects):
-            super().__init__(pybullet_sim=pybullet_sim, objects=objects)
-
-    class PlaceController(PlaceShelfController):
-        """Place controller with pre-configured PyBullet sim."""
-
-        def __init__(self, objects):
-            super().__init__(pybullet_sim=pybullet_sim, objects=objects)
-
-    # Pick shelf controller.
-    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
-    target = Variable("?target", MujocoMovableObjectType)
-
-    # Parameter space: [distance, rotation]
-    pick_shelf_params_space = Box(
-        low=np.array(
-            [MOVE_TO_TARGET_DISTANCE_BOUNDS[0], MOVE_TO_TARGET_ROT_BOUNDS[0]],
-            dtype=np.float32,
-        ),
-        high=np.array(
-            [MOVE_TO_TARGET_DISTANCE_BOUNDS[1], MOVE_TO_TARGET_ROT_BOUNDS[1]],
-            dtype=np.float32,
-        ),
-        dtype=np.float32,
-    )
-
-    LiftedPickShelfController: LiftedParameterizedController = (
-        LiftedParameterizedController(
-            [robot, target],
-            PickController,
-            params_space=pick_shelf_params_space,
-        )
-    )
-
-    # Place controller.
-    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
-    target = Variable("?target", MujocoMovableObjectType)
-    target_place = Variable("?target_place", MujocoFixtureObjectType)
-
-    # Parameter space: [distance, y_offset, rotation]
-    place_shelf_params_space = Box(
-        low=np.array(
-            [
-                BASE_DISTANCE_TO_CUPBOARD + PLACE_SAMPLER_X_OFFSET_BOUNDS[0],
-                PLACE_SAMPLER_Y_OFFSET_BOUNDS[0],
-                BASE_TO_CUPBOARD_ROTATION,
-            ],
-            dtype=np.float32,
-        ),
-        high=np.array(
-            [
-                BASE_DISTANCE_TO_CUPBOARD + PLACE_SAMPLER_X_OFFSET_BOUNDS[1],
-                PLACE_SAMPLER_Y_OFFSET_BOUNDS[1],
-                BASE_TO_CUPBOARD_ROTATION,
-            ],
-            dtype=np.float32,
-        ),
-        dtype=np.float32,
-    )
-
-    LiftedPlaceShelfController: LiftedParameterizedController = (
-        LiftedParameterizedController(
-            [robot, target, target_place],
-            PlaceController,
-            params_space=place_shelf_params_space,
-        )
-    )
-
-    return {
-        "pick_shelf": LiftedPickShelfController,
-        "place_shelf": LiftedPlaceShelfController,
-    }

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -1,5 +1,6 @@
 """Parameterized skills for the TidyBot3D tossing environment."""
 
+import enum
 from typing import Any
 
 import numpy as np
@@ -7,7 +8,11 @@ from bilevel_planning.structs import (
     GroundParameterizedController,
     LiftedParameterizedController,
 )
+from bilevel_planning.trajectory_samplers.trajectory_sampler import (
+    TrajectorySamplingFailure,
+)
 from kinder.envs.dynamic3d.object_types import (
+    MujocoMovableObjectType,
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
 )
@@ -30,19 +35,31 @@ from relational_structs import (
 )
 from spatialmath import SE2
 
+from kinder_models.dynamic3d.cube_symmetry import upright_grasp_rotations
+from kinder_models.dynamic3d.tidybot_pick_controller import TidyBotPickController
+from kinder_models.dynamic3d.tossing.toss_swing import (
+    TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+    TOSS_MAX_VELOCITY,
+    TOSS_RELEASE_ARM_CONFIGURATION,
+    TOSS_WINDUP_ARM_CONFIGURATION,
+    TossSwing,
+    plan_toss_swing,
+    toss_swing_action,
+)
 from kinder_models.dynamic3d.utils import (
     _ARM_MAX_ACCELERATION,
     _ARM_MAX_VELOCITY,
     _CONTROL_TIMESTEP,
     GRASP_CLOSE_THRESHOLD,
+    GRASP_TRANSFORM_TO_OBJECT,
     GRIPPER_CLOSED_THRESHOLD,
     GRIPPER_OPEN_COMMAND_TOLERANCE,
+    MINIMUM_HOLDING_HEIGHT,
     WAYPOINT_TOLERANCE,
     WORLD_X_BOUNDS,
     WORLD_Y_BOUNDS,
     PyBulletSim,
     _compute_per_joint_profile,
-    _trapezoidal_motion_profile,
     get_overhead_object_se2_pose,
     get_target_robot_pose_from_parameters,
     run_base_motion_planning,
@@ -114,14 +131,14 @@ class MoveToTargetGroundController(
 
     def terminated(self) -> bool:
         assert self._current_base_motion_plan is not None
-        return self._robot_is_close_to_pose(self._current_base_motion_plan[-1])
+        return self._check_robot_is_close_to_pose(self._current_base_motion_plan[-1])
 
     def step(self) -> Array:
         assert self._current_base_motion_plan is not None
         while len(self._current_base_motion_plan) > 1:
             peek_pose = self._current_base_motion_plan[0]
             # Close enough, pop and continue.
-            if self._robot_is_close_to_pose(peek_pose):
+            if self._check_robot_is_close_to_pose(peek_pose):
                 self._current_base_motion_plan.pop(0)
             # Not close enough, stop popping.
             break
@@ -158,7 +175,7 @@ class MoveToTargetGroundController(
             return GRASP_CLOSE_THRESHOLD
         return 0.0
 
-    def _robot_is_close_to_pose(
+    def _check_robot_is_close_to_pose(
         self, pose: SE2, atol: float = WAYPOINT_TOLERANCE
     ) -> bool:
         robot_pose = self._get_current_robot_pose()
@@ -318,20 +335,28 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         self._current_params: np.ndarray | None = None
         self._current_arm_joint_plan: list[JointPositions] | None = None
         self._pybullet_sim: PyBulletSim | None = None
-        # Fraction of toss path at which to release gripper.
-        self._release_fraction: float = 0.46
         self._step_idx: int = 0
-        self._toss_dir: np.ndarray = np.zeros(7)
-        self._trajectory: np.ndarray = np.array([])
         self._has_released: bool = False
-        self._start_joint_angles: np.ndarray = np.zeros(7)
+        self._swing: TossSwing | None = None
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
         # We can later implement sampling if it's helpful, but usually the user would
         # want to specify the target arm conf themselves.
         raise NotImplementedError
 
-    def reset(self, x: ObjectCentricState, params: Any) -> None:
+    def reset(
+        self,
+        x: ObjectCentricState,
+        params: Any,
+        release_speed: float = TOSS_MAX_VELOCITY,
+        gripper_release_ms: int = TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+    ) -> None:
+        """Plan the swing, and fix the millisecond the gripper opens on.
+
+        The two knobs the real robot's movej_primitive.execute() takes.
+        gripper_release_ms is deliberately NOT clamped to the swing's duration: a value
+        at or past the end means the gripper never opens and the cube is never thrown.
+        """
         # Initialize the PyBullet interface if this is the first time ever.
         if self._pybullet_sim is None:
             self._pybullet_sim = PyBulletSim(x)
@@ -353,67 +378,37 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         )
         assert plan is not None, "Motion planning failed"
         self._current_arm_joint_plan = plan
-        # Compute trapezoidal velocity profile along the path.
-        curr_joint_angles = self._get_current_robot_arm_conf()
-        final_joint_angles = self._current_arm_joint_plan[-1]
-        dq = np.subtract(final_joint_angles, curr_joint_angles)[:7]
-        s_total = float(np.linalg.norm(dq))
-        if s_total > 1e-4:
-            self._toss_dir = dq / s_total
-        else:
-            self._toss_dir = np.zeros(7)
-        self._trajectory = _trapezoidal_motion_profile(
-            s_total,
-            max_vel=np.deg2rad(140),
-            max_accel=np.deg2rad(300),
-            max_decel=np.deg2rad(200),
-            step_size=_CONTROL_TIMESTEP,
+        self._swing = plan_toss_swing(
+            plan,
+            self._get_current_robot_arm_conf(),
+            release_speed,
+            gripper_release_ms,
         )
-        self._start_joint_angles = np.array(curr_joint_angles[:7])
         self._has_released = False
         self._step_idx = 0
 
     def terminated(self) -> bool:
         # Terminate when we've gone through the entire profile.
-        return self._step_idx >= len(self._trajectory)
+        assert self._swing is not None
+        return self._step_idx >= len(self._swing.trajectory)
 
     def step(self) -> Array:
-        assert self._current_arm_joint_plan is not None
-        gripper_pose = self._get_current_robot_gripper_pose()
-        action = np.zeros(18, dtype=np.float32)
+        """The swing's command for one control step, opening the gripper mid-step.
 
-        # Look up target distance along path from precomputed trapezoidal profile.
-        idx = min(self._step_idx, len(self._trajectory) - 1)
-        s = float(self._trajectory[idx])
-        # Compute velocity via finite difference of the profile.
-        if idx > 0:
-            ds = (self._trajectory[idx] - self._trajectory[idx - 1]) / _CONTROL_TIMESTEP
-        else:
-            ds = 0.0
-
-        # Position target with feedforward gain to compensate for tracking lag.
-        kp = 2.0
-        kv = 2.0
-        curr_joint_angles = self._get_current_robot_arm_conf()
-        target_joint_angles = self._start_joint_angles + self._toss_dir * s
-        action[3:10] = kp * (target_joint_angles - np.array(curr_joint_angles[:7]))
-
-        # Velocity feedforward along the toss direction.
-        action[11:18] = self._toss_dir * (ds * kv)
-
-        # Determine release point based on fraction of total distance.
-        s_total = self._trajectory[-1] if len(self._trajectory) > 0 else 0.0
-        fraction_covered = s / s_total if s_total > 0 else 1.0
-        should_release = (
-            self._has_released or fraction_covered >= self._release_fraction
+        The usual (18,) action, except on the step the release falls inside, which
+        returns a (TOSS_SLICES_PER_CONTROL_STEP, 18) schedule so gripper_release_ms
+        means the millisecond it names rather than the next step boundary.
+        """
+        assert self._swing is not None
+        action = toss_swing_action(
+            self._swing,
+            self._step_idx,
+            self._get_current_robot_arm_conf(),
+            self._get_current_robot_gripper_pose(),
+            self._has_released,
         )
-
-        if should_release:
-            action[10] = 0.0
+        if self._step_idx == self._swing.release_step:
             self._has_released = True
-        else:
-            action[10] = gripper_pose
-
         self._step_idx += 1
         return action
 
@@ -448,7 +443,7 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
             return GRASP_CLOSE_THRESHOLD
         return 0.0
 
-    def _robot_is_close_to_conf(self, conf: JointPositions) -> bool:
+    def _check_robot_is_close_to_conf(self, conf: JointPositions) -> bool:
         current_conf = self._get_current_robot_arm_conf()
         assert self._pybullet_sim is not None
         dist = self._pybullet_sim.get_joint_distance(current_conf, conf)
@@ -633,7 +628,7 @@ class CloseGripperController(GroundParameterizedController[ObjectCentricState, A
         self._last_state = x
 
     def terminated(self) -> bool:
-        return self._robot_gripper_is_closed(atol=0.02)
+        return self._check_robot_gripper_is_closed(atol=0.02)
 
     def step(self) -> Array:
         self.last_gripper_state = self._get_current_gripper_pose()
@@ -650,7 +645,9 @@ class CloseGripperController(GroundParameterizedController[ObjectCentricState, A
         robot = self.objects[0]
         return state.get(robot, "pos_gripper")
 
-    def _robot_gripper_is_closed(self, atol: float = GRIPPER_CLOSED_THRESHOLD) -> bool:
+    def _check_robot_gripper_is_closed(
+        self, atol: float = GRIPPER_CLOSED_THRESHOLD
+    ) -> bool:
         current_gripper_pose = self._get_current_gripper_pose()
         return bool(
             current_gripper_pose > 0.2
@@ -680,7 +677,7 @@ class OpenGripperController(GroundParameterizedController[ObjectCentricState, Ar
         self._last_state = x
 
     def terminated(self) -> bool:
-        return self._robot_gripper_is_open()
+        return self._check_robot_gripper_is_open()
 
     def step(self) -> Array:
         self.last_gripper_state = self._get_current_gripper_pose()
@@ -697,19 +694,447 @@ class OpenGripperController(GroundParameterizedController[ObjectCentricState, Ar
         robot = self.objects[0]
         return state.get(robot, "pos_gripper")
 
-    def _robot_gripper_is_open(
+    def _check_robot_gripper_is_open(
         self, atol: float = GRIPPER_OPEN_COMMAND_TOLERANCE
     ) -> bool:
         current_gripper_pose = self._get_current_gripper_pose()
         return current_gripper_pose < atol
 
 
+class PickCubeController(TidyBotPickController):
+    """Pick a cube up off the ground, taking no continuous parameters.
+
+    The object parameters are:
+        robot: The robot itself.
+        cube: The cube to pick up.
+
+    Where to stand is derived rather than sampled: head-on, at a distance within the
+    arm's reach, so a caller cannot draw an unreachable pose and there is nothing for
+    a refiner to backtrack over. A grasp that closes on nothing releases before
+    terminating, leaving the hand empty rather than commanded shut on air.
+    """
+
+    class PickCubeControllerPhase(enum.Enum):
+        """Grasping, or -- once a closed-on-nothing grasp is caught -- releasing."""
+
+        GRASPING = enum.auto()
+        RELEASING = enum.auto()
+
+    # Directly along the cube's own facing (no rotation offset), at a distance within
+    # the arm's reach. Not searched: the pick zone has no obstacles to route around,
+    # so a failure here is a real planning failure, not a standoff worth retrying.
+    STANDOFF = (0.55, 0.0)
+
+    # Aim at the cube's centre, not the shelf pick's +10 mm. The cube is canonicalised
+    # upright just below, so the third component is a height above the cube's centre,
+    # and at +10 mm the pads close 15 mm below a 50 mm cube's top face. Measured on
+    # Tossing3D-o1 seeds 100-139: that leaves the pinch site 34.3-56.0 mm above the
+    # cube's centre on 25/40 seeds -- past the 25 mm half-height, so the cube ends up
+    # dangling off the fingertips instead of seated between the pads. Aiming at the
+    # centre seats it on 40/40. Scoped to this controller because the shelf pick,
+    # which shares the base class, picks differently-shaped objects off a shelf.
+    GRASP_TRANSFORM = Pose(
+        (
+            GRASP_TRANSFORM_TO_OBJECT.position[0],
+            GRASP_TRANSFORM_TO_OBJECT.position[1],
+            0.0,
+        ),
+        GRASP_TRANSFORM_TO_OBJECT.orientation,
+    )
+
+    # Let the approach actually arrive before the gripper closes, and cancel the
+    # standing error it would otherwise close on. See
+    # TidyBotPickController._approach_has_settled for why the profile alone does not
+    # arrive, and why waiting is not enough on its own.
+    #
+    # Measured on Tossing3D-o1 seeds 100-139, at the moment the gripper closes: the
+    # standing error is about 1 degree on the shoulder, which throws the pinch site
+    # roughly 20 mm across the cube's face. The feedforward gain is the proportional
+    # gain, 2.0, because that is the value that nulls the standing error exactly rather
+    # than a tuned one -- 1.0 halves it and 3.0 overshoots, both measured. The delay is
+    # long enough for the profile's own deceleration to finish, so the error being
+    # cancelled is the standing one and not the tail of the approach.
+    APPROACH_SETTLE_STEPS = 60
+    APPROACH_FEEDFORWARD_GAIN = 2.0
+    APPROACH_FEEDFORWARD_DELAY = 12
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._phase = self.PickCubeControllerPhase.GRASPING
+
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        # No parameters for this controller.
+        return tuple()
+
+    def reset(
+        self,
+        x: ObjectCentricState,
+        params: Any,
+        extend_xy_magnitude: float = 0.025,
+        extend_rot_magnitude: float = np.pi / 8,
+    ) -> None:
+        del params
+        self._phase = self.PickCubeControllerPhase.GRASPING
+        # Grasp as if upright, not from the raw rotation (which could ask for below).
+        cube = self.objects[1]
+        rotations = upright_grasp_rotations(
+            (
+                x.get(cube, "qx"),
+                x.get(cube, "qy"),
+                x.get(cube, "qz"),
+                x.get(cube, "qw"),
+            )
+        )
+        for rotation in rotations:
+            upright = x.copy()
+            for feature, value in zip(("qx", "qy", "qz", "qw"), rotation):
+                upright.set(cube, feature, value)
+            try:
+                super().reset(
+                    upright,
+                    np.array(self.STANDOFF),
+                    extend_xy_magnitude=extend_xy_magnitude,
+                    extend_rot_magnitude=extend_rot_magnitude,
+                )
+                return
+            except (AssertionError, ValueError, RuntimeError):
+                continue
+        raise TrajectorySamplingFailure(
+            f"no reachable pick pose among {len(rotations)} grasp rotations"
+        )
+
+    def terminated(self) -> bool:
+        if not super().terminated():
+            return False
+        if self._check_grasp_successful():
+            return True
+        self._phase = self.PickCubeControllerPhase.RELEASING
+        return self._check_gripper_is_open()
+
+    def step(self) -> Array:
+        if self._phase is self.PickCubeControllerPhase.RELEASING:
+            action = np.zeros(11, dtype=np.float32)
+            action[-1] = 0
+            return action
+        return super().step()
+
+    def _check_grasp_successful(self) -> bool:
+        assert self._last_state is not None
+        return bool(self._last_state.get(self.objects[1], "z") > MINIMUM_HOLDING_HEIGHT)
+
+    def _check_gripper_is_open(self) -> bool:
+        assert self._last_state is not None
+        pos = self._last_state.get(self.objects[0], "pos_gripper")
+        return bool(pos < GRIPPER_OPEN_COMMAND_TOLERANCE)
+
+
+class MoveToTossLocationAndTossController(
+    GroundParameterizedController[ObjectCentricState, Array]
+):
+    """Drive to a pose to throw from and throw, as one skill.
+
+    The object parameters are:
+        robot: The robot itself.
+        target: The object to throw at.
+        held: The movable the robot is holding.
+
+    The continuous parameters are:
+        distance_to_target: float (metres)
+        rotation_to_target: float (radians)
+        tossing_speed: float (radians/second)
+        tossing_ms: float (milliseconds into the swing that the gripper opens)
+
+    Composed rather than split so that no predicate has to name the pose between them.
+    The cost is that a standoff which cannot score is only discovered by throwing from
+    it, where a separate move could have been rejected first.
+
+    One flat controller over an explicit phase, as pick_shelf is: base motion, then
+    the windup, then the swing. The swing is planned at the windup's end rather than
+    in reset, because it has to start from the arm conf actually reached.
+    """
+
+    class MoveToTossLocationAndTossControllerPhase(enum.Enum):
+        """Which leg of drive-then-throw step() is currently stepping."""
+
+        BASE_MOTION = enum.auto()
+        WINDUP = enum.auto()
+        SWING = enum.auto()
+
+    # Where a throw is possible; the upper part does not score.
+    TARGET_DISTANCE_BOUNDS = (1.25, 1.45)
+
+    # Widest rotation that stays within half of WAYPOINT_TOLERANCE at max standoff.
+    MAX_TARGET_ROTATION = float(
+        np.arcsin(0.5 * WAYPOINT_TOLERANCE / TARGET_DISTANCE_BOUNDS[1])
+    )
+    TARGET_ROTATION_BOUNDS = (-MAX_TARGET_ROTATION, MAX_TARGET_ROTATION)
+
+    # TossController's two dials, opened up as sampled parameters. Narrowed from the
+    # originally-shipped (60, TOSS_MAX_VELOCITY) / (600, 840): measured directly
+    # (toss_param_probe4.py, isolated toss draws from a real post-pick state, 480
+    # draws across 16 seeds) that every scoring draw fell in speed_deg [117.5, 140.0]
+    # and release_ms [710.4, 836.1] -- the wide bounds spent the large majority of
+    # the sampler's budget on combinations that can never score. A few degrees/ms of
+    # margin below the measured minimums, since 480 draws is not exhaustive.
+    SPEED_BOUNDS = (np.deg2rad(115.0), TOSS_MAX_VELOCITY)
+    RELEASE_MS_BOUNDS = (700.0, 840.0)
+
+    def __init__(
+        self, *args, pybullet_sim: PyBulletSim | None = None, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        # State and simulator; pybullet_sim is injectable so groundings can share one.
+        self._last_state: ObjectCentricState | None = None
+        self._pybullet_sim: PyBulletSim | None = pybullet_sim
+
+        # The two sampled tossing dials.
+        self._release_speed: float = TOSS_MAX_VELOCITY
+        self._gripper_release_ms: int = TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS
+        self._phase = self.MoveToTossLocationAndTossControllerPhase.BASE_MOTION
+
+        # Base motion: the drive to the toss pose.
+        self._current_base_motion_plan: list[SE2] | None = None
+
+        # Windup: the arm swinging back before the throw.
+        self._windup_trajectory: np.ndarray = np.array([])
+        self._windup_dir: np.ndarray = np.zeros(7)
+        self._windup_start_joint_angles: np.ndarray = np.zeros(7)
+        self._windup_step_idx: int = 0
+
+        # Swing: the throw itself, planned once the windup ends.
+        self._swing: TossSwing | None = None
+        self._swing_step_idx: int = 0
+        self._has_released: bool = False
+
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        del x  # not used
+        return np.array(
+            [
+                rng.uniform(*self.TARGET_DISTANCE_BOUNDS),
+                rng.uniform(*self.TARGET_ROTATION_BOUNDS),
+                rng.uniform(*self.SPEED_BOUNDS),
+                rng.uniform(*self.RELEASE_MS_BOUNDS),
+            ]
+        )
+
+    def reset(
+        self,
+        x: ObjectCentricState,
+        params: Any,
+        extend_xy_magnitude: float = 0.025,
+        extend_rot_magnitude: float = np.pi / 8,
+        disable_collision_objects: list[str] | None = None,
+    ) -> None:
+        if self._pybullet_sim is None:
+            self._pybullet_sim = PyBulletSim(x)
+        current_params = np.asarray(params, dtype=np.float32)
+        assert current_params.shape == (4,)
+        self._last_state = x
+        self._release_speed = float(current_params[2])
+        self._gripper_release_ms = int(round(float(current_params[3])))
+        self._phase = self.MoveToTossLocationAndTossControllerPhase.BASE_MOTION
+        self._windup_step_idx = 0
+        self._swing = None
+        self._swing_step_idx = 0
+        self._has_released = False
+
+        self._current_base_motion_plan = self._plan_base_motion(
+            x,
+            current_params,
+            extend_xy_magnitude,
+            extend_rot_magnitude,
+            disable_collision_objects,
+        )
+        final_base_pose = self._current_base_motion_plan[-1]
+        self._plan_arm_toss(x, final_base_pose)
+
+    def _plan_base_motion(
+        self,
+        x: ObjectCentricState,
+        current_params: np.ndarray,
+        extend_xy_magnitude: float,
+        extend_rot_magnitude: float,
+        disable_collision_objects: list[str] | None,
+    ) -> list[SE2]:
+        # The robot's own cargo would otherwise reject every base plan.
+        if disable_collision_objects is None:
+            disable_collision_objects = [self.objects[2].name]
+        target_object_pose = get_overhead_object_se2_pose(x, self.objects[1])
+        target_base_pose = get_target_robot_pose_from_parameters(
+            target_object_pose, current_params[0], current_params[1]
+        )
+        base_motion_plan = run_base_motion_planning(
+            state=x,
+            target_base_pose=target_base_pose,
+            x_bounds=WORLD_X_BOUNDS,
+            y_bounds=WORLD_Y_BOUNDS,
+            seed=0,
+            extend_xy_magnitude=extend_xy_magnitude,
+            extend_rot_magnitude=extend_rot_magnitude,
+            disable_collision_objects=disable_collision_objects,
+        )
+        if base_motion_plan is None:
+            raise TrajectorySamplingFailure("Base motion planning failed")
+        return base_motion_plan
+
+    def _plan_arm_toss(self, x: ObjectCentricState, final_base_pose: SE2) -> None:
+        """Plan the windup and the swing, from where the base motion will end.
+
+        As pick_shelf does: planning the whole arm motion here, rather than on
+        arrival, surfaces a planning failure from reset instead of from mid-throw.
+        """
+        assert self._pybullet_sim is not None
+        plan_x = x.copy()
+        robot = self.objects[0]
+        plan_x.set(robot, "pos_base_x", final_base_pose.x)
+        plan_x.set(robot, "pos_base_y", final_base_pose.y)
+        plan_x.set(robot, "pos_base_rot", final_base_pose.theta())
+        self._pybullet_sim.set_state(plan_x)
+        windup_plan = run_motion_planning(
+            self._pybullet_sim.robot,
+            self._pybullet_sim.get_robot_joints(),
+            list(TOSS_WINDUP_ARM_CONFIGURATION) + [0.0] * 6,
+            collision_bodies=self._pybullet_sim.get_collision_bodies(),
+            seed=0,
+            physics_client_id=self._pybullet_sim.physics_client_id,
+        )
+        if windup_plan is None:
+            raise TrajectorySamplingFailure("Motion planning failed")
+        windup_start = np.array(self._get_current_robot_arm_conf()[:7])
+        self._windup_trajectory, self._windup_dir = _compute_per_joint_profile(
+            windup_start,
+            np.array(windup_plan[-1][:7]),
+            _ARM_MAX_VELOCITY,
+            _ARM_MAX_ACCELERATION,
+        )
+        self._windup_start_joint_angles = windup_start
+
+        for joint, angle in enumerate(windup_plan[-1][:7], start=1):
+            plan_x.set(robot, f"pos_arm_joint{joint}", angle)
+        self._pybullet_sim.set_state(plan_x)
+        swing_plan = run_motion_planning(
+            self._pybullet_sim.robot,
+            self._pybullet_sim.get_robot_joints(),
+            list(TOSS_RELEASE_ARM_CONFIGURATION) + [0.0] * 6,
+            collision_bodies=self._pybullet_sim.get_collision_bodies(),
+            seed=0,
+            physics_client_id=self._pybullet_sim.physics_client_id,
+        )
+        if swing_plan is None:
+            raise TrajectorySamplingFailure("Motion planning failed")
+        self._swing = plan_toss_swing(
+            swing_plan,
+            windup_plan[-1],
+            self._release_speed,
+            self._gripper_release_ms,
+        )
+
+    def terminated(self) -> bool:
+        return self._swing is not None and self._swing_step_idx >= len(
+            self._swing.trajectory
+        )
+
+    def step(self) -> Array:
+        assert self._current_base_motion_plan is not None
+        if self._phase is self.MoveToTossLocationAndTossControllerPhase.BASE_MOTION:
+            return self._action_base_motion()
+        if self._phase is self.MoveToTossLocationAndTossControllerPhase.WINDUP:
+            return self._action_windup()
+        return self._action_swing()
+
+    def observe(self, x: ObjectCentricState) -> None:
+        self._last_state = x
+
+    def _action_base_motion(self) -> Array:
+        assert self._current_base_motion_plan is not None
+        while len(self._current_base_motion_plan) > 1:
+            peek_pose = self._current_base_motion_plan[0]
+            if self._check_robot_is_close_to_pose(peek_pose):
+                self._current_base_motion_plan.pop(0)
+            break
+        if self._check_robot_is_close_to_pose(self._current_base_motion_plan[-1]):
+            self._phase = self.MoveToTossLocationAndTossControllerPhase.WINDUP
+        robot_pose = self._get_current_robot_pose()
+        next_pose = self._current_base_motion_plan[0]
+        action = np.zeros(11, dtype=np.float32)
+        action[0] = next_pose.x - robot_pose.x
+        action[1] = next_pose.y - robot_pose.y
+        action[2] = get_signed_angle_distance(next_pose.theta(), robot_pose.theta())
+        action[-1] = self._get_current_robot_gripper_pose()
+        return action
+
+    def _action_windup(self) -> Array:
+        action = np.zeros(18, dtype=np.float32)
+        idx = min(self._windup_step_idx, len(self._windup_trajectory) - 1)
+        s = float(self._windup_trajectory[idx])
+        if idx > 0:
+            ds = (
+                self._windup_trajectory[idx] - self._windup_trajectory[idx - 1]
+            ) / _CONTROL_TIMESTEP
+        else:
+            ds = 0.0
+        kp = 2.0
+        kv = 2.0
+        curr = np.array(self._get_current_robot_arm_conf()[:7])
+        target = self._windup_start_joint_angles + self._windup_dir * s
+        action[3:10] = kp * (target - curr)
+        action[11:18] = self._windup_dir * (ds * kv)
+        action[10] = self._get_current_robot_gripper_pose()
+        self._windup_step_idx += 1
+        if self._windup_step_idx >= len(self._windup_trajectory):
+            self._phase = self.MoveToTossLocationAndTossControllerPhase.SWING
+        return action
+
+    def _action_swing(self) -> Array:
+        assert self._swing is not None
+        action = toss_swing_action(
+            self._swing,
+            self._swing_step_idx,
+            self._get_current_robot_arm_conf(),
+            self._get_current_robot_gripper_pose(),
+            self._has_released,
+        )
+        if self._swing_step_idx == self._swing.release_step:
+            self._has_released = True
+        self._swing_step_idx += 1
+        return action
+
+    def _get_current_robot_pose(self) -> SE2:
+        assert self._last_state is not None
+        robot = self.objects[0]
+        return SE2(
+            self._last_state.get(robot, "pos_base_x"),
+            self._last_state.get(robot, "pos_base_y"),
+            self._last_state.get(robot, "pos_base_rot"),
+        )
+
+    def _check_robot_is_close_to_pose(self, pose: SE2) -> bool:
+        robot_pose = self._get_current_robot_pose()
+        return bool(
+            np.hypot(pose.x - robot_pose.x, pose.y - robot_pose.y) < WAYPOINT_TOLERANCE
+            and abs(get_signed_angle_distance(pose.theta(), robot_pose.theta()))
+            < WAYPOINT_TOLERANCE
+        )
+
+    def _get_current_robot_arm_conf(self) -> JointPositions:
+        assert self._last_state is not None
+        robot = self.objects[0]
+        return [
+            self._last_state.get(robot, f"pos_arm_joint{i}") for i in range(1, 8)
+        ] + [0.0] * 6
+
+    def _get_current_robot_gripper_pose(self) -> float:
+        assert self._last_state is not None
+        return float(self._last_state.get(self.objects[0], "pos_gripper"))
+
+
 def create_lifted_controllers(
     action_space: TidyBot3DRobotActionSpace,
     init_constant_state: ObjectCentricState | None = None,
+    pybullet_sim: PyBulletSim | None = None,
 ) -> dict[str, LiftedParameterizedController]:
     """Create lifted parameterized controllers for the TidyBot3D ground environment."""
-
     del action_space, init_constant_state  # not used
 
     # Controllers.
@@ -783,6 +1208,37 @@ def create_lifted_controllers(
         )
     )
 
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    cube = Variable("?cube", MujocoMovableObjectType)
+    # Unused by the controller; present so an operator can say the cube is still on
+    # this side of it, as move_to_target_from_other_target carries ?prev_target.
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    LiftedPickCubeController: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot, cube, barrier],
+            PickCubeController,
+        )
+    )
+
+    class MoveToTossLocationAndToss(MoveToTossLocationAndTossController):
+        """Composed move-and-toss with pre-configured PyBullet sim."""
+
+        def __init__(self, objects):
+            super().__init__(objects, pybullet_sim=pybullet_sim)
+
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+    target = Variable("?target", MujocoObjectType)
+    held = Variable("?held", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoMovableObjectType)
+
+    LiftedMoveToTossLocationAndTossController: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot, target, held, barrier],
+            MoveToTossLocationAndToss,
+        )
+    )
+
     return {
         "move_to_target": LiftedMoveToTargetController,
         "move_to_target_from_other_target": LiftedMoveToTargetFromOtherTargetController,
@@ -791,4 +1247,6 @@ def create_lifted_controllers(
         "move_arm_to_end_effector": LiftedMoveArmToEndEffectorController,
         "close_gripper": LiftedCloseGripperController,
         "open_gripper": LiftedOpenGripperController,
+        "pick_cube": LiftedPickCubeController,
+        "move_to_toss_location_and_toss": LiftedMoveToTossLocationAndTossController,
     }

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -19,7 +19,7 @@ from kinder.envs.dynamic3d.object_types import (
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
 )
-from prpl_utils.utils import get_signed_angle_distance
+from pybullet_helpers.geometry import Quaternion
 from relational_structs import (
     GroundAtom,
     Object,
@@ -27,13 +27,13 @@ from relational_structs import (
     Predicate,
 )
 
+from kinder_models.dynamic3d.cube_symmetry import cube_tilt_from_upright
 from kinder_models.dynamic3d.utils import (
     END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
     GRIPPER_GRASPING_THRESHOLD,
     GRIPPER_OPEN_COMMAND_TOLERANCE,
     MINIMUM_HOLDING_HEIGHT,
     ON_GROUND_TOLERANCE,
-    WAYPOINT_TOLERANCE,
     PyBulletSim,
 )
 
@@ -45,22 +45,21 @@ HandEmpty = Predicate("HandEmpty", [MujocoTidyBotRobotObjectType])
 MovableIsDownX = Predicate(
     "MovableIsDownX", [MujocoMovableObjectType, MujocoMovableObjectType]
 )
-RobotAtThrowPose = Predicate(
-    "RobotAtThrowPose", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType]
-)
+# Static (name-derived, never changes): which object a throw should aim at. Upstream
+# types the bin as a MujocoMovableObjectType exactly like the cube and the barrier, so
+# without this an operator's ?target grounds to any of the three -- silently including
+# the cube being thrown and the barrier, neither of which can ever score. Measured: the
+# classical planner picked the wrong one on 6/9 seeds sampled, dooming refinement no
+# matter how many continuous samples it was given, since a discrete grounding mistake
+# has nothing to do with sampling and max_abstract_plans=1 never tries a second one.
+IsThrowTarget = Predicate("IsThrowTarget", [MujocoObjectType])
 
 # The environment's inflated region, not the task JSON's "ranges".
 GOAL_REGION_NAME = "blocks_goal_region"
 
 CUBE_NAME_PREFIX = "cube"
-BIN_NAME_PREFIX = "bin"
 BARRIER_NAME = "cuboid_barrier"
-
-# Throwable-from standoffs, not the 0.5 m grasping one. Brackets the test's 1.35 m.
-THROW_STANDOFF_BOUNDS = (1.20, 1.65)
-
-# Wider than WAYPOINT_TOLERANCE: the sampler already spends half of it off-axis.
-THROW_POSE_TOLERANCE = 2 * WAYPOINT_TOLERANCE
+BIN_NAME = "bin_0"
 
 
 class Tossing3DStateAbstractor:
@@ -90,8 +89,11 @@ class Tossing3DStateAbstractor:
         movables = state.get_objects(MujocoMovableObjectType)
         all_mujoco_objects = set(fixtures) | set(movables)
         cubes = self._get_cubes(state)
-        bins = [o for o in movables if o.name.startswith(BIN_NAME_PREFIX)]
         barriers = [o for o in movables if o.name == BARRIER_NAME]
+
+        for obj in all_mujoco_objects:
+            if obj.name == BIN_NAME:
+                atoms.add(GroundAtom(IsThrowTarget, [obj]))
 
         if self._check_gripper_open(state, robot):
             atoms.add(GroundAtom(HandEmpty, [robot]))
@@ -106,10 +108,6 @@ class Tossing3DStateAbstractor:
             for barrier in barriers:
                 if self._check_is_down_x(state, cube, barrier):
                     atoms.add(GroundAtom(MovableIsDownX, [cube, barrier]))
-
-        for target_bin in bins:
-            if self._check_at_throw_pose(state, robot, target_bin):
-                atoms.add(GroundAtom(RobotAtThrowPose, [robot, target_bin]))
 
         objects = {robot} | all_mujoco_objects
         return RelationalAbstractState(atoms, objects)
@@ -130,18 +128,32 @@ class Tossing3DStateAbstractor:
 
     @staticmethod
     def _check_on_ground(state: ObjectCentricState, movable: Object) -> bool:
-        """Whether a movable rests flat on the ground.
+        """Whether a movable rests flat on the ground, on any of its faces.
 
-        Flat because the bounding box is pose-independent, so the bottom-face
-        arithmetic only holds while axis-aligned. A toss cannot predict this.
+        Flat because the bounding box is pose-independent, so the bottom-face arithmetic
+        only holds while a face is down. Which face is down is not asked: for a cube
+        those are the same rest, and the grasp is derived from the upright rotation, so
+        a predicate that distinguished them would refuse picks that work.
         """
         z = state.get(movable, "z")
         bounding_box_height = state.get(movable, "bb_z")
-        return bool(
-            np.isclose(z - bounding_box_height / 2, 0.0, atol=ON_GROUND_TOLERANCE)
-            and np.isclose(state.get(movable, "qx"), 0.0, atol=ON_GROUND_TOLERANCE)
-            and np.isclose(state.get(movable, "qy"), 0.0, atol=ON_GROUND_TOLERANCE)
+        if not np.isclose(z - bounding_box_height / 2, 0.0, atol=ON_GROUND_TOLERANCE):
+            return False
+        rotation: Quaternion = (
+            state.get(movable, "qx"),
+            state.get(movable, "qy"),
+            state.get(movable, "qz"),
+            state.get(movable, "qw"),
         )
+        # Only a cube's faces are interchangeable; anything else keeps the strict test.
+        extents = [state.get(movable, f) for f in ("bb_x", "bb_y", "bb_z")]
+        if not np.allclose(extents, extents[0]):
+            qx, qy, _, _ = rotation
+            return bool(
+                np.isclose(qx, 0.0, atol=ON_GROUND_TOLERANCE)
+                and np.isclose(qy, 0.0, atol=ON_GROUND_TOLERANCE)
+            )
+        return bool(cube_tilt_from_upright(rotation) < ON_GROUND_TOLERANCE)
 
     def _check_holding(
         self, state: ObjectCentricState, robot: Object, movable: Object
@@ -168,25 +180,6 @@ class Tossing3DStateAbstractor:
     ) -> bool:
         """Whether a movable is at lower x than another, read live rather than fixed."""
         return state.get(movable, "x") < state.get(other, "x")
-
-    @staticmethod
-    def _check_at_throw_pose(
-        state: ObjectCentricState, robot: Object, target: Object
-    ) -> bool:
-        """Whether the base is at a throwable standoff, on axis, facing the target."""
-        low, high = THROW_STANDOFF_BOUNDS
-        dx = state.get(target, "x") - state.get(robot, "pos_base_x")
-        dy = state.get(target, "y") - state.get(robot, "pos_base_y")
-        heading_error = abs(
-            get_signed_angle_distance(
-                np.arctan2(dy, dx), state.get(robot, "pos_base_rot")
-            )
-        )
-        return bool(
-            abs(dy) <= THROW_POSE_TOLERANCE
-            and low - THROW_POSE_TOLERANCE <= dx <= high + THROW_POSE_TOLERANCE
-            and heading_error <= THROW_POSE_TOLERANCE
-        )
 
     def goal_deriver(self, state: ObjectCentricState) -> RelationalAbstractGoal:
         """The goal is to toss every cube into the goal region."""

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
@@ -1,0 +1,137 @@
+"""How hard a toss is thrown, and the swing itself.
+
+Plain functions over a motion plan rather than controller methods, so the release
+schedule can be tested without a simulator and so every toss is timed the same way. The
+limits are hand-tuned for throwing rather than derived from the arm's own, and are
+demonstrated on the real TidyBot (`yixuanhuang98/tidybot_real`, `robot/kinova.py`).
+"""
+
+from typing import NamedTuple
+
+import numpy as np
+from kinder.envs.dynamic3d.mujoco_utils import CONTROL_SCHEDULE_TIMESTEP
+from pybullet_helpers.inverse_kinematics import JointPositions
+from relational_structs import Array
+
+from kinder_models.dynamic3d.utils import _CONTROL_TIMESTEP, _trapezoidal_motion_profile
+
+# Wind up and back, then swing forward and release.
+TOSS_WINDUP_ARM_CONFIGURATION = np.deg2rad(
+    [0.0, 50.0, 180.0, -110.0, 0.0, -100.0, 90.0]
+)
+TOSS_RELEASE_ARM_CONFIGURATION = np.deg2rad([0.0, 20.0, 180.0, -35.0, 0.0, 25.0, 90.0])
+
+# Deliberately over-driving _ARM_MAX_VELOCITY: a toss throws hard on purpose.
+TOSS_MAX_VELOCITY = np.deg2rad(140.0)
+TOSS_MAX_ACCELERATION = np.deg2rad(300.0)
+TOSS_MAX_DECELERATION = np.deg2rad(200.0)
+
+# 1 ms, matching the real robot's 1 kHz servo loop.
+TOSS_SLICES_PER_CONTROL_STEP = int(round(_CONTROL_TIMESTEP / CONTROL_SCHEDULE_TIMESTEP))
+
+# Milliseconds from the start of the swing, as movej_primitive.execute() takes.
+# Re-derive by running the swing, not by recomputing from the confs.
+TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS = 720
+
+
+class TossSwing(NamedTuple):
+    """A planned swing: where the arm goes, and when the gripper opens."""
+
+    trajectory: np.ndarray
+    direction: np.ndarray
+    start_joint_angles: np.ndarray
+    release_step: int
+    release_slice: int
+
+
+def toss_swing_action(
+    swing: TossSwing,
+    step_idx: int,
+    current_joint_angles: JointPositions,
+    gripper_pose: float,
+    has_released: bool,
+) -> Array:
+    """The swing's command for one control step, opening the gripper mid-step.
+
+    The usual (18,) action, except on the step the release falls inside, which returns a
+    (TOSS_SLICES_PER_CONTROL_STEP, 18) schedule so gripper_release_ms means the
+    millisecond it names rather than the next step boundary.
+    """
+    action = np.zeros(18, dtype=np.float32)
+    idx = min(step_idx, len(swing.trajectory) - 1)
+    s = float(swing.trajectory[idx])
+    if idx > 0:
+        ds = (swing.trajectory[idx] - swing.trajectory[idx - 1]) / _CONTROL_TIMESTEP
+    else:
+        ds = 0.0
+    kp = 2.0
+    kv = 2.0
+    target_joint_angles = swing.start_joint_angles + swing.direction * s
+    action[3:10] = kp * (target_joint_angles - np.array(current_joint_angles[:7]))
+    action[11:18] = swing.direction * (ds * kv)
+
+    if has_released or step_idx > swing.release_step:
+        action[10] = 0.0
+        return action
+    if step_idx != swing.release_step:
+        action[10] = gripper_pose
+        return action
+    if swing.release_slice == 0:
+        action[10] = 0.0
+        return action
+    schedule = np.repeat(action[None], TOSS_SLICES_PER_CONTROL_STEP, axis=0)
+    schedule[: swing.release_slice, 10] = gripper_pose
+    schedule[swing.release_slice :, 10] = 0.0
+    return schedule
+
+
+def plan_toss_swing(
+    joint_plan: list[JointPositions],
+    current_joint_angles: JointPositions,
+    release_speed: float = TOSS_MAX_VELOCITY,
+    gripper_release_ms: int = TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+) -> TossSwing:
+    """Time a motion plan as a toss, and fix the millisecond the gripper opens on.
+
+    gripper_release_ms is deliberately NOT clamped to the swing's duration: a value at
+    or past the end means the gripper never opens and the cube is never thrown.
+    """
+    dq = np.subtract(joint_plan[-1], current_joint_angles)[:7]
+    s_total = float(np.linalg.norm(dq))
+    # Do not align this with the _compute_per_joint_profile siblings.
+    direction = dq / s_total if s_total > 1e-4 else np.zeros(7)
+    max_vel, max_accel, max_decel = toss_profile_limits(release_speed)
+    trajectory = _trapezoidal_motion_profile(
+        s_total,
+        max_vel=max_vel,
+        max_accel=max_accel,
+        max_decel=max_decel,
+        step_size=_CONTROL_TIMESTEP,
+    )
+    release_step, release_slice = divmod(
+        int(gripper_release_ms), TOSS_SLICES_PER_CONTROL_STEP
+    )
+    return TossSwing(
+        trajectory,
+        direction,
+        np.array(current_joint_angles[:7]),
+        release_step,
+        release_slice,
+    )
+
+
+def toss_profile_limits(
+    release_speed: float = TOSS_MAX_VELOCITY,
+) -> tuple[float, float, float]:
+    """The (max_vel, max_accel, max_decel) triple a toss at release_speed is timed by.
+
+    One factor on all three, so this is an effort and not a speed cap: raising max_vel
+    alone turns the profile triangular and moves the release into the acceleration
+    phase. Clamped at 1, the real arm's own ceiling.
+    """
+    effort = min(max(release_speed / TOSS_MAX_VELOCITY, 0.0), 1.0)
+    return (
+        TOSS_MAX_VELOCITY * effort,
+        TOSS_MAX_ACCELERATION * effort,
+        TOSS_MAX_DECELERATION * effort,
+    )

--- a/kinder-models/tests/dynamic3d/shelf/test_shelf_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/shelf/test_shelf_parameterized_skills.py
@@ -82,11 +82,18 @@ def _create_robot_state(
             "pos_base_rot": base_theta,
             **{f"pos_arm_joint{i+1}": v for i, v in enumerate(arm_joints)},
             "pos_gripper": gripper,
+            # The eight Robotiq 2F-85 joints. `pos_gripper` is the commanded ctrl
+            # value; these are where the fingers actually are, and zero is the open
+            # hand this fixture describes. create_state_from_dict reads only the
+            # features the robot type lists, so these keys are ignored by a
+            # kindergarden whose type does not carry them yet.
+            **{f"pos_gripper_joint{i+1}": 0.0 for i in range(8)},
             "vel_base_x": 0.0,
             "vel_base_y": 0.0,
             "vel_base_rot": 0.0,
             **{f"vel_arm_joint{i+1}": 0.0 for i in range(7)},
             "vel_gripper": 0.0,
+            **{f"vel_gripper_joint{i+1}": 0.0 for i in range(8)},
         },
         cube: {
             "x": 0.0,

--- a/kinder-models/tests/dynamic3d/tossing/test_cube_symmetry.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_cube_symmetry.py
@@ -1,0 +1,74 @@
+"""Tests for cube_symmetry.py."""
+
+import numpy as np
+
+from kinder_models.dynamic3d.cube_symmetry import (
+    CUBE_ROTATION_SYMMETRIES,
+    upright_grasp_rotations,
+)
+
+
+def test_there_are_twenty_four_cube_rotation_symmetries():
+    """A cube has 6 faces it can rest on, each at 4 yaws."""
+    assert len(CUBE_ROTATION_SYMMETRIES) == 24
+    seen = {tuple(np.round(q, 6)) for q in CUBE_ROTATION_SYMMETRIES}
+    assert len(seen) == 24
+
+
+def test_every_cube_symmetry_is_a_rotation():
+    """Unit quaternions, so each maps the cube onto itself without scaling it."""
+    for q in CUBE_ROTATION_SYMMETRIES:
+        assert np.isclose(np.linalg.norm(q), 1.0)
+
+
+def test_the_nearest_upright_rotation_flattens_every_face_down_rest():
+    """Each of the six face-down rests is the same cube, so each must canonicalise to a
+    pure yaw -- which is what makes a top-down grasp derivable from it."""
+
+    def quat(axis, deg):
+        a = np.deg2rad(deg) / 2
+        v = np.array(axis, dtype=float)
+        x, y, z = np.sin(a) * v
+        return (float(x), float(y), float(z), float(np.cos(a)))
+
+    for axis, deg in [
+        ([0, 0, 1], 0),
+        ([0, 0, 1], 90),
+        ([1, 0, 0], 90),
+        ([1, 0, 0], 180),
+        ([1, 0, 0], -90),
+        ([0, 1, 0], 90),
+        ([0, 1, 0], -90),
+        ([0, 1, 0], 180),
+    ]:
+        x, y, _, _ = upright_grasp_rotations(quat(axis, deg))[0]
+        assert abs(x) < 1e-6, (axis, deg, x)
+        assert abs(y) < 1e-6, (axis, deg, y)
+
+
+def test_the_nearest_upright_rotation_keeps_the_yaw():
+    """Yaw is the only real information in a cube's resting pose, so it must survive."""
+    for deg in (0.0, 30.0, 90.0, 200.0):
+        a = np.deg2rad(deg) / 2
+        q = (0.0, 0.0, float(np.sin(a)), float(np.cos(a)))
+        _, _, z, w = upright_grasp_rotations(q)[0]
+        got = np.rad2deg(2 * np.arctan2(z, w)) % 90.0
+        assert np.isclose(got, deg % 90.0, atol=1e-4) or np.isclose(
+            got, deg % 90.0 - 90.0, atol=1e-4
+        ), (deg, got)
+
+
+def test_upright_grasp_rotations_offers_all_four_equivalent_yaws():
+    """Resting on a face, a cube is four-fold symmetric about the vertical, so all four
+    yaws are the same grasp -- and the arm cannot reach every one of them."""
+    a = np.deg2rad(90) / 2
+    pitched = (0.0, float(np.sin(a)), 0.0, float(np.cos(a)))
+    rotations = upright_grasp_rotations(pitched)
+    assert len(rotations) == 4
+    for x, y, _, _ in rotations:
+        assert abs(x) < 1e-6 and abs(y) < 1e-6
+    yaws = sorted(
+        round(np.rad2deg(2 * np.arctan2(z, w)) % 360.0, 3) for _, _, z, w in rotations
+    )
+    gaps = {round((b - a_) % 360.0, 3) for a_, b in zip(yaws, yaws[1:])}
+    assert gaps == {90.0}, yaws

--- a/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
@@ -1,0 +1,164 @@
+"""Tests for toss_swing.py."""
+
+import numpy as np
+
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    MoveToTossLocationAndTossController,
+)
+from kinder_models.dynamic3d.tossing.toss_swing import (
+    TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+    TOSS_MAX_ACCELERATION,
+    TOSS_MAX_DECELERATION,
+    TOSS_MAX_VELOCITY,
+    TOSS_RELEASE_ARM_CONFIGURATION,
+    TOSS_SLICES_PER_CONTROL_STEP,
+    TOSS_WINDUP_ARM_CONFIGURATION,
+    plan_toss_swing,
+    toss_profile_limits,
+    toss_swing_action,
+)
+from kinder_models.dynamic3d.utils import _CONTROL_TIMESTEP, _trapezoidal_motion_profile
+
+
+def _straight_swing(release_ms=TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS):
+    """A planned swing between the two demonstrated confs, without a simulator."""
+    start = list(TOSS_WINDUP_ARM_CONFIGURATION) + [0.0] * 6
+    end = list(TOSS_RELEASE_ARM_CONFIGURATION) + [0.0] * 6
+    return plan_toss_swing([end], start, TOSS_MAX_VELOCITY, release_ms)
+
+
+def test_plan_toss_swing_splits_the_release_millisecond_into_step_and_slice():
+    """The millisecond names a slice inside a control step, not a step boundary."""
+    swing = _straight_swing(release_ms=725)
+    step, slice_ = divmod(725, TOSS_SLICES_PER_CONTROL_STEP)
+    assert swing.release_step == step
+    assert swing.release_slice == slice_
+
+
+def test_plan_toss_swing_direction_is_a_unit_vector_along_the_swing():
+    """The profile carries the distance; the direction carries only the heading."""
+    swing = _straight_swing()
+    assert np.isclose(np.linalg.norm(swing.direction), 1.0)
+
+
+def test_plan_toss_swing_direction_is_zero_for_a_swing_that_does_not_move():
+    """Otherwise the unit vector is a division by zero."""
+    conf = list(TOSS_WINDUP_ARM_CONFIGURATION) + [0.0] * 6
+    swing = plan_toss_swing(
+        [conf], conf, TOSS_MAX_VELOCITY, TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS
+    )
+    assert np.allclose(swing.direction, 0.0)
+
+
+def test_toss_swing_action_holds_the_gripper_shut_before_the_release_step():
+    """Before the release step, the gripper command still matches the caller's own."""
+    swing = _straight_swing()
+    action = toss_swing_action(swing, 0, [0.0] * 13, 1.0, False)
+    assert action.shape == (18,)
+    assert action[10] == 1.0
+
+
+def test_toss_swing_action_opens_the_gripper_after_the_release_step():
+    """Once has_released is set, the gripper stays open regardless of step_idx."""
+    swing = _straight_swing()
+    action = toss_swing_action(swing, swing.release_step + 1, [0.0] * 13, 1.0, True)
+    assert action.shape == (18,)
+    assert action[10] == 0.0
+
+
+def test_toss_swing_action_emits_a_schedule_on_the_step_the_release_falls_inside():
+    """A (slices, 18) schedule, so the millisecond means the millisecond."""
+    swing = _straight_swing(release_ms=725)
+    assert swing.release_slice != 0
+    schedule = toss_swing_action(swing, swing.release_step, [0.0] * 13, 1.0, False)
+    assert schedule.shape == (TOSS_SLICES_PER_CONTROL_STEP, 18)
+    assert np.all(schedule[: swing.release_slice, 10] == 1.0)
+    assert np.all(schedule[swing.release_slice :, 10] == 0.0)
+
+
+def test_toss_swing_action_stays_flat_when_the_release_lands_on_a_step_boundary():
+    """No schedule is needed when no millisecond inside the step is special."""
+    swing = _straight_swing(release_ms=TOSS_SLICES_PER_CONTROL_STEP * 7)
+    assert swing.release_slice == 0
+    action = toss_swing_action(swing, swing.release_step, [0.0] * 13, 1.0, False)
+    assert action.shape == (18,)
+    assert action[10] == 0.0
+
+
+def test_gripper_release_ms_splits_into_a_control_step_and_a_slice():
+    """The parameter is absolute wall-clock milliseconds from the start of the swing.
+
+    reset() only decomposes it; nothing rounds it to a control-step boundary.
+    """
+    assert TOSS_SLICES_PER_CONTROL_STEP == 100
+    for ms, expected in [(0, (0, 0)), (723, (7, 23)), (100, (1, 0)), (2399, (23, 99))]:
+        assert divmod(ms, TOSS_SLICES_PER_CONTROL_STEP) == expected
+
+
+def test_toss_release_speed_default_rebuilds_the_unscaled_profile():
+    """The default must rebuild the profile the literal 140/300/200 deg/s limits give.
+
+    Asserts equality of the sampled trajectory rather than of the three limits, so a
+    refactor of how the limits reach the profile still has to keep the motion.
+    """
+    total_dist = float(
+        np.linalg.norm(TOSS_RELEASE_ARM_CONFIGURATION - TOSS_WINDUP_ARM_CONFIGURATION)
+    )
+    expected = _trapezoidal_motion_profile(
+        total_dist,
+        max_vel=np.deg2rad(140),
+        max_accel=np.deg2rad(300),
+        max_decel=np.deg2rad(200),
+        step_size=_CONTROL_TIMESTEP,
+    )
+    max_vel, max_accel, max_decel = toss_profile_limits()
+    actual = _trapezoidal_motion_profile(
+        total_dist,
+        max_vel=max_vel,
+        max_accel=max_accel,
+        max_decel=max_decel,
+        step_size=_CONTROL_TIMESTEP,
+    )
+    assert np.array_equal(actual, expected)
+
+
+def test_toss_release_speed_scales_every_limit_by_the_same_factor():
+    """A release speed is an effort scale on the whole profile, not on max_vel alone.
+
+    Scaling max_vel alone moves the release out of the cruise phase, where the
+    acceleration limits set the speed instead, so it stops tracking max_vel.
+    """
+    # The invariant is the profile's shape. Asserted a few ULP wide rather than bitwise:
+    # recovering a ratio divides a factor back out, and a/(b*c)*c need not round back.
+    shape = np.array([TOSS_MAX_ACCELERATION, TOSS_MAX_DECELERATION]) / TOSS_MAX_VELOCITY
+    for scale in (0.25, 0.5, 1.0, 1.7, 2.0, 3.0):
+        max_vel, max_accel, max_decel = toss_profile_limits(scale * TOSS_MAX_VELOCITY)
+        assert np.allclose([max_accel, max_decel] / max_vel, shape, rtol=1e-15), scale
+        assert max_vel == min(scale, 1.0) * TOSS_MAX_VELOCITY
+
+    # Proportional through the origin, not merely affine, or "twice the speed" would
+    # mean other than twice the effort. Below the clamp only; clamping is not
+    # homogeneous.
+    rng = np.random.default_rng(0)
+    for _ in range(200):
+        factor = rng.uniform(0.05, 1.0)
+        speed = rng.uniform(0.05, 1.0) * TOSS_MAX_VELOCITY
+        scaled = np.array(toss_profile_limits(factor * speed))
+        assert np.allclose(
+            scaled, factor * np.array(toss_profile_limits(speed)), rtol=1e-12
+        )
+    assert np.array_equal(np.array(toss_profile_limits(0.0)), np.zeros(3))
+
+
+def test_toss_release_speed_clamps_the_effort_to_zero_and_one():
+    """The arm's own ceiling, and no reverse swing below it."""
+    at_ceiling = toss_profile_limits(TOSS_MAX_VELOCITY)
+    assert toss_profile_limits(2.0 * TOSS_MAX_VELOCITY) == at_ceiling
+    assert toss_profile_limits(-TOSS_MAX_VELOCITY) == toss_profile_limits(0.0)
+    assert np.array_equal(np.array(toss_profile_limits(-1.0)), np.zeros(3))
+
+
+def test_the_release_speeds_the_sampler_draws_are_never_clamped():
+    """SPEED_BOUNDS' top edge is the clamp point, so it must pass through."""
+    for speed in np.linspace(*MoveToTossLocationAndTossController.SPEED_BOUNDS, 25):
+        assert np.isclose(toss_profile_limits(speed)[0], speed)

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import kinder
 import numpy as np
 import pybullet as p
+from bilevel_planning.structs import GroundParameterizedController
 from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
 from kinder.envs.dynamic3d.envs import TidyBot3DEnv
@@ -17,13 +18,32 @@ from kinder.envs.dynamic3d.object_types import (
 from relational_structs import Object, ObjectCentricState
 from relational_structs.spaces import ObjectCentricBoxSpace
 from relational_structs.utils import create_state_from_dict
+from scipy.spatial.transform import Rotation  # type: ignore[import-untyped]
 from spatialmath import SE2
 
-from kinder_models.dynamic3d.shelf.parameterized_skills import (
-    create_lifted_controllers as shelf_create_lifted_controllers,)
+from kinder_models.dynamic3d import tidybot_pick_controller as pick_base
+from kinder_models.dynamic3d.shelf import parameterized_skills as shelf_skills
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    MoveToTossLocationAndTossController,
+    PickCubeController,
     create_lifted_controllers,
     get_target_robot_pose_from_parameters,
+)
+from kinder_models.dynamic3d.tossing.toss_swing import (
+    TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+    TOSS_MAX_VELOCITY,
+    TOSS_RELEASE_ARM_CONFIGURATION,
+    TOSS_SLICES_PER_CONTROL_STEP,
+    TOSS_WINDUP_ARM_CONFIGURATION,
+    toss_profile_limits,
+)
+from kinder_models.dynamic3d.utils import (
+    _CONTROL_TIMESTEP,
+    GRASP_TRANSFORM_TO_OBJECT,
+    MINIMUM_HOLDING_HEIGHT,
+    MOVE_TO_TARGET_DISTANCE_BOUNDS,
+    PyBulletSim,
+    _trapezoidal_motion_profile,
 )
 
 kinder.register_all_environments()
@@ -70,15 +90,20 @@ def _create_robot_state(
             "pos_base_x": base_x,
             "pos_base_y": base_y,
             "pos_base_rot": base_theta,
-            **{f"pos_arm_joint{i+1}": v for i, v in enumerate(arm_joints)},
+            **{f"pos_arm_joint{i + 1}": v for i, v in enumerate(arm_joints)},
             "pos_gripper": gripper,
-            **{f"pos_gripper_joint{i+1}": 0.0 for i in range(8)},
+            # The eight Robotiq 2F-85 joints. `pos_gripper` is the commanded ctrl
+            # value; these are where the fingers actually are, and zero is the open
+            # hand this fixture describes. create_state_from_dict reads only the
+            # features the robot type lists, so these keys are ignored by a
+            # kindergarden whose type does not carry them yet.
+            **{f"pos_gripper_joint{i + 1}": 0.0 for i in range(8)},
             "vel_base_x": 0.0,
             "vel_base_y": 0.0,
             "vel_base_rot": 0.0,
-            **{f"vel_arm_joint{i+1}": 0.0 for i in range(7)},
+            **{f"vel_arm_joint{i + 1}": 0.0 for i in range(7)},
             "vel_gripper": 0.0,
-            **{f"vel_gripper_joint{i+1}": 0.0 for i in range(8)},
+            **{f"vel_gripper_joint{i + 1}": 0.0 for i in range(8)},
         },
         cube: {
             "x": 0.0,
@@ -104,7 +129,6 @@ def _create_robot_state(
 
 def test_get_target_robot_pose_from_parameters():
     """Tests for get_target_robot_pose_from_parameters()."""
-
     target = SE2(1.0, 0.0, 0.0)
     robot_pose = get_target_robot_pose_from_parameters(
         target, target_distance=1.0, target_rot=0.0
@@ -160,7 +184,6 @@ def test_get_target_robot_pose_from_parameters():
 
 def test_move_to_target_controller_one_cube():
     """Test move-to-target controller in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = TidyBot3DEnv(
@@ -206,7 +229,6 @@ def test_move_to_target_controller_one_cube():
 
 def test_move_to_target_arm_configuration():
     """Test move-arm-to-conf controller in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = TidyBot3DEnv(
@@ -256,7 +278,6 @@ def test_repeated_grounding_does_not_leak_pybullet_clients():
     planner or data-collection loop creates one PyBulletSim per skill execution. Those
     clients must be released when the controller is dropped.
     """
-
     # Create the environment.
     num_cubes = 1
     env = TidyBot3DEnv(
@@ -331,7 +352,6 @@ def test_repeated_grounding_does_not_leak_pybullet_clients():
 
 def test_move_to_target_arm_end_effector():
     """Test move-arm-to-end-effector controller in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = TidyBot3DEnv(
@@ -386,7 +406,6 @@ def test_move_to_target_arm_end_effector():
 
 def test_close_gripper_controller():
     """Test close-gripper controller in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = TidyBot3DEnv(
@@ -493,7 +512,6 @@ def test_close_gripper_controller():
 
 def test_pick_place_ground():
     """Test pick and place in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = TidyBot3DEnv(
@@ -695,7 +713,6 @@ def test_pick_place_ground():
 
 def test_pick_place_shelf():
     """Test fake interface in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = kinder.make(
@@ -897,7 +914,6 @@ def test_pick_place_shelf():
 
 def test_velocity_tracking_mode():
     """Test pick and place in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = TidyBot3DEnv(
@@ -986,7 +1002,6 @@ def test_velocity_tracking_mode():
 
 def test_pick_toss():
     """Test pick and place in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = kinder.make(
@@ -1192,7 +1207,6 @@ def test_pick_toss():
 
 def test_pick_ground_toss():
     """Test pick and place in ground environment with 1 cube."""
-
     # Create the environment.
     num_cubes = 1
     env = kinder.make(
@@ -1213,7 +1227,7 @@ def test_pick_ground_toss():
     state = env.observation_space.devectorize(obs)
 
     # Create the move-base controller.
-    controllers = shelf_create_lifted_controllers(env.action_space)
+    controllers = shelf_skills.create_lifted_controllers(env.action_space)
 
     # create the pick ground controller.
     lifted_controller = controllers["pick_shelf"]
@@ -1322,3 +1336,597 @@ def test_pick_ground_toss():
     print("distance", distance)
 
     env.close()
+
+
+def test_toss_release_speed_raises_the_speed_the_profile_commands_at_release():
+    """The point of the parameter: a higher setting must actually release faster.
+
+    Compared below the ceiling, since TOSS_MAX_VELOCITY is both the default and the
+    clamp. Asserted against the profile rather than a thrown cube: whether the arm
+    tracks it is measured elsewhere.
+    """
+    total_dist = float(
+        np.linalg.norm(TOSS_RELEASE_ARM_CONFIGURATION - TOSS_WINDUP_ARM_CONFIGURATION)
+    )
+    release_fraction = 0.46
+
+    def commanded_release_speed(release_speed):
+        max_vel, max_accel, max_decel = toss_profile_limits(release_speed)
+        trajectory = _trapezoidal_motion_profile(
+            total_dist,
+            max_vel=max_vel,
+            max_accel=max_accel,
+            max_decel=max_decel,
+            step_size=_CONTROL_TIMESTEP,
+        )
+        final = trajectory[-1]
+        idx = int(np.argmax(trajectory / final >= release_fraction))
+        return (trajectory[idx] - trajectory[idx - 1]) / _CONTROL_TIMESTEP
+
+    default = commanded_release_speed(TOSS_MAX_VELOCITY)
+    slower = commanded_release_speed(0.4 * TOSS_MAX_VELOCITY)
+    assert default > 1.5 * slower
+
+
+def _default_speed_trajectory():
+    """The commanded distance profile of the shipped windup->release swing."""
+    s_total = float(
+        np.linalg.norm(TOSS_RELEASE_ARM_CONFIGURATION - TOSS_WINDUP_ARM_CONFIGURATION)
+    )
+    max_vel, max_accel, max_decel = toss_profile_limits(TOSS_MAX_VELOCITY)
+    trajectory = _trapezoidal_motion_profile(
+        s_total,
+        max_vel=max_vel,
+        max_accel=max_accel,
+        max_decel=max_decel,
+        step_size=_CONTROL_TIMESTEP,
+    )
+    return trajectory, s_total
+
+
+def test_the_default_release_ms_falls_at_fraction_046_of_the_swing():
+    """720 ms is where fraction 0.46 of the swing falls at the default speed.
+
+    720 and not the nominal 723 because reset() profiles the motion-planned path, which
+    moves the crossing 3 ms; a live rollout lands the cube 52 mm further with 723. The
+    tolerance here holds on either path, so only that rollout distinguishes them.
+    """
+    assert TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS == 720
+    trajectory, s_total = _default_speed_trajectory()
+    step, slice_ = divmod(
+        TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS, TOSS_SLICES_PER_CONTROL_STEP
+    )
+    # Linear interpolation between the two samples the release falls between, which is
+    # how the commanded distance actually varies inside one held control period.
+    below, above = float(trajectory[step]), float(trajectory[step + 1])
+    covered = below + (above - below) * (slice_ / TOSS_SLICES_PER_CONTROL_STEP)
+    assert abs(covered / s_total - 0.46) < 0.005
+
+
+def test_a_release_ms_past_the_swing_never_opens_the_gripper():
+    """The degenerate corner is reachable on purpose, not clamped away.
+
+    A release past the swing's end leaves the cube still held when the controller
+    terminates -- a real region of the parameter space a sweep must be able to reach.
+    """
+    trajectory, _ = _default_speed_trajectory()
+    duration_ms = (len(trajectory) - 1) * TOSS_SLICES_PER_CONTROL_STEP
+    assert duration_ms == 1700
+    late_step, _ = divmod(2400, TOSS_SLICES_PER_CONTROL_STEP)
+    assert late_step >= len(trajectory)
+
+
+def test_toss_schedules_its_release_at_the_requested_millisecond():
+    """End to end: exactly one action of a real toss is a control schedule.
+
+    That schedule has to reach the simulator and land on the millisecond asked for
+    rather than the next control-step boundary. Every other action is a plain (18,).
+    """
+    requested_ms = 812  # deliberately not a multiple of 100
+    expected_step, expected_slice = divmod(requested_ms, TOSS_SLICES_PER_CONTROL_STEP)
+
+    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", scene_bg=False)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    obs, _ = env.reset(seed=125)
+    state = env.observation_space.devectorize(obs)
+    shelf = shelf_skills.create_lifted_controllers(env.action_space)
+    tossing = create_lifted_controllers(env.action_space)
+
+    def _run(controller, params, **reset_kwargs):
+        """Drive one controller to termination, returning the actions it emitted."""
+        nonlocal state
+        controller.reset(state, params, **reset_kwargs)
+        emitted = []
+        for _ in range(400):
+            action = controller.step()
+            emitted.append(np.array(action, copy=True))
+            observation, _, _, _, _ = env.step(action)
+            state = env.observation_space.devectorize(observation)
+            controller.observe(state)
+            if controller.terminated():
+                return emitted
+        assert False, "Controller did not terminate"
+
+    # The cube has to be *in* the gripper, or the release is a no-op: an empty hand
+    # commands 0.0 both sides of the release.
+    robot = _get_robot_from_state(state)
+    pick = shelf["pick_shelf"].ground((robot, state.get_object_from_name("cube_0")))
+    _run(pick, pick.sample_parameters(state, np.random.default_rng(123)))
+
+    robot = _get_robot_from_state(state)
+    move = tossing["move_to_target"].ground(
+        (robot, state.get_object_from_name("bin_0"))
+    )
+    _run(move, np.array([1.35, 0.0]), disable_collision_objects=["cube_0"])
+
+    robot = _get_robot_from_state(state)
+    _run(tossing["move_arm_to_conf"].ground((robot,)), TOSS_WINDUP_ARM_CONFIGURATION)
+
+    robot = _get_robot_from_state(state)
+    toss = tossing["toss"].ground((robot,))
+    actions = _run(
+        toss, TOSS_RELEASE_ARM_CONFIGURATION, gripper_release_ms=requested_ms
+    )
+
+    scheduled = [i for i, action in enumerate(actions) if action.ndim == 2]
+    assert scheduled == [expected_step]
+    schedule = actions[expected_step]
+    # A schedule covers the whole control period, so release is located by index.
+    assert schedule.shape == (TOSS_SLICES_PER_CONTROL_STEP, 18)
+    assert np.all(schedule[:expected_slice, 10] == schedule[0, 10])
+    assert schedule[0, 10] > 0.0
+    assert np.all(schedule[expected_slice:, 10] == 0.0)
+
+    # Only the gripper column varies; the arm is commanded identically across slices.
+    columns = [c for c in range(18) if c != 10]
+    assert np.all(schedule[:, columns] == schedule[0, columns])
+
+    # Everything before the release still holds the cube, everything after is open.
+    assert all(action[10] > 0.0 for action in actions[:expected_step])
+    assert all(action[10] == 0.0 for action in actions[expected_step + 1 :])
+
+    env.close()
+
+
+def test_pick_cube_takes_no_continuous_parameters():
+    """The sampler has nothing to draw, so a refiner has nothing to backtrack over."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["pick_cube"].ground((robot, cube, barrier))
+    for seed in range(5):
+        params = controller.sample_parameters(state, np.random.default_rng(seed))
+        # The empty tuple every other zero-parameter controller here returns, not a
+        # zero-length array: the refiner only ever passes this straight back to reset.
+        assert params == tuple()
+        assert np.asarray(params).shape == (0,)
+    env.close()
+
+
+def test_pick_cube_grasps_at_the_cubes_centre_without_moving_the_shelf_pick():
+    """The cube pick aims at the centre; the shelf pick keeps the shared transform.
+
+    Measured on Tossing3D-o1 seeds 100-139: at the shared +10 mm the pinch site ends
+    up 34.3-56.0 mm above the cube's centre on 25/40 seeds -- past the 25 mm
+    half-height, so the cube dangles off the fingertips rather than sitting between
+    the pads. Aiming at the centre puts the pinch inside the cube on 40/40.
+    """
+    toss_grasp = PickCubeController.GRASP_TRANSFORM
+    shelf_grasp = pick_base.TidyBotPickController.GRASP_TRANSFORM
+
+    # The cube is canonicalised upright before the grasp is computed, so the
+    # transform's third component is a height above the cube's own centre.
+    assert toss_grasp.position[2] == 0.0
+    # Only the height moves; the approach offset and the orientation are the shelf's.
+    assert toss_grasp.position[:2] == shelf_grasp.position[:2]
+    assert toss_grasp.orientation == shelf_grasp.orientation
+    # The shelf pick is untouched: still the module-level constant it always used.
+    assert shelf_grasp == GRASP_TRANSFORM_TO_OBJECT
+
+
+def test_pick_cube_stands_head_on_within_the_shelf_picks_reach():
+    """No rotation offset from the cube's own facing, at a distance the shelf pick used
+    to sample -- not a range, since the pick zone has nothing to route around."""
+    distance, rot = PickCubeController.STANDOFF
+    assert rot == 0.0
+    assert (
+        MOVE_TO_TARGET_DISTANCE_BOUNDS[0]
+        <= distance
+        <= MOVE_TO_TARGET_DISTANCE_BOUNDS[1]
+    )
+
+
+def test_pick_cube_lifts_the_cube_off_the_ground():
+    """End to end, with no parameters supplied by the caller."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["pick_cube"].ground((robot, cube, barrier))
+    controller.reset(
+        state, controller.sample_parameters(state, np.random.default_rng(0))
+    )
+    for _ in range(2000):
+        if controller.terminated():
+            break
+        obs, _, _, _, _ = env.step(controller.step())
+        state = env.observation_space.devectorize(obs)
+        controller.observe(state)
+    assert controller.terminated()
+    assert state.get(cube, "z") > MINIMUM_HOLDING_HEIGHT
+    env.close()
+
+
+def test_pick_cube_releases_when_the_grasp_closed_on_nothing():
+    """Otherwise the hand is neither empty nor holding, and no operator applies."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["pick_cube"].ground((robot, cube, barrier))
+    controller.reset(
+        state, controller.sample_parameters(state, np.random.default_rng(0))
+    )
+    # The arm finished its retract with the cube still on the floor and the gripper
+    # commanded shut: a grasp that closed on nothing.
+    missed = state.copy()
+    missed.set(robot, "pos_gripper", 1.0)
+    controller.observe(missed)
+    controller._lifted = True  # pylint: disable=protected-access
+    assert not controller.terminated()
+    assert controller.step()[-1] == 0
+    opened = missed.copy()
+    opened.set(robot, "pos_gripper", 0.0)
+    controller.observe(opened)
+    assert controller.terminated()
+    env.close()
+
+
+def test_move_to_toss_location_and_toss_samples_four_parameters():
+    """Standoff, rotation, release speed and release millisecond, all in bounds."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    target_bin = state.get_object_from_name("bin_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["move_to_toss_location_and_toss"].ground(
+        (robot, target_bin, cube, barrier)
+    )
+    draws = np.array(
+        [
+            controller.sample_parameters(state, np.random.default_rng(seed))
+            for seed in range(50)
+        ]
+    )
+    assert draws.shape == (50, 4)
+    for column, (low, high) in enumerate(
+        [
+            MoveToTossLocationAndTossController.TARGET_DISTANCE_BOUNDS,
+            MoveToTossLocationAndTossController.TARGET_ROTATION_BOUNDS,
+            MoveToTossLocationAndTossController.SPEED_BOUNDS,
+            MoveToTossLocationAndTossController.RELEASE_MS_BOUNDS,
+        ]
+    ):
+        assert draws[:, column].min() >= low
+        assert draws[:, column].max() <= high
+        # A sampler, not a constant, in every component.
+        assert draws[:, column].min() < draws[:, column].max()
+    env.close()
+
+
+def test_pick_cube_then_move_and_toss_scores():
+    """The whole domain, end to end: two skills and no third."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    target_bin = state.get_object_from_name("bin_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+
+    def run(controller, params):
+        nonlocal state
+        controller.reset(state, params)
+        for _ in range(3000):
+            if controller.terminated():
+                return
+            obs_, _, _, _, _ = env.step(controller.step())
+            state = env.observation_space.devectorize(obs_)
+            controller.observe(state)
+        raise AssertionError("controller did not terminate")
+
+    pick = controllers["pick_cube"].ground((robot, cube, barrier))
+    run(pick, pick.sample_parameters(state, np.random.default_rng(0)))
+    assert state.get(cube, "z") > MINIMUM_HOLDING_HEIGHT
+
+    toss = controllers["move_to_toss_location_and_toss"].ground(
+        (robot, target_bin, cube, barrier)
+    )
+    run(toss, np.array([1.30, 0.0, TOSS_MAX_VELOCITY, 720.0]))
+    sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
+    assert sim._check_goals()  # pylint: disable=protected-access
+    env.close()
+
+
+def test_open_gripper_commands_open_until_the_gripper_reads_open():
+    """The controller predates this branch and had no test of its own."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    controller = controllers["open_gripper"].ground((robot,))
+
+    shut = state.copy()
+    shut.set(robot, "pos_gripper", 1.0)
+    controller.reset(shut)
+    assert not controller.terminated()
+    action = controller.step()
+    assert action.shape == (11,)
+    assert action[-1] == 0
+
+    opened = state.copy()
+    opened.set(robot, "pos_gripper", 0.0)
+    controller.observe(opened)
+    assert controller.terminated()
+    env.close()
+
+
+def test_move_to_target_from_other_target_drives_to_the_target_it_names():
+    """Three object parameters, but only the target governs where the base goes: the
+    third exists so an operator can say where the robot came from."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    target_bin = state.get_object_from_name("bin_0")
+    controller = controllers["move_to_target_from_other_target"].ground(
+        (robot, cube, target_bin)
+    )
+    controller.reset(state, np.array([0.5, 0.0]))
+    for _ in range(2000):
+        if controller.terminated():
+            break
+        obs_, _, _, _, _ = env.step(controller.step())
+        state = env.observation_space.devectorize(obs_)
+        controller.observe(state)
+    assert controller.terminated()
+    achieved = np.hypot(
+        state.get(cube, "x") - state.get(robot, "pos_base_x"),
+        state.get(cube, "y") - state.get(robot, "pos_base_y"),
+    )
+    assert abs(achieved - 0.5) < 0.1
+    env.close()
+
+
+def test_move_to_toss_location_and_toss_holds_no_sub_controllers():
+    """One flat controller over phase flags, as pick_shelf is, rather than a controller
+    that drives controllers it owns."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    target_bin = state.get_object_from_name("bin_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["move_to_toss_location_and_toss"].ground(
+        (robot, target_bin, cube, barrier)
+    )
+    nested = [
+        name
+        for name, value in vars(controller).items()
+        if isinstance(value, GroundParameterizedController)
+    ]
+    assert not nested, f"holds sub-controllers: {nested}"
+    env.close()
+
+
+def test_move_to_toss_location_and_toss_plans_every_phase_in_reset():
+    """As pick_shelf does: a planning failure surfaces from reset rather than from the
+    middle of a throw, where a refiner would see a crash instead of a rejected
+    sample."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    target_bin = state.get_object_from_name("bin_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["move_to_toss_location_and_toss"].ground(
+        (robot, target_bin, cube, barrier)
+    )
+    controller.reset(state, np.array([1.30, 0.0, TOSS_MAX_VELOCITY, 720.0]))
+    # Every phase is planned before the first action is asked for.
+    # pylint: disable-next=protected-access
+    assert controller._current_base_motion_plan is not None
+    assert len(controller._windup_trajectory) > 0  # pylint: disable=protected-access
+    assert controller._swing is not None  # pylint: disable=protected-access
+    env.close()
+
+
+def test_pick_cube_plans_a_grasp_for_a_cube_resting_on_its_side():
+    """pick_shelf derives the grasp from the raw rotation and finds no IK solution for
+    any of the five non-original face-down rests.
+
+    Canonicalising first, all of them plan.
+    """
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["pick_cube"].ground((robot, cube, barrier))
+
+    def rest(axis, deg):
+        a = np.deg2rad(deg) / 2
+        vec = np.array(axis, dtype=float)
+        return tuple(float(v) for v in np.sin(a) * vec) + (float(np.cos(a)),)
+
+    for axis, deg in [
+        ([1, 0, 0], 90),
+        ([1, 0, 0], 180),
+        ([1, 0, 0], -90),
+        ([0, 1, 0], 90),
+        ([0, 1, 0], -90),
+    ]:
+        tipped = state.copy()
+        for feature, value in zip(("qx", "qy", "qz", "qw"), rest(axis, deg)):
+            tipped.set(cube, feature, value)
+        # Raises if no candidate in the ladder plans.
+        controller.reset(
+            tipped, controller.sample_parameters(tipped, np.random.default_rng(0))
+        )
+    env.close()
+
+
+def _pick_and_measure_grasp(env, seed):
+    """Run pick_cube from a fresh reset and report where the cube sits in the jaws.
+
+    The offset is expressed on axes measured from PyBullet rather than assumed: the two
+    `*_inner_finger_pad` links separate along the end effector's own +x, and the gripper
+    base points at their midpoint along +z, so +x is the jaw axis, +z is the approach
+    axis, and y -- perpendicular to both -- is the direction along the gripped face that
+    nothing holds the cube against. Returns (jaw, lateral, depth) in millimetres.
+    """
+    obs, _ = env.reset(seed=seed)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    cube = state.get_object_from_name("cube_0")
+    barrier = state.get_object_from_name("cuboid_barrier")
+    controller = controllers["pick_cube"].ground((robot, cube, barrier))
+    controller.reset(
+        state, controller.sample_parameters(state, np.random.default_rng(0))
+    )
+    for _ in range(3000):
+        if controller.terminated():
+            break
+        obs, _, _, _, _ = env.step(controller.step())
+        state = env.observation_space.devectorize(obs)
+        controller.observe(state)
+    assert controller.terminated()
+    sim = PyBulletSim(state)
+    try:
+        sim.set_state(state)
+        end_effector = sim.get_ee_pose()
+        offset = (
+            Rotation.from_quat(end_effector.orientation)
+            .inv()
+            .apply(
+                np.array(
+                    [state.get(cube, "x"), state.get(cube, "y"), state.get(cube, "z")]
+                )
+                - np.array(end_effector.position)
+            )
+        )
+    finally:
+        sim.close()
+    return offset * 1000
+
+
+def test_pick_cube_closes_on_the_middle_of_a_face_not_near_its_edge():
+    """The pads must end up centred on the gripped face, on every seed.
+
+    Measured on Tossing3D-o1 seeds 100-139 before this: the approach ended when its
+    trapezoidal profile ran out of steps rather than when the arm arrived, and the
+    proportional command it tracks with leaves a standing error it cannot remove -- about
+    1 degree on the shoulder, which throws the pinch site about 20 mm across the cube's
+    face. The cube ended up 0.5-27.2 mm (median 22.9) off the middle of the face along
+    the one axis nothing holds it against, and the seven worst -- all past 25 mm, half a
+    cube width -- dropped the cube during the toss's windup.
+
+    Settling the approach and cancelling that standing error puts all forty at 0.4-7.7 mm
+    (median 5.1), the jaw within 0.7 degrees of the face normal on 40/40, and takes the
+    fixed-parameter toss from 33/40 to 40/40. Half of the half-extent is the bound
+    asserted: comfortably inside the contact patch, and well clear of both measured
+    populations.
+    """
+    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=1)
+    obs, _ = env.reset(seed=100)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    half_extent_mm = 1000 * state.get(state.get_object_from_name("cube_0"), "bb_x") / 2
+    try:
+        for seed in (100, 113, 127, 135):
+            jaw, lateral, depth = _pick_and_measure_grasp(env, seed)
+            assert abs(lateral) < half_extent_mm / 2, (
+                f"seed {seed}: cube {lateral:.1f} mm off the face's middle, past the "
+                f"{half_extent_mm / 2:.1f} mm this allows"
+            )
+            # The depth the shared transform's height was corrected for; keep it inside
+            # the cube rather than off the fingertips.
+            assert abs(depth) < half_extent_mm, f"seed {seed}: depth {depth:.1f} mm"
+            assert abs(jaw) < half_extent_mm, f"seed {seed}: jaw {jaw:.1f} mm"
+    finally:
+        env.close()
+
+
+def test_the_shelf_pick_still_closes_its_gripper_the_moment_its_profile_ends():
+    """The settling is the cube pick's, by class attribute, exactly as the grasp is.
+
+    The shelf pick reaches for differently-shaped objects on a shelf and has its own
+    measured behaviour; nothing here has been measured against it.
+    """
+    assert pick_base.TidyBotPickController.APPROACH_SETTLE_STEPS == 0
+    assert PickCubeController.APPROACH_SETTLE_STEPS > 0

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -72,11 +72,13 @@ def _create_robot_state(
             "pos_base_rot": base_theta,
             **{f"pos_arm_joint{i+1}": v for i, v in enumerate(arm_joints)},
             "pos_gripper": gripper,
+            **{f"pos_gripper_joint{i+1}": 0.0 for i in range(8)},
             "vel_base_x": 0.0,
             "vel_base_y": 0.0,
             "vel_base_rot": 0.0,
             **{f"vel_arm_joint{i+1}": 0.0 for i in range(7)},
             "vel_gripper": 0.0,
+            **{f"vel_gripper_joint{i+1}": 0.0 for i in range(8)},
         },
         cube: {
             "x": 0.0,

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -9,21 +9,14 @@ from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType
 from relational_structs import GroundAtom, ObjectCentricState
 from relational_structs.spaces import ObjectCentricBoxSpace
 
-from kinder_models.dynamic3d.tossing.parameterized_skills import (
-    create_lifted_controllers,
-)
 from kinder_models.dynamic3d.tossing.state_abstractions import (
     HandEmpty,
     Holding,
     MovableInGoalRegion,
     MovableIsDownX,
     OnGround,
-    RobotAtThrowPose,
     Tossing3DStateAbstractor,
 )
-
-# The standoff the pick-and-toss tests drive to, inside THROW_STANDOFF_BOUNDS.
-THROW_STANDOFF = 1.35
 
 
 def _get_robot_from_state(state: ObjectCentricState):
@@ -154,40 +147,54 @@ def test_the_goal_is_every_cube_in_the_goal_region():
     env.close()
 
 
-def test_robot_at_throw_pose_holds_after_driving_to_a_throw_standoff():
-    """Checked against the controller that establishes it, not a hand-set state."""
-    env, abstractor, state = _make_env_and_abstractor("Tossing3D-state-abstraction")
-    robot = _get_robot_from_state(state)
-    target_bin = state.get_object_from_name("bin_0")
-    controller = create_lifted_controllers(env.action_space)["move_to_target"].ground(
-        (robot, target_bin)
-    )
-    # cube_0 rests at x = 0.71 and the base is headed for x = 0.65, so it is excluded
-    # the way MoveToThrowPoseController excludes the object it holds.
-    controller.reset(
-        state,
-        np.array([THROW_STANDOFF, 0.0]),
-        disable_collision_objects=["cube_0"],
-    )
-    for _ in range(300):
-        obs, _, _, _, _ = env.step(controller.step())
-        state = env.observation_space.devectorize(obs)
-        controller.observe(state)
-        if controller.terminated():
-            break
-    else:
-        assert False, "Controller did not terminate"
-
-    atoms = abstractor.state_abstractor(state).atoms
-    assert GroundAtom(RobotAtThrowPose, [robot, target_bin]) in atoms
-    env.close()
-
-
 def test_the_abstractor_rejects_the_two_cube_variant():
-    """o2 is out of scope: no operator says which cube a throw is aimed at."""
+    """O2 is out of scope: no operator says which cube a throw is aimed at."""
     kinder.register_all_environments()
     env = kinder.make("kinder/Tossing3D-o2-v0", render_mode="rgb_array")
     sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
     with pytest.raises(AssertionError, match="only Tossing3D-o1 is supported"):
         Tossing3DStateAbstractor(sim)
+    env.close()
+
+
+def _rest(axis, deg):
+    """A quaternion (qx, qy, qz, qw) rotating `deg` about `axis`."""
+    half = np.deg2rad(deg) / 2
+    vec = np.array(axis, dtype=float)
+    return tuple(float(v) for v in np.sin(half) * vec) + (float(np.cos(half)),)
+
+
+def test_on_ground_holds_for_a_cube_resting_on_any_of_its_faces():
+    """A cube on its side is the same cube on the same floor. The grasp no longer cares
+    which face is up, so neither should the predicate."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    for axis, deg in [
+        ([0, 0, 1], 0),
+        ([0, 0, 1], 90),
+        ([1, 0, 0], 90),
+        ([1, 0, 0], 180),
+        ([1, 0, 0], -90),
+        ([0, 1, 0], 90),
+        ([0, 1, 0], -90),
+        ([0, 1, 0], 180),
+    ]:
+        rested = state.copy()
+        for feature, value in zip(("qx", "qy", "qz", "qw"), _rest(axis, deg)):
+            rested.set(cube, feature, value)
+        atoms = abstractor.state_abstractor(rested).atoms
+        assert GroundAtom(OnGround, [cube]) in atoms, (axis, deg)
+    env.close()
+
+
+def test_on_ground_still_fails_for_a_cube_balanced_between_faces():
+    """Canonicalising is not the same as ignoring orientation: a cube on an edge rests
+    on no face at all, and the bounding-box arithmetic stops meaning anything."""
+    env, abstractor, state = _make_env_and_abstractor()
+    cube = state.get_object_from_name("cube_0")
+    balanced = state.copy()
+    for feature, value in zip(("qx", "qy", "qz", "qw"), _rest([1, 0, 0], 45)):
+        balanced.set(cube, feature, value)
+    atoms = abstractor.state_abstractor(balanced).atoms
+    assert GroundAtom(OnGround, [cube]) not in atoms
     env.close()


### PR DESCRIPTION
# DRAFT — not reviewed by a human

**This description was written by an agent and has not been checked by Josh Roy. Any claim
in it may be wrong. Please do not act on it or reply to it until he has reviewed it.**

---

Adds `tidybot3d_tossing3D` bilevel planning models: two operators over the five Tossing3D
predicates, paired with the two skills this branch's parent adds. Measured end to end on
`Tossing3D-o1` seeds 100–139: **40/40 scored, 40/40 honest, 0/40 `plan_not_found`**.

Stacked on kb#113
(https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/113),
which reduces Tossing3D to the two skills these operators are paired to. Review that one
first. Also depends on `kindergarden` `josh/fix/set-state-restores-gripper-joints`
(`e02cdb8`) — without it, the honesty column below is not measurable.

> **This replaces kb#122, which was merged into kb#113's branch by accident.** Nothing is
> lost: that merge's content is here unchanged, and kb#113 is back to `kinder-models` only.
> Four commits that #122 carried were `kinder-models` changes and did **not** belong to it
> — the `?barrier` skill variable, the `TrajectorySamplingFailure` raise, `IsThrowTarget`,
> and the narrowed sampling bounds. Those now sit in kb#113 where they belong, so this PR
> is `kinder-bilevel-planning` only: two files, the env model and its test.

## Question / goal

Give Tossing3D a symbolic layer a bilevel planner can refine against — the operator models
KINDER ships for `Shelf3D`, `Sweep3D` and base motion but not for Tossing3D — and then
measure what fraction of seeds it plans for, and of those, what fraction actually score.

## Background

`kinder-bilevel-planning` refines an abstract plan by grounding each operator to a
parameterized controller and sampling its continuous parameters, accepting a sample only
when the achieved abstract state equals the operator's effects **exactly** —
`ParameterizedControllerTrajectorySampler` requires set equality, not "the add effects
hold". So an effect set that is wrong in *either* direction rejects throws that physically
worked. There was no such model for Tossing3D at all, so the domain could not be planned
for; `tidybot3d_shelf3D.py` is the shape this follows, where a `LiftedOperator` is paired
to one of upstream's controllers.

The parent branch is what makes two operators sufficient. Under the old three-skill
decomposition the middle rung (drive to a throw pose) needed a predicate describing
"somewhere the throw can work from", calibrated by measurement. kb#113 composes the drive
and the throw, so no operator names the pose between them — the skill does not stop there.

```
pick_cube(?robot, ?cube, ?barrier)
  pre  HandEmpty(?robot), OnGround(?cube), MovableIsDownX(?cube, ?barrier)
  add  Holding(?robot, ?cube)
  del  HandEmpty(?robot), OnGround(?cube)

move_to_toss_location_and_toss(?robot, ?target, ?held, ?barrier)
  pre  Holding(?robot, ?held)
  add  HandEmpty(?robot), MovableInGoalRegion(?held), OnGround(?held)
  del  Holding(?robot, ?held), MovableIsDownX(?held, ?barrier)
```

## Hypothesis

**None — implementation task, not an experiment.** The one open empirical question inside
it (does the throw *delete* `OnGround` or *add* it?) was settled by measurement rather than
argument; see *Methods*.

## Guidance given

Follow `tidybot3d_shelf3D.py`'s shape. Do not let an operator name the intermediate throw
pose. Settle the `OnGround` effect by running throws and reading the resulting abstract
state, not by reasoning about it. Raise rather than assert on a planning failure inside a
controller, so the refiner can back-track instead of the process dying. Then measure
plans-found and goal-reached across seeds, and report how many of the plans refinement
claimed to solve actually scored.

## Methods

Four commits:

- **`1da208c`** the two operators and the env-model dispatcher entry, plus its test.
- **`9d4e34b`** `TossController` raises `TrajectorySamplingFailure` instead of asserting
  when its toss fails to plan, so a failed sample is a rejected sample rather than a dead
  process. Worth knowing when reading the refiner: `TrajectorySamplingFailure` is **not**
  an `Exception` subclass, so `except Exception` misses every sampling failure — this
  measurement catches `BaseException` throughout.
- **`32d5259`** constrains the toss operator's `?target` and `?barrier` grounding, so the
  planner does not enumerate bindings the controllers cannot honour.
- **`a1adebd`** narrows the toss's speed and gripper-release-millisecond sampling bounds to
  the ranges measured to score.

Three design points a reviewer should look at:

**`?barrier` is an object parameter the controllers ignore.** `LiftedSkill` asserts the
operator's parameters equal the controller's variables exactly, so expressing
`MovableIsDownX` as a precondition means carrying the barrier through the controller.
`move_to_target_from_other_target` already carries `?prev_target` the same way. Deleting
`MovableIsDownX` on the throw is the one-way door: past the barrier, the cube cannot be
picked again.

**The throw adds `OnGround` rather than deleting it.** Settled by running 20 throws and
reading the resulting abstract state: **15/15** that scored left the cube resting on a
face. This is only sound because kb#113 makes `OnGround` face-interchangeable — under the
old "flat on the face it started on" test the add effect would have been dishonest for a
cube that landed on a different face.

**One cube only.** `num_objects != 1` raises rather than planning something the operators
cannot express, matching the state abstractor's own assertion.

**Measurement.** `kinder/Tossing3D-o1-v0`, seeds 100–139 (40 seeds), `samples_per_step=5`,
`max_abstract_plans=1`, `max_skill_horizon=250`, driven through this package's own
`BilevelPlanningAgent`. Outcomes are `scored` (`_check_goals()` after executing the refined
plan), `planned_not_scored` (refinement returned a plan, execution did not score) and
`plan_not_found`. **"honest"** is `scored / (scored + planned_not_scored)` — of the plans
refinement claimed to solve, how many actually scored. That column is the one worth
watching: a planner that reports a plan for a seed it cannot actually solve is worse than
one that reports no plan.

## Results

### End state of the stack, seeds 100–139

| configuration | scored | planned_not_scored | plan_not_found | honest |
| --- | --- | --- | --- | --- |
| these models, on the pre-fix trees | 15/40 | 19/40 | 6/40 | 15/34 |
| + `kindergarden` gripper-joint `set_state` fix | 15/40 | 0/40 | 25/40 | 15/15 |
| + kb#113's centre grasp | 33/40 | 0/40 | 7/40 | 33/33 |
| **+ kb#113's approach settling (final)** | **40/40** | **0/40** | **0/40** | **40/40** |

Every number in that table was produced *through these models* — they are what makes the
domain plannable at all — but the movement in it belongs to the fixes below the stack, not
to this branch. Stated plainly so the credit is not misread: **this branch is what makes
Tossing3D refinable; kb#113 and the `kindergarden` fix are what make refinement correct.**

TODO — drag in `2026-08-16-tossing3d-grasp-height-results.png`:
http://agni:8765/2026-08-16-tossing3d-grasp-height-results.png

### Refinement is not search-limited

`samples_per_step=25` gives the identical result to `samples_per_step=5`. And with kb#113's
approach fix in place, four different fixed `pick_cube` standoffs — `(0.55, 0.00)`,
`(0.50, 0.00)`, `(0.55, −0.35)`, `(0.58, +0.20)` — all score 40/40, where before the fix
they gave 33/40, 40/40, 40/40 and 22/40. So the refiner is not hunting for something rare
in the continuous space; it was being handed unrecoverable grasps.

TODO — drag in `standoff_vs_approach.png`: http://agni:8765/standoff_vs_approach.png

## Recommendation

Merge after kb#113.

- **Review order is kb#113 then this.** The two operators are meaningless without the two
  skills they are paired to, and `LiftedSkill`'s exact-parameter assertion means the two
  cannot be split further.
- The `kindergarden` fix (`josh/fix/set-state-restores-gripper-joints`, `e02cdb8`) is a
  prerequisite for the honesty column being meaningful. Before it, `planned_not_scored` was
  19/40.
- **`TOSS_RELEASE_MS_BOUNDS`'s window is narrowed to the measured-to-score range** rather
  than derived. It is a starting range, and the speed bounds are the better-grounded of the
  two (the upper edge is the profile's own clamp, with a test asserting no draw is silently
  rescaled).
- Composing the drive and the throw means a standoff that cannot score is only discovered
  by throwing from it. That was worth watching in the rejection counts, and on the final
  tree it does not bind — 0/40 `plan_not_found`.

