### PR TITLE
Persist environment normalization statistics in RL checkpoints

### DIFF
--- a/kinder-rl/src/kinder_rl/gym_utils.py
+++ b/kinder-rl/src/kinder_rl/gym_utils.py
@@ -425,3 +425,52 @@ class ReplayBuffer(BaseBuffer):
         if dtype == np.float64:
             return np.float32
         return dtype
+
+
+def get_env_normalization_stats(envs: gym.vector.VectorEnv) -> list[dict]:
+    """Collect the NormalizeObservation/NormalizeReward running statistics.
+
+    Returns one entry per sub-environment. Works for both Sync and Async vector
+    envs (Async returns copies, which is sufficient for checkpointing).
+    """
+    obs_rms = envs.get_attr("obs_rms")
+    return_rms = envs.get_attr("return_rms")
+    # Plain lists/floats keep checkpoints loadable under torch.load's
+    # weights_only=True default (torch >= 2.6 rejects pickled numpy arrays).
+    return [
+        {
+            "obs_mean": np.asarray(o.mean).tolist(),
+            "obs_var": np.asarray(o.var).tolist(),
+            "obs_count": float(o.count),
+            "return_mean": np.asarray(r.mean).tolist(),
+            "return_var": np.asarray(r.var).tolist(),
+            "return_count": float(r.count),
+        }
+        for o, r in zip(obs_rms, return_rms)
+    ]
+
+
+def set_env_normalization_stats(
+    envs: gym.vector.VectorEnv, stats: list[dict]
+) -> None:
+    """Restore statistics collected by get_env_normalization_stats.
+
+    Only synchronous vector envs are supported (Async get_attr returns copies,
+    so mutation would be silently lost). If fewer stat entries than
+    sub-environments are provided, the first entry is broadcast.
+    """
+    if isinstance(envs, gym.vector.AsyncVectorEnv):
+        raise NotImplementedError(
+            "Restoring normalization statistics into AsyncVectorEnv is not "
+            "supported; build a SyncVectorEnv for evaluation."
+        )
+    obs_rms = envs.get_attr("obs_rms")
+    return_rms = envs.get_attr("return_rms")
+    for i, (o, r) in enumerate(zip(obs_rms, return_rms)):
+        s = stats[i] if i < len(stats) else stats[0]
+        o.mean = np.asarray(s["obs_mean"]).copy()
+        o.var = np.asarray(s["obs_var"]).copy()
+        o.count = s["obs_count"]
+        r.mean = np.asarray(s["return_mean"]).copy()
+        r.var = np.asarray(s["return_var"]).copy()
+        r.count = s["return_count"]

--- a/kinder-rl/src/kinder_rl/ppo_agent.py
+++ b/kinder-rl/src/kinder_rl/ppo_agent.py
@@ -29,7 +29,7 @@ except ImportError:
     TENSORBOARD_AVAILABLE = False
 
 from kinder_rl.agent import BaseRLAgent
-from kinder_rl.gym_utils import make_env_ppo
+from kinder_rl.gym_utils import get_env_normalization_stats, make_env_ppo
 
 _O = TypeVar("_O")
 _U = TypeVar("_U")
@@ -227,6 +227,9 @@ class PPOAgent(BaseRLAgent[_O, _U]):
 
         # Device setup
         cuda_enabled = cfg.get("cuda", False)
+        # Env-side normalization statistics captured at the end of train()
+        # and persisted in checkpoints.
+        self.env_normalization_stats: list[dict] | None = None
         self.device = torch.device(
             "cuda" if torch.cuda.is_available() and cuda_enabled else "cpu"
         )
@@ -681,6 +684,15 @@ class PPOAgent(BaseRLAgent[_O, _U]):
                 )
 
         # Close environments and writer
+        # Preserve the env-side normalization statistics the policy depends on.
+        self.env_normalization_stats = get_env_normalization_stats(envs)
+        _s0 = self.env_normalization_stats[0]
+        logging.info(
+            f"Captured normalization statistics for "
+            f"{len(self.env_normalization_stats)} envs "
+            f"(obs_count={_s0['obs_count']:.0f}); they will be included in "
+            f"saved checkpoints."
+        )
         envs.close()  # type: ignore[no-untyped-call]
         if self.writer is not None:
             self.writer.close()  # type: ignore[no-untyped-call]
@@ -696,6 +708,7 @@ class PPOAgent(BaseRLAgent[_O, _U]):
             {
                 "network_state_dict": self.agent.state_dict(),
                 "optimizer_state_dict": self.optimizer.state_dict(),
+                "env_normalization_stats": self.env_normalization_stats,
             },
             filepath,
         )
