### PR TITLE
Add optional top-down grasp constraint to VegaPickPlace3D pick and place

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d_v2/vega_pickplace3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d_v2/vega_pickplace3d.py
@@ -43,13 +43,16 @@ def create_bilevel_planning_models(
     action_space: Space,
     config: VegaPickPlace3DEnvConfig | None = None,
     prefer_ompl: bool = True,
+    grasp_approach_max_tilt: float | None = None,
 ) -> SesameModels:
     """Create the env models for VegaPickPlace3D.
 
     ``config`` overrides the env config of the internal sim. Defaults to
     ``VegaPickPlace3DEnvConfig()`` if not provided. ``prefer_ompl`` selects the OMPL
     motion planner when ompl is installed; set it to False to force the BiRRT
-    fallback.
+    fallback. ``grasp_approach_max_tilt`` bounds how far (in radians) the end
+    effector may point off straight down in sampled pick and place configurations,
+    with the yaw free; None (the default) leaves grasp orientations unconstrained.
     """
     assert isinstance(observation_space, ObjectCentricBoxSpace)
     assert isinstance(action_space, BimanualArmJointDeltaGraspActionSpace)
@@ -139,7 +142,12 @@ def create_bilevel_planning_models(
     )
 
     # Controllers.
-    controllers = create_lifted_controllers(action_space, sim, prefer_ompl=prefer_ompl)
+    controllers = create_lifted_controllers(
+        action_space,
+        sim,
+        prefer_ompl=prefer_ompl,
+        grasp_approach_max_tilt=grasp_approach_max_tilt,
+    )
 
     # Finalize the skills.
     skills = {

--- a/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_pickplace3d.py
+++ b/kinder-bilevel-planning/tests/env_models/kinematic3d_v2/test_vega_pickplace3d.py
@@ -1,6 +1,7 @@
 """Tests for vega_pickplace3d.py."""
 
 import kinder
+import numpy as np
 import pytest
 from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
@@ -11,7 +12,7 @@ from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 # VegaPickPlace3D needs prpl_kinematics, which is an optional extra of both kindergarden
 # and this package, and a kindergarden release that contains the environment. Skip the
 # module rather than fail collection when either is missing.
-pytest.importorskip("kinder.envs.kinematic3d_v2.vega_pickplace3d")
+vega_pickplace3d = pytest.importorskip("kinder.envs.kinematic3d_v2.vega_pickplace3d")
 pytest.importorskip(
     "kinder_models.kinematic3d_v2.vega_pickplace3d.parameterized_skills"
 )
@@ -58,6 +59,38 @@ def test_vega_pickplace3d_bilevel_planning():
         env = RecordVideo(env, "unit_test_videos", name_prefix="VegaPickPlace3D")
     # For seed 0 the cube and the target are both on the right side of the table.
     _run_bilevel_planning(env, seed=0)
+    env.close()
+
+
+def test_vega_pickplace3d_grasp_approach_max_tilt_plumbing():
+    """The tilt constraint threads through model creation to the pick sampler."""
+    max_tilt = 0.1
+    env = kinder.make("kinder/VegaPickPlace3D-v0")
+    env_models = create_bilevel_planning_models(
+        "vega_pickplace3d",
+        env.observation_space,
+        env.action_space,
+        prefer_ompl=False,
+        grasp_approach_max_tilt=max_tilt,
+    )
+    # For seed 0 the cube is on the right side of the table.
+    obs, _ = env.reset(seed=0)
+    state = env_models.observation_to_state(obs)
+    pick = next(s for s in env_models.skills if s.operator.name == "Pick")
+    arm = state.get_object_from_name("right_arm")
+    cube = state.get_object_from_name("cube")
+    params = pick.controller.ground((arm, cube)).sample_parameters(
+        state, np.random.default_rng(0)
+    )
+
+    sim = vega_pickplace3d.ObjectCentricVegaPickPlace3DEnv(allow_state_access=True)
+    sim.set_state(state)
+    sim.set_arm_joint_positions("right", params)
+    rotation = sim.end_effector_pose("right").R
+    tilt = np.arccos(np.clip(-rotation[2, 2], -1.0, 1.0))
+    assert tilt <= max_tilt
+
+    sim.close()
     env.close()
 
 

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
@@ -12,6 +12,13 @@ grasp command to grasp, release, or take the cube.
 The handover skill moves both arms in sequence: the holding arm carries the cube into a
 region in front of the robot that both arms can reach, and the receiving arm then
 reaches to the cube and takes it.
+
+An optional grasp-approach tilt constraint (``grasp_approach_max_tilt``) restricts pick
+and place configurations to top-down approaches: the end effector points at most that
+angle off straight down, with the yaw free. When it is set, those two skills sample
+constraint-aware, drawing a yaw and solving full-pose IK for a down-facing target,
+because rejection over uniform draws essentially never produces a near-vertical end
+effector that also reaches the cube.
 """
 
 from __future__ import annotations
@@ -85,6 +92,22 @@ REFINE_MAX_ITERS = 50
 # fraction of the environment's grasp radius, so the grasp cannot sit on the boundary.
 GRASP_RADIUS_MARGIN = 0.9
 
+# Constraint-aware sampling under a grasp-approach tilt constraint: each candidate is a
+# full-pose IK solve from a uniformly drawn seed (~0.2 s), not a forward-kinematics
+# call (~0.3 ms), so the budget is far smaller than DEFAULT_NUM_GOAL_CANDIDATES.
+# Measured per-candidate acceptance for reachable cubes is 20-55% depending on the
+# cube's position, so 50 candidates make a spurious exhaustion vanishingly rare
+# (under 1e-5 at the low end) while a genuine exhaustion (an unreachable cube) still
+# resolves in about ten seconds. A spurious exhaustion is the costlier mistake, since
+# it discards a feasible abstract plan, so the budget favors reliability over a
+# faster failure path.
+DOWN_FACING_NUM_GOAL_CANDIDATES = 50
+
+# Full-pose IK from a random seed needs more iterations than the position-only
+# refinement: capping at 50 iterations drops the hard-case acceptance rate from 20%
+# to 16%, and beyond 100 the failure path gets slower without a matching gain.
+DOWN_FACING_IK_MAX_ITERS = 100
+
 # Sampled place configurations put the cube center within this fraction of the target
 # patch half extents, so the drop cannot land on the patch boundary.
 PLACE_EXTENT_MARGIN = 0.7
@@ -131,6 +154,16 @@ def _side_of(arm: Object) -> str:
     return side
 
 
+def _down_facing_rotation(yaw: float) -> np.ndarray:
+    """The end-effector rotation whose approach axis points straight down.
+
+    The Vega tool frames carry the fingertip offset along their z axis, so a
+    down-facing grasp is one whose frame z axis points along world -z; ``yaw`` spins
+    the frame about the vertical.
+    """
+    return np.asarray((SE3.Rz(yaw) * SE3.Rx(np.pi)).R)
+
+
 class _VegaPickPlaceControllerBase(
     GroundParameterizedController[ObjectCentricState, np.ndarray]
 ):
@@ -148,12 +181,17 @@ class _VegaPickPlaceControllerBase(
         planners: dict[str, MotionPlanner],
         collision_fn: Callable[[Configuration], bool],
         num_goal_candidates: int = DEFAULT_NUM_GOAL_CANDIDATES,
+        grasp_approach_max_tilt: float | None = None,
     ) -> None:
         super().__init__(objects)
         self._sim = sim
         self._planners = planners
         self._collision_fn = collision_fn
         self._num_goal_candidates = num_goal_candidates
+        # The tilt bound doubles as the IK orientation tolerance, so zero is
+        # unsatisfiable rather than "exactly vertical".
+        assert grasp_approach_max_tilt is None or grasp_approach_max_tilt > 0
+        self._grasp_approach_max_tilt = grasp_approach_max_tilt
         self._ik_refiners = {
             side: NumericalIK(
                 sim.tree,
@@ -165,6 +203,25 @@ class _VegaPickPlaceControllerBase(
             )
             for side in ARM_SIDES
         }
+        # Full-pose solvers for constraint-aware sampling. The orientation tolerance
+        # is the tilt bound: a converged solve is within that angle of the down-facing
+        # target rotation, and the achieved approach axis deviates from vertical by at
+        # most the full rotation error, so the tilt constraint holds by construction.
+        self._down_facing_iks = (
+            {
+                side: NumericalIK(
+                    sim.tree,
+                    self._joint_space(side),
+                    sim.robot.manipulators[side].ee_frame,
+                    position_tolerance=REFINE_POSITION_TOLERANCE,
+                    orientation_tolerance=grasp_approach_max_tilt,
+                    max_iters=DOWN_FACING_IK_MAX_ITERS,
+                )
+                for side in ARM_SIDES
+            }
+            if grasp_approach_max_tilt is not None
+            else {}
+        )
         self._current_state: ObjectCentricState | None = None
         self._current_params: np.ndarray | None = None
         # (side, goal joints) for each arm motion, in execution order.
@@ -251,6 +308,39 @@ class _VegaPickPlaceControllerBase(
             if self._collision_fn(refined):
                 continue
             return space.to_vector(refined)
+        return None
+
+    def _sample_down_facing_configuration(
+        self,
+        side: str,
+        make_target: Callable[[np.ndarray], SE3],
+        accept: Callable[[Configuration], bool],
+        rng: np.random.Generator,
+    ) -> np.ndarray | None:
+        """A collision-free configuration whose end effector points down.
+
+        Each candidate draws a yaw and a seed configuration uniformly, solves
+        full-pose IK for the target that ``make_target`` builds from the down-facing
+        rotation at that yaw, and keeps solutions that ``accept`` admits. A converged
+        solve satisfies the tilt constraint by construction (see the solver setup in
+        ``__init__``). The sim must already be at the state to sample around. Returns
+        None when the budget is exhausted.
+        """
+        space = self._arm_space(side)
+        lower, upper = space.bounds()
+        base = dict(self._sim.configuration)
+        solver = self._down_facing_iks[side]
+        for _ in range(DOWN_FACING_NUM_GOAL_CANDIDATES):
+            target = make_target(_down_facing_rotation(rng.uniform(-np.pi, np.pi)))
+            seed = base | space.to_configuration(rng.uniform(lower, upper))
+            solved = solver.solve(target, seed)
+            if solved is None:
+                continue
+            if not accept(solved):
+                continue
+            if self._collision_fn(solved):
+                continue
+            return space.to_vector(solved)
         return None
 
     def reset(self, x: ObjectCentricState, params: np.ndarray) -> None:
@@ -367,17 +457,37 @@ class GroundPickController(_VegaPickPlaceControllerBase):
         self._sim.set_state(x)
         side = _side_of(self.objects[0])
         cube = np.asarray(x.cube_position)
-        joints = self._sample_ee_reach_configuration(
-            side,
-            cube,
-            GRASP_RADIUS_MARGIN * self._sim.config.grasp_radius,
-            rng,
-            self._num_goal_candidates,
-        )
+        distance = GRASP_RADIUS_MARGIN * self._sim.config.grasp_radius
+        if self._grasp_approach_max_tilt is None:
+            joints = self._sample_ee_reach_configuration(
+                side, cube, distance, rng, self._num_goal_candidates
+            )
+        else:
+            # Aim above the cube for the same reason the refinement does: a
+            # down-facing gripper at the cube center would collide with the table.
+            target_position = cube + np.array([0.0, 0.0, REFINE_TARGET_Z_OFFSET])
+            assert distance > REFINE_POSITION_TOLERANCE + REFINE_TARGET_Z_OFFSET
+            ee_frame = self._sim.robot.manipulators[side].ee_frame
+
+            def in_grasp_range(config: Configuration) -> bool:
+                ee = self._sim.tree.forward_kinematics(ee_frame, config).t
+                return bool(np.linalg.norm(ee - cube) < distance)
+
+            joints = self._sample_down_facing_configuration(
+                side,
+                lambda rotation: SE3.Rt(rotation, target_position),
+                in_grasp_range,
+                rng,
+            )
         if joints is None:
+            num_samples = (
+                self._num_goal_candidates
+                if self._grasp_approach_max_tilt is None
+                else DOWN_FACING_NUM_GOAL_CANDIDATES
+            )
             raise TrajectorySamplingFailure(
                 f"No grasp configuration found for the {side} arm at cube "
-                f"{tuple(cube)} after {self._num_goal_candidates} samples"
+                f"{tuple(cube)} after {num_samples} samples"
             )
         return joints
 
@@ -420,6 +530,36 @@ class GroundPlaceController(_VegaPickPlaceControllerBase):
         place_point = np.array(
             [target[0], target[1], resting_z + PLACE_MAX_RELEASE_HEIGHT / 2]
         )
+
+        if self._grasp_approach_max_tilt is not None:
+            ee_frame = self._sim.robot.manipulators[side].ee_frame
+            base = dict(self._sim.configuration)
+            ee_pose = self._sim.tree.forward_kinematics(ee_frame, base)
+            held_cube = self._sim.tree.forward_kinematics(CUBE_NODE, base).t
+            # The cube rides rigidly on the end effector, so its offset in the
+            # end-effector frame is fixed; under a candidate rotation the end
+            # effector must sit at the place point minus the rotated offset for the
+            # cube to land there.
+            offset = np.asarray(ee_pose.R).T @ (held_cube - ee_pose.t)
+
+            def cube_in_slab(config: Configuration) -> bool:
+                cube = self._sim.tree.forward_kinematics(CUBE_NODE, config).t
+                return cube_accepted(cube)
+
+            joints = self._sample_down_facing_configuration(
+                side,
+                lambda rotation: SE3.Rt(rotation, place_point - rotation @ offset),
+                cube_in_slab,
+                rng,
+            )
+            if joints is not None:
+                return joints
+            raise TrajectorySamplingFailure(
+                f"No place configuration found for the {side} arm over target "
+                f"{tuple(target)} after {DOWN_FACING_NUM_GOAL_CANDIDATES} "
+                "down-facing samples"
+            )
+
         space = self._arm_space(side)
         lower, upper = space.bounds()
         base = dict(self._sim.configuration)
@@ -545,8 +685,16 @@ def create_lifted_controllers(
     sim: ObjectCentricVegaPickPlace3DEnv,
     rng: np.random.Generator | None = None,
     prefer_ompl: bool = True,
+    grasp_approach_max_tilt: float | None = None,
 ) -> dict[str, LiftedParameterizedController]:
-    """Create lifted parameterized controllers for VegaPickPlace3D."""
+    """Create lifted parameterized controllers for VegaPickPlace3D.
+
+    ``grasp_approach_max_tilt`` bounds how far (in radians) the end effector may point
+    off straight down in sampled pick and place configurations, with the yaw free;
+    None (the default) leaves grasp orientations unconstrained. Handover sampling is
+    never constrained: the take-over happens in mid-air, where approach direction
+    does not matter.
+    """
     del action_space  # the action space is implied by the environment
 
     if rng is None:
@@ -566,13 +714,25 @@ def create_lifted_controllers(
         """Pick up the cube with one arm."""
 
         def __init__(self, objects):
-            super().__init__(objects, sim, planners, collision_fn)
+            super().__init__(
+                objects,
+                sim,
+                planners,
+                collision_fn,
+                grasp_approach_max_tilt=grasp_approach_max_tilt,
+            )
 
     class PlaceController(GroundPlaceController):
         """Place the held cube onto the target patch."""
 
         def __init__(self, objects):
-            super().__init__(objects, sim, planners, collision_fn)
+            super().__init__(
+                objects,
+                sim,
+                planners,
+                collision_fn,
+                grasp_approach_max_tilt=grasp_approach_max_tilt,
+            )
 
     class HandoverController(GroundHandoverController):
         """Pass the cube from one arm to the other."""

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
@@ -52,7 +52,7 @@ from prpl_kinematics.ik import NumericalIK
 from prpl_kinematics.planning.configuration_space import ConfigurationSpace
 from prpl_kinematics.planning.joint_space import JointSpace
 from prpl_kinematics.planning.motion_planner import MotionPlanner
-from prpl_kinematics.tree.kinematic_tree import Configuration
+from prpl_kinematics.tree.kinematic_tree import Configuration, KinematicTree
 from relational_structs import Object, ObjectCentricState, Variable
 from spatialmath import SE3
 
@@ -95,18 +95,40 @@ GRASP_RADIUS_MARGIN = 0.9
 # Constraint-aware sampling under a grasp-approach tilt constraint: each candidate is a
 # full-pose IK solve from a uniformly drawn seed (~0.2 s), not a forward-kinematics
 # call (~0.3 ms), so the budget is far smaller than DEFAULT_NUM_GOAL_CANDIDATES.
-# Measured per-candidate acceptance for reachable cubes is 20-55% depending on the
-# cube's position, so 50 candidates make a spurious exhaustion vanishingly rare
-# (under 1e-5 at the low end) while a genuine exhaustion (an unreachable cube) still
-# resolves in about ten seconds. A spurious exhaustion is the costlier mistake, since
-# it discards a feasible abstract plan, so the budget favors reliability over a
-# faster failure path.
-DOWN_FACING_NUM_GOAL_CANDIDATES = 50
+# Measured per-candidate acceptance for reachable cubes is 10-46% depending on the
+# cube's position (the soft limit margin costs several points, most at the hard
+# end), so 100 candidates make a spurious exhaustion vanishingly rare (under 3e-5
+# at the low end) while a genuine exhaustion (an unreachable cube) resolves in under
+# half a minute. A spurious exhaustion is the costlier mistake, since it discards a
+# feasible abstract plan, so the budget favors reliability over a faster failure
+# path.
+DOWN_FACING_NUM_GOAL_CANDIDATES = 100
 
 # Full-pose IK from a random seed needs more iterations than the position-only
 # refinement: capping at 50 iterations drops the hard-case acceptance rate from 20%
 # to 16%, and beyond 100 the failure path gets slower without a matching gain.
 DOWN_FACING_IK_MAX_ITERS = 100
+
+# The physical Vega's firmware zero-torques any axis whose position passes its soft
+# limit (dynamically, not only at boot), so a goal configuration on the boundary
+# risks a limp joint on tracking overshoot. Constrained samples keep every arm joint
+# at least this far inside its limits; the IK solver clamps to the limits each
+# iteration, so without a margin accepted solutions can sit exactly on them.
+DOWN_FACING_JOINT_LIMIT_MARGIN = 0.1
+
+# Constrained placing prefers the posture the arm is already in. It tries this many
+# yaws fanning out from the current yaw (plus the current yaw itself), each seeded
+# from the current configuration, and keeps the solution closest to that
+# configuration in max joint change; full posture resampling is the last resort. A
+# nearby yaw does not imply a nearby posture (unwinding a wrist pinned against the
+# margin boundary can spin the roll joint by radians while the yaw barely moves),
+# hence closest-solution selection rather than first-success.
+PLACE_POSTURE_SEED_ATTEMPTS = 12
+
+# A posture-preserving solution whose max joint change is below this is accepted
+# immediately, skipping the rest of the fan; tier-one successes (a short transfer at
+# the current yaw) measure 0.7-0.9 rad, so the common case stays a single solve.
+PLACE_POSTURE_ACCEPT_DELTA = 1.2
 
 # Sampled place configurations put the cube center within this fraction of the target
 # patch half extents, so the drop cannot land on the patch boundary.
@@ -164,6 +186,24 @@ def _down_facing_rotation(yaw: float) -> np.ndarray:
     return np.asarray((SE3.Rz(yaw) * SE3.Rx(np.pi)).R)
 
 
+class _MarginJointSpace(JointSpace):
+    """A JointSpace with every joint's bounds pulled in by a fixed margin.
+
+    The constrained IK solvers use this so their solutions stay clear of the soft
+    limits during the solve (the solver clamps to the space's bounds each
+    iteration), rather than rejecting boundary solutions after the fact; a seeded
+    solve then converges to a nearby margin-respecting solution when one exists.
+    """
+
+    def __init__(
+        self, tree: KinematicTree, joint_names: Sequence[str], margin: float
+    ) -> None:
+        super().__init__(tree, joint_names)
+        assert np.all(self._upper - self._lower > 2 * margin)
+        self._lower = self._lower + margin
+        self._upper = self._upper - margin
+
+
 class _VegaPickPlaceControllerBase(
     GroundParameterizedController[ObjectCentricState, np.ndarray]
 ):
@@ -207,11 +247,17 @@ class _VegaPickPlaceControllerBase(
         # is the tilt bound: a converged solve is within that angle of the down-facing
         # target rotation, and the achieved approach axis deviates from vertical by at
         # most the full rotation error, so the tilt constraint holds by construction.
+        # The solvers run in a margin-shrunken joint space, so their solutions also
+        # stay clear of the soft limits by construction.
         self._down_facing_iks = (
             {
                 side: NumericalIK(
                     sim.tree,
-                    self._joint_space(side),
+                    _MarginJointSpace(
+                        sim.tree,
+                        self._joint_space(side).joint_names,
+                        DOWN_FACING_JOINT_LIMIT_MARGIN,
+                    ),
                     sim.robot.manipulators[side].ee_frame,
                     position_tolerance=REFINE_POSITION_TOLERANCE,
                     orientation_tolerance=grasp_approach_max_tilt,
@@ -310,6 +356,28 @@ class _VegaPickPlaceControllerBase(
             return space.to_vector(refined)
         return None
 
+    def _solve_down_facing_candidate(
+        self,
+        side: str,
+        target: SE3,
+        seed: Configuration,
+        accept: Callable[[Configuration], bool],
+    ) -> np.ndarray | None:
+        """One constrained candidate: solve, then check ``accept`` and collision.
+
+        A converged solve satisfies the tilt constraint and the soft limit margin
+        by construction (see the solver setup in ``__init__``). Returns the arm
+        joint vector, or None if the solve failed or a check rejected it.
+        """
+        solved = self._down_facing_iks[side].solve(target, seed)
+        if solved is None:
+            return None
+        if not accept(solved):
+            return None
+        if self._collision_fn(solved):
+            return None
+        return self._arm_space(side).to_vector(solved)
+
     def _sample_down_facing_configuration(
         self,
         side: str,
@@ -321,26 +389,19 @@ class _VegaPickPlaceControllerBase(
 
         Each candidate draws a yaw and a seed configuration uniformly, solves
         full-pose IK for the target that ``make_target`` builds from the down-facing
-        rotation at that yaw, and keeps solutions that ``accept`` admits. A converged
-        solve satisfies the tilt constraint by construction (see the solver setup in
-        ``__init__``). The sim must already be at the state to sample around. Returns
-        None when the budget is exhausted.
+        rotation at that yaw, and keeps solutions that pass the candidate checks.
+        The sim must already be at the state to sample around. Returns None when the
+        budget is exhausted.
         """
         space = self._arm_space(side)
         lower, upper = space.bounds()
         base = dict(self._sim.configuration)
-        solver = self._down_facing_iks[side]
         for _ in range(DOWN_FACING_NUM_GOAL_CANDIDATES):
             target = make_target(_down_facing_rotation(rng.uniform(-np.pi, np.pi)))
             seed = base | space.to_configuration(rng.uniform(lower, upper))
-            solved = solver.solve(target, seed)
-            if solved is None:
-                continue
-            if not accept(solved):
-                continue
-            if self._collision_fn(solved):
-                continue
-            return space.to_vector(solved)
+            joints = self._solve_down_facing_candidate(side, target, seed, accept)
+            if joints is not None:
+                return joints
         return None
 
     def reset(self, x: ObjectCentricState, params: np.ndarray) -> None:
@@ -545,6 +606,42 @@ class GroundPlaceController(_VegaPickPlaceControllerBase):
             def cube_in_slab(config: Configuration) -> bool:
                 cube = self._sim.tree.forward_kinematics(CUBE_NODE, config).t
                 return cube_accepted(cube)
+
+            # Prefer the posture the arm already has (see the fan constants above),
+            # so the transfer stays near the current configuration rather than
+            # flipping to an independently sampled posture. Yaw is free for a cube,
+            # so reusing or fanning out from the current yaw loses nothing. Targets
+            # use the exactly-vertical rotation at each candidate yaw, not the
+            # current rotation, so the converged tilt stays within the bound even
+            # though the held grasp may itself be tilted. When the held grasp is
+            # not down-facing at all (an unconstrained pick or a handover), the
+            # seeded fan usually fails and the resampling fallback takes over.
+            rotation_now = np.asarray(ee_pose.R)
+            yaw_now = float(np.arctan2(rotation_now[1, 0], rotation_now[0, 0]))
+            yaw_offsets = [0.0]
+            for k in range(1, PLACE_POSTURE_SEED_ATTEMPTS // 2 + 1):
+                step = 2 * np.pi * k / (PLACE_POSTURE_SEED_ATTEMPTS + 1)
+                yaw_offsets.extend([step, -step])
+            arm_joints_now = self._arm_space(side).to_vector(base)
+            best: np.ndarray | None = None
+            best_delta = np.inf
+            for yaw_offset in yaw_offsets:
+                rotation = _down_facing_rotation(yaw_now + yaw_offset)
+                joints = self._solve_down_facing_candidate(
+                    side,
+                    SE3.Rt(rotation, place_point - rotation @ offset),
+                    base,
+                    cube_in_slab,
+                )
+                if joints is None:
+                    continue
+                delta = float(np.max(np.abs(joints - arm_joints_now)))
+                if delta < PLACE_POSTURE_ACCEPT_DELTA:
+                    return joints
+                if delta < best_delta:
+                    best, best_delta = joints, delta
+            if best is not None:
+                return best
 
             joints = self._sample_down_facing_configuration(
                 side,

--- a/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d_v2/vega_pickplace3d/parameterized_skills.py
@@ -116,6 +116,21 @@ DOWN_FACING_IK_MAX_ITERS = 100
 # iteration, so without a margin accepted solutions can sit exactly on them.
 DOWN_FACING_JOINT_LIMIT_MARGIN = 0.1
 
+# First-valid-wins sampling tends to return contorted postures: over half of the
+# valid down-facing solutions rest a joint exactly on the margin boundary (the
+# solver clamps there), and a boundary-pinned posture stalls the posture-preserving
+# place solve just like a limit-pinned one stalls the servos. The sampler therefore
+# scores each valid solution by its max joint change from the current configuration
+# plus a penalty per pinned joint, accepts an unpinned solution within the
+# threshold immediately, and otherwise returns the best of this many valid
+# solutions. The threshold is calibrated to well-conditioned pick postures, which
+# measure about 2 rad from home.
+DOWN_FACING_SELECT_CANDIDATES = 5
+DOWN_FACING_ACCEPT_DELTA = 2.5
+# Dwarfs any possible joint delta, so an unpinned solution always outranks a pinned
+# one and pinned solutions rank by how many joints they pin.
+DOWN_FACING_PINNED_PENALTY = 10.0
+
 # Constrained placing prefers the posture the arm is already in. It tries this many
 # yaws fanning out from the current yaw (plus the current yaw itself), each seeded
 # from the current configuration, and keeps the solution closest to that
@@ -387,22 +402,39 @@ class _VegaPickPlaceControllerBase(
     ) -> np.ndarray | None:
         """A collision-free configuration whose end effector points down.
 
-        Each candidate draws a yaw and a seed configuration uniformly, solves
+        Each candidate draws a yaw and a seed configuration uniformly and solves
         full-pose IK for the target that ``make_target`` builds from the down-facing
-        rotation at that yaw, and keeps solutions that pass the candidate checks.
-        The sim must already be at the state to sample around. Returns None when the
-        budget is exhausted.
+        rotation at that yaw. Among solutions that pass the candidate checks, the
+        sampler prefers postures near the current configuration and away from the
+        margin boundary (see the selection constants). The sim must already be at
+        the state to sample around. Returns None when the budget is exhausted.
         """
         space = self._arm_space(side)
         lower, upper = space.bounds()
         base = dict(self._sim.configuration)
+        arm_joints_now = space.to_vector(base)
+        pin_lower = lower + DOWN_FACING_JOINT_LIMIT_MARGIN + 1e-6
+        pin_upper = upper - DOWN_FACING_JOINT_LIMIT_MARGIN - 1e-6
+        best: np.ndarray | None = None
+        best_score = np.inf
+        num_valid = 0
         for _ in range(DOWN_FACING_NUM_GOAL_CANDIDATES):
             target = make_target(_down_facing_rotation(rng.uniform(-np.pi, np.pi)))
             seed = base | space.to_configuration(rng.uniform(lower, upper))
             joints = self._solve_down_facing_candidate(side, target, seed, accept)
-            if joints is not None:
+            if joints is None:
+                continue
+            delta = float(np.max(np.abs(joints - arm_joints_now)))
+            pinned = int(np.count_nonzero((joints < pin_lower) | (joints > pin_upper)))
+            if pinned == 0 and delta < DOWN_FACING_ACCEPT_DELTA:
                 return joints
-        return None
+            score = delta + DOWN_FACING_PINNED_PENALTY * pinned
+            if score < best_score:
+                best, best_score = joints, score
+            num_valid += 1
+            if num_valid >= DOWN_FACING_SELECT_CANDIDATES:
+                break
+        return best
 
     def reset(self, x: ObjectCentricState, params: np.ndarray) -> None:
         self._current_state = x

--- a/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
@@ -174,10 +174,15 @@ def test_top_down_pick_and_place_controllers():
     )
     rng = np.random.default_rng(123)
 
+    space = sim.robot.groups[sim.robot.manipulators["right"].group]
+    lower, upper = space.bounds()
+    margin = skills.DOWN_FACING_JOINT_LIMIT_MARGIN - 1e-9
+
     pick = controllers["pick"].ground((arms["right"], cube))
     params = pick.sample_parameters(state, rng)
     sim.set_state(state)
     assert _ee_tilt(sim, "right", params) <= GRASP_APPROACH_MAX_TILT
+    assert np.all(params >= lower + margin) and np.all(params <= upper - margin)
     distance = np.linalg.norm(
         sim.end_effector_pose("right").t - np.array(state.cube_position)
     )
@@ -190,6 +195,13 @@ def test_top_down_pick_and_place_controllers():
     params = place.sample_parameters(state, rng)
     sim.set_state(state)
     assert _ee_tilt(sim, "right", params) <= GRASP_APPROACH_MAX_TILT
+    assert np.all(params >= lower + margin) and np.all(params <= upper - margin)
+    # The place sampler prefers the posture the arm is already in, so the goal
+    # stays near the pick posture instead of flipping to an independently sampled
+    # one (posture-preserved transfers measure under 1 rad of max joint change;
+    # flips measure around 5 rad).
+    pick_posture = np.asarray(state.arm_joint_positions("right"))
+    assert np.max(np.abs(params - pick_posture)) < 1.5
     place.reset(state, params)
     state = _run_controller(env, place, state)
     assert state.holder is None

--- a/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
@@ -151,6 +151,82 @@ def test_sampled_pick_parameters_reach_the_cube():
     env.close()
 
 
+GRASP_APPROACH_MAX_TILT = 0.1
+
+
+def _ee_tilt(sim, side, joints):
+    """The angle (radians) between the arm's approach axis and straight down."""
+    sim.set_arm_joint_positions(side, joints)
+    rotation = sim.end_effector_pose(side).R
+    return float(np.arccos(np.clip(-rotation[2, 2], -1.0, 1.0)))
+
+
+def test_top_down_pick_and_place_controllers():
+    """Constrained pick and place sample near-vertical grasps and reach the goal."""
+    env, state = _make_env_and_state(0, name_prefix="VegaPickPlace3D-topdown")
+    arms, cube, target = _scene_objects(state)
+    sim = ObjectCentricVegaPickPlace3DEnv(allow_state_access=True)
+    controllers = create_lifted_controllers(
+        env.action_space,
+        sim,
+        prefer_ompl=False,
+        grasp_approach_max_tilt=GRASP_APPROACH_MAX_TILT,
+    )
+    rng = np.random.default_rng(123)
+
+    pick = controllers["pick"].ground((arms["right"], cube))
+    params = pick.sample_parameters(state, rng)
+    sim.set_state(state)
+    assert _ee_tilt(sim, "right", params) <= GRASP_APPROACH_MAX_TILT
+    distance = np.linalg.norm(
+        sim.end_effector_pose("right").t - np.array(state.cube_position)
+    )
+    assert distance < sim.config.grasp_radius
+    pick.reset(state, params)
+    state = _run_controller(env, pick, state)
+    assert state.holder == "right"
+
+    place = controllers["place"].ground((arms["right"], cube, target))
+    params = place.sample_parameters(state, rng)
+    sim.set_state(state)
+    assert _ee_tilt(sim, "right", params) <= GRASP_APPROACH_MAX_TILT
+    place.reset(state, params)
+    state = _run_controller(env, place, state)
+    assert state.holder is None
+
+    sim.set_state(state)
+    assert sim.goal_reached()
+
+    sim.close()
+    env.close()
+
+
+def test_top_down_pick_sampling_fails_for_out_of_reach_arm():
+    """Constrained sampling with an arm that cannot reach the cube should fail.
+
+    The constrained sampler has its own (much smaller) candidate budget, so the
+    exhaustion path is separate from the unconstrained sampler's.
+    """
+    # For seed 19 the cube is far on the left side, out of the right arm's reach.
+    env, state = _make_env_and_state(19)
+    arms, cube, _ = _scene_objects(state)
+    sim = ObjectCentricVegaPickPlace3DEnv(allow_state_access=True)
+    controllers = create_lifted_controllers(
+        env.action_space,
+        sim,
+        prefer_ompl=False,
+        grasp_approach_max_tilt=GRASP_APPROACH_MAX_TILT,
+    )
+    rng = np.random.default_rng(0)
+
+    pick = controllers["pick"].ground((arms["right"], cube))
+    with pytest.raises(TrajectorySamplingFailure):
+        pick.sample_parameters(state, rng)
+
+    sim.close()
+    env.close()
+
+
 def test_pick_sampling_fails_for_out_of_reach_arm():
     """Sampling a grasp with an arm that cannot reach the cube should fail.
 

--- a/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d_v2/vega_pickplace3d/test_vega_pickplace3d_parameterized_skills.py
@@ -183,6 +183,10 @@ def test_top_down_pick_and_place_controllers():
     sim.set_state(state)
     assert _ee_tilt(sim, "right", params) <= GRASP_APPROACH_MAX_TILT
     assert np.all(params >= lower + margin) and np.all(params <= upper - margin)
+    # Candidate selection prefers postures strictly inside the margin boundary; a
+    # joint resting exactly on it stalls the posture-preserving place solve.
+    assert np.all(params > lower + margin + 1e-6)
+    assert np.all(params < upper - margin - 1e-6)
     distance = np.linalg.norm(
         sim.end_effector_pose("right").t - np.array(state.cube_position)
     )


### PR DESCRIPTION
Closes #134.

## What this does

Adds an optional `grasp_approach_max_tilt` constraint (radians off vertical; `None` = current behavior) to the VegaPickPlace3D skills. When set, `GroundPickController` and `GroundPlaceController` sample goal configurations constraint-aware instead of by rejection:

1. Draw a yaw uniformly and build the down-facing end-effector target rotation (the Vega tool frames carry the fingertip offset along their z axis, so "fingers down" is frame z along world -z).
2. Solve full-pose IK for that target with `NumericalIK`, seeded from a uniform joint draw. The solver's orientation tolerance is the tilt bound itself, so a converged solve satisfies the constraint by construction.
3. Apply the existing acceptance checks: strict grasp-range reach for pick, the release slab over the target patch for place, and the collision check.

For place, the end-effector target position accounts for the held cube's fixed offset in the end-effector frame, rotated by the candidate target rotation, so the cube (not the gripper) lands over the patch.

The parameter is plumbed through `create_lifted_controllers` and `create_bilevel_planning_models` (the `env_models` dispatcher already forwards kwargs, so top-level callers can pass it directly). Handover sampling is unconstrained: the take-over happens in mid-air, where approach direction does not matter.

## Why constraint-aware instead of rejection

As measured in #134, a uniform draw is within 15 deg of vertical about 2% of the time before the reach condition, and zero of 250k draws satisfied tilt <= 12 deg plus reach at the real-table grasp pose. Rejection cannot be salvaged by budget.

## Budget and iteration choices (measured on this sampler)

Each constrained candidate is a full IK solve (~0.2 s) rather than an FK call (~0.3 ms), so the constrained budget is separate: `DOWN_FACING_NUM_GOAL_CANDIDATES = 100`.

- Per-candidate acceptance for reachable cubes (tilt bound 0.1 rad, `max_iters=100`, soft-limit margin applied): 46% for seed 0 / right arm, 10% for the harder seed 19 / left arm. At 10%, 100 candidates leave a spurious-exhaustion probability under 3e-5.
- A genuine exhaustion (cube out of the arm's reach) resolves in ~25 s at `max_iters=100`. Bilevel planning relies on that failure to discard wrong-arm abstract plans; a spurious failure is the costlier mistake, so the budget favors reliability.
- `max_iters=50` would halve the failure-path cost but drops hard-case acceptance from 20% to 16%; `DOWN_FACING_IK_MAX_ITERS = 100` keeps the better acceptance.

## Tests

- `test_top_down_pick_and_place_controllers`: constrained pick and place reach the environment goal, with both sampled configurations verified within the tilt bound and the grasp within grasp radius.
- `test_top_down_pick_sampling_fails_for_out_of_reach_arm`: the constrained sampler's (separate) exhaustion path still raises `TrajectorySamplingFailure`.
- `test_vega_pickplace3d_grasp_approach_max_tilt_plumbing` (kinder-bilevel-planning): the kwarg threads through model creation to the pick sampler, verified by tilt of the sampled configuration.

CI: mypy, pylint, and black are clean in both packages. Full kinder-bilevel-planning suite passes (80 tests + notebook). Full kinder-models suite: all vega_pickplace3d tests pass; 22 failures in unrelated environments (tossing, obstruction3d, shelf3d, transport3d, test_utils) reproduce identically on a clean checkout of main in my environment (e.g. TidyBot task-config paths resolving into site-packages), so they are pre-existing and not caused by this change.

## Not addressed

- The constrained sampler keeps `NumericalIK` with random restarts, as proposed in the issue. I benchmarked Vega's attached analytic solver (`VegaArmIK`, via `sim.robot.manipulators[side].ik`) as an alternative: it solves exactly-reachable poses reliably (5/5 on FK-derived controls, ~40 ms per query) but returned 0 solutions in 150 attempts on the sampler's actual targets, because it is an exact solver and the down-facing targets are only reachable within the sampler's tolerances (4 cm position, the tilt bound). The tolerance slack is what makes top-down grasps feasible across the table, and the numerical solver exploits it natively; using the analytic solver would require discretizing that slack into many exact queries, a different design with no demonstrated win.
- Handover take-over orientation is left unconstrained (see above).
- `grasp_approach_max_tilt` must be positive when set: it doubles as the IK orientation tolerance, so exactly zero is unsatisfiable. An assert guards this.
- The repo's committed formatting disagrees with the current venv formatter versions (black 26.x / isort 8.x / docformatter 1.7.8) on ~14 files untouched here; I reverted that churn rather than folding it into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

