### PR TITLE
kinder_models: exclude the target cube from PickCube's BASE_MOTION collision

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -856,9 +856,10 @@ class PickCubeController(GroundParameterizedController[ObjectCentricState, Array
             seed=0,  # To make this effectively deterministic
             extend_xy_magnitude=extend_xy_magnitude,
             extend_rot_magnitude=extend_rot_magnitude,
-            # The 0.55m standoff is within the robot's own 0.5x0.5m footprint of
-            # the cube, so a robot already parked nearby would otherwise start in
-            # collision. Mirrors MoveToTossLocationAndTossController's own
+            # During random resets, the cube can spawn directly under or right
+            # next to the robot, which would otherwise put the standoff in
+            # collision before planning even starts. Mirrors
+            # MoveToTossLocationAndTossController's own
             # disable_collision_objects=[target] for the same reason.
             disable_collision_objects=[cube_to_pick_up.name],
         )

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -856,6 +856,11 @@ class PickCubeController(GroundParameterizedController[ObjectCentricState, Array
             seed=0,  # To make this effectively deterministic
             extend_xy_magnitude=extend_xy_magnitude,
             extend_rot_magnitude=extend_rot_magnitude,
+            # The 0.55m standoff is within the robot's own 0.5x0.5m footprint of
+            # the cube, so a robot already parked nearby would otherwise start in
+            # collision. Mirrors MoveToTossLocationAndTossController's own
+            # disable_collision_objects=[target] for the same reason.
+            disable_collision_objects=[cube_to_pick_up.name],
         )
         assert self.plans[self.PickCubeControllerPhase.BASE_MOTION] is not None
 


### PR DESCRIPTION
## TL;DR
`PickCubeController.reset()`'s `BASE_MOTION` planning call didn't exclude the target cube from collision, so a robot parked within ~0.3m of the cube had a start pose already in collision and failed deterministically. Adds `disable_collision_objects=[cube_to_pick_up.name]`, mirroring `MoveToTossLocationAndTossController`'s own identical fix.

## Question / goal
Why does `PickCube`'s `BASE_MOTION` planning sometimes fail deterministically -- same start, same target -- rather than occasionally?

## Background
`PickCube`'s standoff is only `TARGET_DISTANCE=0.55m` from the cube, and the robot's own 0.5x0.5m footprint means any start pose within ~0.25-0.35m of the cube already overlaps it. `MoveToTossLocationAndTossController`'s own base-motion call already excludes its target from collision for the identical reason ("the robot's own cargo would otherwise reject every base plan"), but `PickCubeController`'s own base-motion call never did. This is the root cause of an intermittent "controller does nothing" symptom late in a practice run: once a robot lands close to a cube (e.g. from an earlier dispatch), no path can escape a starting collision.

## Hypothesis
Excluding the target cube from collision, matching the toss controller's own pattern, removes this failure mode.

## Guidance given
None beyond the original investigation that traced the intermittent-failure symptom to this exact call.

## Methods
Added `disable_collision_objects=[cube_to_pick_up.name]` to the `BASE_MOTION` `run_base_motion_planning` call.

## Results
Verified as part of the larger branch this was originally developed on (now split into this stack): `pytest tests/environments/tossing3d` (hitl-pmp, consuming project) 202 passed, 1 xfailed; kinder-baselines' own `tests/dynamic3d/{shelf,tossing}` 54 passed. black/isort; pylint 10.00/10.

## Recommendation
Land as a straightforward, well-understood collision-planning bug fix.