@@ -705,3 +718,4 @@ class PPOAgent(BaseRLAgent[_O, _U]):
         checkpoint = torch.load(filepath, map_location=self.device)
         self.agent.load_state_dict(checkpoint["network_state_dict"])
         self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.env_normalization_stats = checkpoint.get("env_normalization_stats")

--- a/kinder-rl/src/kinder_rl/sac_agent.py
+++ b/kinder-rl/src/kinder_rl/sac_agent.py
@@ -30,7 +30,11 @@ except ImportError:
     TENSORBOARD_AVAILABLE = False
 
 from kinder_rl.agent import BaseRLAgent
-from kinder_rl.gym_utils import ReplayBuffer, make_env_sac
+from kinder_rl.gym_utils import (
+    ReplayBuffer,
+    get_env_normalization_stats,
+    make_env_sac,
+)
 
 _O = TypeVar("_O")
 _U = TypeVar("_U")
@@ -227,6 +231,9 @@ class SACAgent(BaseRLAgent[_O, _U]):
 
         # Device setup
         cuda_enabled = cfg.get("cuda", False)
+        # Env-side normalization statistics captured at the end of train()
+        # and persisted in checkpoints.
+        self.env_normalization_stats: list[dict] | None = None
         self.device = torch.device(
             "cuda" if torch.cuda.is_available() and cuda_enabled else "cpu"
         )
@@ -656,6 +663,15 @@ class SACAgent(BaseRLAgent[_O, _U]):
                 )
 
         # Close environments and writer
+        # Preserve the env-side normalization statistics the policy depends on.
+        self.env_normalization_stats = get_env_normalization_stats(envs)
+        _s0 = self.env_normalization_stats[0]
+        logging.info(
+            f"Captured normalization statistics for "
+            f"{len(self.env_normalization_stats)} envs "
+            f"(obs_count={_s0['obs_count']:.0f}); they will be included in "
+            f"saved checkpoints."
+        )
         envs.close()  # type: ignore
         if self.writer is not None:
             self.writer.close()  # type: ignore
@@ -668,6 +684,7 @@ class SACAgent(BaseRLAgent[_O, _U]):
     def save(self, filepath: str) -> None:
         """Save agent parameters."""
         save_dict: dict[str, Any] = {
+            "env_normalization_stats": self.env_normalization_stats,
             "actor_state_dict": self.actor.state_dict(),
             "qf1_state_dict": self.qf1.state_dict(),
             "qf2_state_dict": self.qf2.state_dict(),
@@ -684,6 +701,7 @@ class SACAgent(BaseRLAgent[_O, _U]):
     def load(self, filepath: str) -> None:
         """Load agent parameters."""
         checkpoint = torch.load(filepath, map_location=self.device)
+        self.env_normalization_stats = checkpoint.get("env_normalization_stats")
         self.actor.load_state_dict(checkpoint["actor_state_dict"])
         self.qf1.load_state_dict(checkpoint["qf1_state_dict"])
         self.qf2.load_state_dict(checkpoint["qf2_state_dict"])


### PR DESCRIPTION
## Summary

Make RL checkpoints self-contained: PPO/SAC train inside `NormalizeObservation`/`NormalizeReward`, whose running statistics live in the env wrappers — but `agent.save()` persisted only network and optimizer state, so a loaded checkpoint fed the policy observations on the wrong scale and could not reproduce the trained agent. This PR:

- captures the per-env `obs_rms`/`return_rms` statistics at the end of `train()` (before the envs close), for both PPO and SAC, with a log line stating what was captured;
- includes them in the checkpoint as plain lists/floats, keeping `torch.load(weights_only=True)` compatibility (torch ≥2.6 default rejects pickled numpy arrays);
- restores the field on `load()`; and
- adds `set_env_normalization_stats` to apply them to synchronous evaluation envs (explicit `NotImplementedError` for async, where `get_attr` returns copies and mutation would be silently lost).

Legacy checkpoints load unchanged (`env_normalization_stats=None`).

## Motivation

Found while validating kindergarden#135: we intended to evaluate the released frozen checkpoints before/after the environment change, but the released `agent.pkl` archives cannot reproduce the trained policies — the normalization statistics they depend on were never saved — forcing full retraining instead. Any future frozen-checkpoint evaluation, checkpoint release, or resume-from-checkpoint workflow hits the same wall.

## Test plan

- Train → save → `torch.load(weights_only=True)` succeeds and contains per-env stats with the expected counts.
- Fresh-process `load()` → `set_env_normalization_stats` into a new `SyncVectorEnv` → statistics round-trip exactly (means/vars/counts bit-equal).
- SAC path verified through `AsyncVectorEnv` capture.
- Backward compatibility: a checkpoint without the new key loads with `stats=None`.
- A behavioral A/B (frozen eval with vs without restored statistics on a fully trained BaseMotion3D PPO agent) is running; results to follow as a comment.
