### PR TITLE
kinder_models: add a NoOpController tossing skill

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -759,6 +759,49 @@ class OpenGripperController(GroundParameterizedController[ObjectCentricState, Ar
         return current_gripper_pose < atol
 
 
+class NoOpController(GroundParameterizedController[ObjectCentricState, Array]):
+    """Controller that does nothing for a single control step.
+
+    The object parameters are:
+        robot: The robot itself.
+
+    Re-issues the robot's own current gripper command rather than zeroing it --
+    a bare all-zero action would command the gripper OPEN (see
+    OpenGripperController.step()), which is not a no-op if the robot is
+    currently holding something.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._last_state: ObjectCentricState | None = None
+
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        del x, rng
+        return np.zeros(0)
+
+    def reset(self, x: ObjectCentricState, params: Any | None = None) -> None:
+        del params
+        self._last_state = x
+
+    def terminated(self) -> bool:
+        return True
+
+    def step(self) -> Array:
+        action = np.zeros(11, dtype=np.float32)
+        action[-1] = self._get_current_gripper_pose()
+        return action
+
+    def observe(self, x: ObjectCentricState) -> None:
+        self._last_state = x
+
+    def _get_current_gripper_pose(self) -> float:
+        assert self._last_state is not None
+        robot = self.objects[0]
+        if self._last_state.get(robot, "pos_gripper") > 0.2:
+            return GRASP_CLOSE_THRESHOLD
+        return 0.0
+
+
 class PickCubeController(GroundParameterizedController[ObjectCentricState, Array]):
     """Pick a cube up off the ground.
 
@@ -1710,6 +1753,14 @@ def create_lifted_controllers(
         )
     )
 
+    # No-op controller.
+    robot = Variable("?robot", MujocoTidyBotRobotObjectType)
+
+    LiftedNoOpController: LiftedParameterizedController = LiftedParameterizedController(
+        [robot],
+        NoOpController,
+    )
+
     robot = Variable("?robot", MujocoTidyBotRobotObjectType)
     cube = Variable("?cube", MujocoMovableObjectType)
     # Unused by the controller; present so an operator can say the cube is still on
@@ -1748,6 +1799,7 @@ def create_lifted_controllers(
         "move_arm_to_end_effector": LiftedMoveArmToEndEffectorController,
         "close_gripper": LiftedCloseGripperController,
         "open_gripper": LiftedOpenGripperController,
+        "no_op": LiftedNoOpController,
         "pick_cube": LiftedPickCubeController,
         "move_to_toss_location_and_toss": LiftedMoveToTossLocationAndTossController,
     }

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -37,6 +37,7 @@ from kinder_models.dynamic3d.tossing.toss_swing import (
 )
 from kinder_models.dynamic3d.utils import (
     _CONTROL_TIMESTEP,
+    GRASP_CLOSE_THRESHOLD,
     MOVE_TO_TARGET_DISTANCE_BOUNDS,
     _trapezoidal_motion_profile,
 )
@@ -1698,6 +1699,40 @@ def test_open_gripper_commands_open_until_the_gripper_reads_open():
     opened.set(robot, "pos_gripper", 0.0)
     controller.observe(opened)
     assert controller.terminated()
+    env.close()
+
+
+def test_no_op_controller_terminates_immediately_and_holds_the_gripper_command():
+    """A no-op dispatches one all-zero-motion action and is already terminated --
+    except the gripper index, which must re-issue the robot's own current command
+    rather than zero, since zero means "open" (OpenGripperController.step()) and
+    would drop anything currently held."""
+    num_cubes = 1
+    env = kinder.make(
+        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
+    )
+    obs, _ = env.reset(seed=125)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    controllers = create_lifted_controllers(env.action_space)
+    robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
+    controller = controllers["no_op"].ground((robot,))
+
+    open_gripper = state.copy()
+    open_gripper.set(robot, "pos_gripper", 0.0)
+    controller.reset(open_gripper)
+    assert controller.terminated()
+    action = controller.step()
+    assert action.shape == (11,)
+    assert np.all(action == 0)
+
+    closed_gripper = state.copy()
+    closed_gripper.set(robot, "pos_gripper", 1.0)
+    controller.reset(closed_gripper)
+    assert controller.terminated()
+    action = controller.step()
+    assert action[:-1].tolist() == [0.0] * (action.shape[0] - 1)
+    assert action[-1] == GRASP_CLOSE_THRESHOLD
     env.close()
 
 


### PR DESCRIPTION
## TL;DR
Adds a `NoOpController` tossing skill: a single-tick controller that does nothing, for use wherever the planner/practice loop needs a genuine no-op dispatch.

## Question / goal
None -- implementation task, not an experiment.

## Background
The tossing skill set (`PickCube`, `MoveToTossLocationAndToss`, `OpenGripper`, `CloseGripper`, `move_to_target`, ...) has no skill that dispatches and genuinely does nothing.

## Hypothesis
None -- implementation task, not an experiment.

## Guidance given
Requested directly, to have a genuine no-op skill available in the skill set.

## Methods
A single-tick controller: zero base/arm motion, and re-issues the robot's own current gripper command rather than zeroing it -- a bare all-zero action would command the gripper OPEN (see `OpenGripperController.step()`), which is not a no-op if the robot is currently holding something. Registered in `create_lifted_controllers` as `"no_op"`, alongside the other single-object skills.

## Results
New test: terminates immediately, all-zero action with the gripper index open (0.0), and with the gripper index preserving `GRASP_CLOSE_THRESHOLD` when the robot is holding. `pytest tests/environments/tossing3d` (hitl-pmp, consuming project) 202 passed, 1 xfailed; kinder-baselines' own `tests/dynamic3d/{shelf,tossing}` 54 passed. black/isort; pylint 10.00/10.

## Recommendation
Land as a straightforward new capability.
