### PR TITLE
kinder_models: add a RETURN_HOME phase to MoveToTossLocationAndToss

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -1307,6 +1307,10 @@ class MoveToTossLocationAndTossController(
         BASE_MOTION = enum.auto()
         WINDUP = enum.auto()
         SWING = enum.auto()
+        # Returns the arm to a fixed retract configuration after the swing, so
+        # the NEXT PickCube dispatch's MOVE_ARM_TO_HOVER_OVER_CUBE plans from a
+        # known-good starting pose instead of wherever the release left the arm.
+        RETURN_HOME = enum.auto()
 
     # Where a throw is possible; the upper part does not score.
     TARGET_DISTANCE_BOUNDS = (1.25, 1.45)
@@ -1354,6 +1358,13 @@ class MoveToTossLocationAndTossController(
         self._swing: TossSwing | None = None
         self._swing_step_idx: int = 0
         self._has_released: bool = False
+
+        # RETURN_HOME's target: the same retract configuration
+        # PickCubeController.home_joints uses, so a post-toss arm and a
+        # post-lift arm land in the same known pose.
+        self._return_home_arm_config = np.deg2rad(
+            [0, -20, 180, -146, 0, -50, 90, 0, 0, 0, 0, 0, 0]
+        )
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
         del x  # not used
@@ -1480,9 +1491,14 @@ class MoveToTossLocationAndTossController(
         )
 
     def terminated(self) -> bool:
-        return self._swing is not None and self._swing_step_idx >= len(
-            self._swing.trajectory
+        if self._phase is not self.MoveToTossLocationAndTossControllerPhase.RETURN_HOME:
+            return False
+        assert self._pybullet_sim is not None
+        curr = self._get_current_robot_arm_conf()
+        dist = self._pybullet_sim.get_joint_distance(
+            curr, list(self._return_home_arm_config)
         )
+        return bool(dist < WAYPOINT_TOLERANCE)
 
     def step(self) -> Array:
         assert self._current_base_motion_plan is not None
@@ -1490,7 +1506,9 @@ class MoveToTossLocationAndTossController(
             return self._action_base_motion()
         if self._phase is self.MoveToTossLocationAndTossControllerPhase.WINDUP:
             return self._action_windup()
-        return self._action_swing()
+        if self._phase is self.MoveToTossLocationAndTossControllerPhase.SWING:
+            return self._action_swing()
+        return self._action_return_home()
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -1547,6 +1565,22 @@ class MoveToTossLocationAndTossController(
         if self._swing_step_idx == self._swing.release_step:
             self._has_released = True
         self._swing_step_idx += 1
+        if self._swing_step_idx >= len(self._swing.trajectory):
+            self._phase = self.MoveToTossLocationAndTossControllerPhase.RETURN_HOME
+        return action
+
+    def _action_return_home(self) -> Array:
+        # wrap_arm_joint_difference, not a raw subtraction: the retract target holds
+        # joint index 2 at 180 degrees (as does TOSS_WINDUP/RELEASE_ARM_CONFIGURATION
+        # throughout windup/swing/release, so the arm is expected to be right at that
+        # wrap boundary when RETURN_HOME starts), and a raw target-curr can report
+        # ~2*pi of travel between two identical poses across it.
+        kp = 2.0
+        curr = np.array(self._get_current_robot_arm_conf()[:7])
+        target = self._return_home_arm_config[:7]
+        action = np.zeros(18, dtype=np.float32)
+        action[3:10] = kp * wrap_arm_joint_difference(target - curr)
+        action[10] = self._get_current_robot_gripper_pose()
         return action
 
     def _get_current_robot_pose(self) -> SE2:

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -1435,7 +1435,19 @@ class MoveToTossLocationAndTossController(
             disable_collision_objects=disable_collision_objects,
         )
         if base_motion_plan is None:
+            logger.debug(
+                "TOSS_BASE_PLAN result=FAIL target=(%.4f,%.4f,%.4f)",
+                target_base_pose.x,
+                target_base_pose.y,
+                target_base_pose.theta(),
+            )
             raise TrajectorySamplingFailure("Base motion planning failed")
+        logger.debug(
+            "TOSS_BASE_PLAN result=OK target=(%.4f,%.4f,%.4f)",
+            target_base_pose.x,
+            target_base_pose.y,
+            target_base_pose.theta(),
+        )
         return base_motion_plan
 
     def _plan_arm_toss(self, x: ObjectCentricState, final_base_pose: SE2) -> None:
@@ -1460,7 +1472,9 @@ class MoveToTossLocationAndTossController(
             physics_client_id=self._pybullet_sim.physics_client_id,
         )
         if windup_plan is None:
+            logger.debug("MoveToTossLocationAndToss: windup motion planning FAILED")
             raise TrajectorySamplingFailure("Motion planning failed")
+        logger.debug("MoveToTossLocationAndToss: windup motion planning ok")
         windup_start = np.array(self._get_current_robot_arm_conf()[:7])
         self._windup_trajectory, self._windup_dir = _compute_per_joint_profile(
             windup_start,
@@ -1482,7 +1496,9 @@ class MoveToTossLocationAndTossController(
             physics_client_id=self._pybullet_sim.physics_client_id,
         )
         if swing_plan is None:
+            logger.debug("MoveToTossLocationAndToss: swing motion planning FAILED")
             raise TrajectorySamplingFailure("Motion planning failed")
+        logger.debug("MoveToTossLocationAndToss: swing motion planning ok")
         self._swing = plan_toss_swing(
             swing_plan,
             windup_plan[-1],
@@ -1566,6 +1582,9 @@ class MoveToTossLocationAndTossController(
             self._has_released = True
         self._swing_step_idx += 1
         if self._swing_step_idx >= len(self._swing.trajectory):
+            logger.debug(
+                "MoveToTossLocationAndToss: swing done -- entering RETURN_HOME"
+            )
             self._phase = self.MoveToTossLocationAndTossControllerPhase.RETURN_HOME
         return action
 


### PR DESCRIPTION
## TL;DR
Adds a `RETURN_HOME` phase to `MoveToTossLocationAndToss`: after the swing releases, drives the arm back to a fixed retract configuration, so the next `PickCube` dispatch always plans from a known-good starting pose. Also adds permanent `logger.debug()` calls around the toss controller's base-motion/windup/swing planning.

## Question / goal
None -- implementation task, not an experiment.

## Background
Previously the arm stayed wherever the throw's release motion left it. This makes the NEXT `PickCube` dispatch's `MOVE_ARM_TO_HOVER_OVER_CUBE` plan from an arbitrary, unpredictable starting pose, and makes post-toss video hard to read.

## Hypothesis
None -- implementation task, not an experiment.

## Guidance given
Requested directly, for readable post-toss video and a consistent handoff pose between the two controllers.

## Methods
Added a `RETURN_HOME` phase targeting the same fixed retract configuration `PickCubeController.home_joints` already uses. The P-controller toward that fixed target uses `wrap_arm_joint_difference`, not a raw subtraction -- the retract target holds joint index 2 at 180 degrees, the wrap discontinuity itself, and `TOSS_WINDUP`/`RELEASE_ARM_CONFIGURATION` hold that same joint there throughout windup/swing/release, so the arm is expected to be sitting right at that boundary when `RETURN_HOME` starts. A raw subtraction there could report ~2*pi of travel between two identical poses and send the arm the long way around a joint. The second commit adds permanent `logger.debug()` calls around the toss controller's own base-motion/windup/swing planning, added while chasing this and the related fixes in this stack -- replaces ad hoc diagnostic monkeypatches.

## Results
Verified as part of the larger branch this was originally developed on (now split into this stack): `pytest tests/environments/tossing3d` (hitl-pmp, consuming project) 202 passed, 1 xfailed; kinder-baselines' own `tests/dynamic3d/{shelf,tossing}` 54 passed. black/isort; pylint 10.00/10.

## Recommendation
Land as a quality-of-life fix. Not a correctness bug on its own, but the P-controller wrap fix folded in here was flagged as a real latent bug by independent code review before this stack was split out (a raw subtraction could have sent the arm the long way around a joint).
