### PR TITLE
Align RL agent configs with the released training runs

### DIFF
--- a/kinder-rl/experiments/conf/agent/ppo_basemotion3d.yaml
+++ b/kinder-rl/experiments/conf/agent/ppo_basemotion3d.yaml
@@ -4,7 +4,7 @@ name: ppo
 # Core training parameters
 args:
   total_timesteps: 1000000
-  num_envs: 8
+  num_envs: 16
   num_steps: 256
   num_eval_envs: 1
   # Network architecture
@@ -20,3 +20,6 @@ cuda: false
 # Logging settings
 exp_name: "ppo_basemotion3d_train"
 tb_log_dir: "runs"
+
+# Episode cap used by the released training runs (overrides the global default).
+max_episode_steps: 100

--- a/kinder-rl/experiments/conf/agent/ppo_transport3d.yaml
+++ b/kinder-rl/experiments/conf/agent/ppo_transport3d.yaml
@@ -4,7 +4,7 @@ name: ppo
 # Core training parameters
 args:
   total_timesteps: 1000000
-  num_envs: 8
+  num_envs: 16
   num_steps: 256
   num_eval_envs: 1
   hidden_size: 128
@@ -16,3 +16,6 @@ cuda: false
 # Logging settings
 exp_name: "ppo_transport3d_train"
 tb_log_dir: "runs"
+
+# Episode cap used by the released training runs (overrides the global default).
+max_episode_steps: 1200

--- a/kinder-rl/experiments/conf/agent/sac_basemotion3d.yaml
+++ b/kinder-rl/experiments/conf/agent/sac_basemotion3d.yaml
@@ -5,7 +5,7 @@ name: sac
 args:
   total_timesteps: 1000000
   num_eval_envs: 1
-  num_envs: 8
+  num_envs: 16
   hidden_size: 128
   buffer_size: 100000
   learning_starts: 5000
@@ -20,3 +20,6 @@ cuda: false
 # Logging settings
 exp_name: "sac_basemotion3d_train"
 tb_log_dir: "runs"
+
+# Episode cap used by the released training runs (overrides the global default).
+max_episode_steps: 100

--- a/kinder-rl/experiments/conf/agent/sac_transport3d.yaml
+++ b/kinder-rl/experiments/conf/agent/sac_transport3d.yaml
@@ -6,7 +6,7 @@ args:
   total_timesteps: 1000000
   num_eval_envs: 1
   hidden_size: 128
-  num_envs: 8
+  num_envs: 16
   buffer_size: 100000
   learning_starts: 5000
   async_envs: true  # Use AsyncVectorEnv for faster parallel stepping
@@ -20,3 +20,6 @@ cuda: false
 # Logging settings
 exp_name: "sac_transport3d_train"
 tb_log_dir: "runs"
+
+# Episode cap used by the released training runs (overrides the global default).
+max_episode_steps: 1200

--- a/kinder-rl/experiments/run_experiment.py
+++ b/kinder-rl/experiments/run_experiment.py
@@ -107,6 +107,11 @@ def _main(cfg: DictConfig) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     runs_dir.mkdir(parents=True, exist_ok=True)
 
+    # Per-agent-config episode caps (as used by the released training runs)
+    # take priority over the global default.
+    with read_write(cfg):
+        cfg.max_episode_steps = cfg.agent.get("max_episode_steps", cfg.max_episode_steps)
+
     logging.info(
         f"Running agent={cfg.agent.name}, env={cfg.env_id},"
         f" max_episode_steps={cfg.max_episode_steps},"


### PR DESCRIPTION
## Summary

Align the PPO/SAC agent configs for BaseMotion3D and Transport3D with the configuration the released training runs actually used:

- `num_envs: 8 → 16` in the four agent configs;
- add per-agent `max_episode_steps` (100 for BaseMotion3D, 1200 for Transport3D-o2), which `run_experiment.py` now prefers over the global default of 300.

## Motivation

The released result archives (PPO/SAC Google Drive links in the README) include each run's resolved `config.yaml`, and those show `num_envs: 16` with per-environment episode caps — but the checked-in configs say `num_envs: 8` and nothing overrides the global `max_episode_steps: 300`. The difference is not cosmetic:

- **Training from the repo as-is fails to reproduce the release.** PPO BaseMotion3D trained with the checked-in configs never learns (mean eval return −300, the failure floor for a 300-step cap); with the archived settings applied as overrides, the released result reproduces almost exactly (−98.9 vs the released −98.5).
- The episode cap changes the task itself (BaseMotion's released cap is 100 steps, not 300; Transport's is 1200), and `num_envs` changes PPO's batch structure.

Found while running before/after regression baselines for kindergarden#135 — the first retraining fleet silently produced failure-floor results until the archives' configs were diffed against the repo's.

## Test plan

- Smoke runs confirm the resolved values: `max_episode_steps=100` (BaseMotion3D) and `1200` (Transport3D-o2), `num_envs=16`.
- Full-scale confirmation from the kindergarden#135 validation study: PPO BaseMotion3D retrained with these settings reaches −98.9 (released anchor −98.5); with the previous checked-in settings, −300.
- Configs not covered by released archives are left untouched; the per-agent `max_episode_steps` key is optional and defaults to the existing global behavior.
