### PR TITLE
Raise max_skill_horizon for Shelf3D and PrplLab3D planning configs

### DIFF
--- a/kinder-bilevel-planning/experiments/conf/env/kinematic-shelf3d-o1.yaml
+++ b/kinder-bilevel-planning/experiments/conf/env/kinematic-shelf3d-o1.yaml
@@ -10,3 +10,6 @@ env_model_kwargs:
   num_objects: 1
 
 max_eval_steps: 500
+
+# Bounded base actions need more simulation steps per skill than the global default.
+max_skill_horizon: 1000

--- a/kinder-bilevel-planning/experiments/conf/env/kinematic-shelf3d-o2.yaml
+++ b/kinder-bilevel-planning/experiments/conf/env/kinematic-shelf3d-o2.yaml
@@ -8,3 +8,6 @@ make_kwargs:
 # Passed into create_bilevel_planning_models() to create the env models.
 env_model_kwargs:
   num_objects: 2
+
+# Bounded base actions need more simulation steps per skill than the global default.
+max_skill_horizon: 1000

--- a/kinder-bilevel-planning/experiments/conf/env/kinematic-shelf3d-o3.yaml
+++ b/kinder-bilevel-planning/experiments/conf/env/kinematic-shelf3d-o3.yaml
@@ -8,3 +8,6 @@ make_kwargs:
 # Passed into create_bilevel_planning_models() to create the env models.
 env_model_kwargs:
   num_objects: 3
+
+# Bounded base actions need more simulation steps per skill than the global default.
+max_skill_horizon: 1000

--- a/kinder-bilevel-planning/experiments/conf/env/prpl3d-o1.yaml
+++ b/kinder-bilevel-planning/experiments/conf/env/prpl3d-o1.yaml
@@ -7,3 +7,6 @@ env_model_kwargs:
   num_objects: 1
 
 max_eval_steps: 500
+
+# Bounded base actions need more simulation steps per skill than the global default.
+max_skill_horizon: 1000

--- a/kinder-bilevel-planning/experiments/conf/env/prpl3d-o2.yaml
+++ b/kinder-bilevel-planning/experiments/conf/env/prpl3d-o2.yaml
@@ -7,3 +7,6 @@ env_model_kwargs:
   num_objects: 2
 
 max_eval_steps: 700
+
+# Bounded base actions need more simulation steps per skill than the global default.
+max_skill_horizon: 1000


### PR DESCRIPTION
## Summary

Add `max_skill_horizon: 1000` to the KinematicShelf3D and PrplLab3D bilevel-planning experiment configs, matching the override the Transport3D configs already carry.

## Motivation

`max_skill_horizon` caps how many simulation steps a single skill gets during the planner's internal rollouts; a rollout truncated mid-skill fails its postcondition check and the sample is rejected even when the skill is feasible. With bound-compliant base navigation (companion skills PR), skills take more, smaller steps — a long approach that used to fit in a handful of oversized steps now needs 100+ compliant ones — so the global default of 100 truncates planning rollouts on these environments. Transport3D's configs already set 1000 for this exact reason; Shelf3D and PrplLab3D never received the override because their old skills' oversized steps kept rollouts short.

## Results

On Shelf3D-o2 with compliant skills, the default horizon of 100 fails 22/250 episodes outright at the abstract-planning level and inflates planning times ~8× on the rest (34–49 s vs ~5 s); at horizon ≥200 every previously failing episode plans in ~5 s, and 200 vs 1000 are identical (the cap merely needs to exceed the true skill length). With this override plus the skills fix, Shelf3D reaches 250/250 at the standard 60 s planning budget. Execution behavior is unaffected — the horizon only bounds planning-time rollouts, not episodes.

Full evidence in the kindergarden validation thread (Princeton-Robot-Planning-and-Learning/kindergarden#135).
