### PR TITLE
Choose the placement board from the shelf openings; joint-limit-safe planar plans

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
@@ -126,7 +126,10 @@ def create_bilevel_planning_models(
                 if target.name == x.grasped_object:
                     atoms.add(GroundAtom(Holding, [robot, target]))
 
-        # OnFixture.
+        # OnFixture: within the shelf footprint and resting above floor
+        # level (a floor-standing cylinder has pose_z == half_extent_z; one
+        # standing on any shelf board sits at least a board thickness
+        # higher).
         for target in target_objects:
             for fixture in target_fixtures:
                 if (
@@ -140,7 +143,8 @@ def create_bilevel_planning_models(
                         0.0,
                         atol=0.25,
                     )
-                    and x.get(target, "pose_z") > 0.3
+                    and x.get(target, "pose_z")
+                    > x.get(target, "half_extent_z") + 0.015
                 ):
                     atoms.add(GroundAtom(OnFixture, [target, fixture]))
 

--- a/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
@@ -83,7 +83,15 @@ MOVE_TO_TARGET_DISTANCE_BOUNDS = (0.78, 0.88)
 MOVE_TO_TARGET_ROT_BOUNDS = (-np.pi, np.pi)
 PLACE_X_OFFSET_BOUNDS = (-0.15, 0.15)
 PLACE_Y_OFFSET_BOUNDS = (-0.05, 0.1)
-PLACE_BASE_DISTANCE = 0.75
+# The staging distance is a sampled parameter: low board targets need the
+# base farther back (a close base forces the folded arm into it), high
+# targets need it closer (reach). Infeasible draws fail the sample's
+# collision or reach checks and the planner resamples.
+PLACE_BASE_DISTANCE_BOUNDS = (0.65, 0.88)
+# Headroom (beyond the standing cylinder) an opening must have for the
+# place approach to slide the cylinder in: the pre-place waypoint enters
+# slightly lifted, so a bare height-sized opening is not placeable.
+PLACE_VERTICAL_CLEARANCE = 0.04
 
 # Side-grasp geometry. The approach axis is tilted down by
 # SIDE_GRASP_PITCH from horizontal (a purely horizontal approach is
@@ -603,7 +611,8 @@ class GroundPlaceController(
         assert isinstance(x, CylinderShelf3DObjectCentricState)
         place_x_offset = rng.uniform(*PLACE_X_OFFSET_BOUNDS)  # type: ignore
         place_y_offset = rng.uniform(*PLACE_Y_OFFSET_BOUNDS)  # type: ignore
-        return np.array([place_x_offset, place_y_offset])
+        base_distance = rng.uniform(*PLACE_BASE_DISTANCE_BOUNDS)
+        return np.array([place_x_offset, place_y_offset, base_distance])
 
     def reset(self, x: ObjectCentricState, params: Any) -> None:
         self._current_params = params
@@ -640,7 +649,7 @@ class GroundPlaceController(
                 target_pose_temp_se2.rot,
             )
             target_base_pose = get_target_robot_pose_from_parameters(
-                target_place_pose_se2, PLACE_BASE_DISTANCE, np.pi / 2
+                target_place_pose_se2, self._current_params[2], np.pi / 2
             )
             all_collision_ids = (
                 self._sim._get_collision_object_ids()  # pylint: disable=protected-access
@@ -700,26 +709,32 @@ class GroundPlaceController(
                 assert grasped_object_transform is not None
 
                 # Compute the desired object placement pose: standing
-                # upright on the shelf layer, at the sampled offset from
-                # the shelf center. The second shelf layer's top surface
-                # sits at shelf_z + 2 * (spacing + layer height) + layer
-                # height / 2; rest the cylinder just above it (within the
-                # env's placement distance threshold) so the release
-                # registers as a placement.
+                # upright on a shelf board, at the sampled offset from the
+                # shelf center, resting just above the board surface
+                # (within the env's placement distance threshold) so the
+                # release registers as a placement.
                 target_surface_pose = self._current_state.get_object_pose(
                     self.objects[2].name
                 )
                 half_height = self._current_state.get(self.objects[1], "half_extent_z")
-                layer_top_z = (
-                    target_surface_pose.position[2]
-                    + (self._sim.config.shelf_spacing + self._sim.config.shelf_height)
-                    * 2
-                    + self._sim.config.shelf_height / 2
-                )
+                # Choose the lowest present board whose opening fits the
+                # standing cylinder plus approach clearance. With the
+                # default full shelf that is a regular gap; with an inner
+                # board omitted (see shelf_omitted_layers) a tall cylinder
+                # lands on the board below the merged opening.
+                cylinder_height = 2 * half_height
+                for surface_z, opening in self._sim.config.get_layer_openings():
+                    if opening >= cylinder_height + PLACE_VERTICAL_CLEARANCE:
+                        target_surface_z = surface_z
+                        break
+                else:
+                    raise TrajectorySamplingFailure(
+                        "No shelf opening fits the cylinder"
+                    )
                 desired_object_position = (
                     target_surface_pose.position[0] + self._current_params[0],
                     target_surface_pose.position[1] - 0.05 + self._current_params[1],
-                    layer_top_z + half_height + 0.004,
+                    target_surface_z + half_height + 0.004,
                 )
 
                 # The cylinder was grasped from an arbitrary angle around
@@ -924,8 +939,20 @@ def create_lifted_controllers(
         [robot, target, target_shelf],
         PlaceController,
         Box(
-            low=np.array([PLACE_X_OFFSET_BOUNDS[0], PLACE_Y_OFFSET_BOUNDS[0]]),
-            high=np.array([PLACE_X_OFFSET_BOUNDS[1], PLACE_Y_OFFSET_BOUNDS[1]]),
+            low=np.array(
+                [
+                    PLACE_X_OFFSET_BOUNDS[0],
+                    PLACE_Y_OFFSET_BOUNDS[0],
+                    PLACE_BASE_DISTANCE_BOUNDS[0],
+                ]
+            ),
+            high=np.array(
+                [
+                    PLACE_X_OFFSET_BOUNDS[1],
+                    PLACE_Y_OFFSET_BOUNDS[1],
+                    PLACE_BASE_DISTANCE_BOUNDS[1],
+                ]
+            ),
         ),
     )
 

--- a/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
@@ -212,6 +212,16 @@ def _plan_planar_reach(
             raise TrajectorySamplingFailure(
                 f"Planar reach solve failed at {np.round(position, 3)}"
             )
+        lower = arm.joint_lower_limits[:7]
+        upper = arm.joint_upper_limits[:7]
+        limit_margin = 0.03
+        if any(
+            value < low + limit_margin or value > high - limit_margin
+            for value, low, high in zip(solution, lower, upper)
+        ):
+            raise TrajectorySamplingFailure(
+                "Planar reach solution exceeds a joint limit"
+            )
         full_joints = extend_joints_to_include_fingers(solution)
         arm.set_joints(full_joints)
         if held_object_id is not None:
@@ -286,7 +296,11 @@ def _interpolated_path_targets(
     for step in range(1, num_one + 1):
         t = step / num_one
         position = start_position + t * (mid_position - start_position)
-        pitch = start_pitch + t * (end_pitch - start_pitch)
+        # Quadratic pitch schedule: extend first, pitch late. Pitching
+        # down while the end effector is still close to the body folds
+        # the elbow (joint 4) past its hard limit; extending first
+        # straightens it before the wrist comes down.
+        pitch = start_pitch + t * t * (end_pitch - start_pitch)
         targets.append((position, pitch))
     leg_two = float(np.linalg.norm(end_position - mid_position))
     num_two = max(3, int(np.ceil(leg_two / PLANAR_PATH_STEP)))

--- a/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
@@ -2,6 +2,9 @@
 
 import kinder
 import numpy as np
+from bilevel_planning.trajectory_samplers.trajectory_sampler import (
+    TrajectorySamplingFailure,
+)
 from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
 from kinder.envs.kinematic3d.cylinder_shelf3d import ObjectCentricCylinderShelf3DEnv
@@ -64,26 +67,40 @@ def test_pick_and_place_controller():
     target = state.get_object_from_name("cylinder0")
     target_shelf = state.get_object_from_name("shelf")
     object_parameters = (robot, target, target_shelf)
-    controller = lifted_controller.ground(object_parameters)
 
+    # The place resamples on infeasible draws (e.g. a staging distance
+    # whose reach or collision checks fail), just as the planner does.
     rng = np.random.default_rng(123)
-    params = controller.sample_parameters(state, rng)
+    placed = False
+    for _ in range(8):
+        controller = lifted_controller.ground(object_parameters)
+        params = controller.sample_parameters(state, rng)
+        controller.reset(state, params)
+        try:
+            for _ in range(500):
+                action = controller.step()
+                obs, _, _, _, _ = env.step(action)
+                next_state = env.observation_space.devectorize(obs)
+                controller.observe(next_state)
+                state = next_state
+                if controller.terminated():
+                    placed = True
+                    break
+            if placed:
+                break
+        except TrajectorySamplingFailure:
+            continue
+    assert placed, "Place controller never terminated"
 
-    controller.reset(state, params)
-    for _ in range(500):
-        action = controller.step()
-        obs, _, _, _, _ = env.step(action)
-        next_state = env.observation_space.devectorize(obs)
-        controller.observe(next_state)
-        state = next_state
-        if controller.terminated():
-            break
-    else:
-        assert False, "Controller did not terminate"
-
-    # The cylinder should be standing on the shelf.
+    # The cylinder should be standing on a shelf board at resting height.
+    config = sim.config
     target = state.get_object_from_name("cylinder0")
-    assert state.get(target, "pose_z") > 0.5, "Cylinder is not on the shelf"
+    half_height = state.get(target, "half_extent_z")
+    resting_zs = [z + half_height for z in config.get_layer_surface_zs()]
+    cylinder_z = state.get(target, "pose_z")
+    assert any(
+        abs(cylinder_z - resting_z) < 0.05 for resting_z in resting_zs
+    ), f"Cylinder z {cylinder_z} is not resting on a shelf board"
 
     env.close()
 

--- a/scripts/install_all.py
+++ b/scripts/install_all.py
@@ -19,7 +19,7 @@ from generate_topological_order import get_topological_order
 # release.
 PREINSTALL_REQUIREMENTS = [
     "kindergarden @ git+https://github.com/Princeton-Robot-Planning-and-Learning/"
-    "kindergarden.git@bf420c4404168c13c3ac3270c19918810aa0d4c7",
+    "kindergarden.git@86c55a4e9a19f4f37cd7103d425ee88465042173",
 ]
 
 


### PR DESCRIPTION
## Summary

Companion to kindergarden #172 (shelves with omitted boards): the CylinderShelf3D place skill now chooses its placement board from the shelf's actual openings, plus two fixes surfaced by the first real-robot runs.

- **Opening-based placement**: the place targets the lowest present board whose opening fits the standing cylinder plus approach clearance, instead of hardcoding the second layer. With the physical shelf's bottom inner board removed, the Pringles can (233 mm, taller than a regular 241 mm board gap) lands on the bottom board inside the merged opening.
- **Sampled staging distance**: the place base distance becomes a third sampled parameter (0.65–0.88 m). Low board targets need the base farther back (a close base forces the folded arm into it), high targets need it closer for reach; infeasible draws fail the sample's collision/reach checks and the planner resamples.
- **Joint-limit safety (real-robot fix)**: the reach's linear pitch ramp drove joint 4 to −2.88 rad — past the Kinova's −2.66 hard limit — freezing the real arm, while the kinematic sim masked it by silently clipping. The pitch now ramps quadratically (extend first, pitch late; worst-case joint 4 is −2.58 across the staging range), and `_plan_planar_reach` rejects any solution within 0.03 rad of a limit so out-of-limit plans fail the sample instead of being generated.
- **OnFixture** moves from a fixed z > 0.3 threshold to "within the shelf footprint and resting above floor level", matching the env's new goal semantics.
- `install_all.py`'s kindergarden preinstall bumps to the #172 merge commit.

## Testing

- Cylinder skills tests updated (resampling place, board-resting assertion) and passing.
- Multi-seed Pringles pick+place on the omitted-board shelf: places at the expected bottom-board resting height every seed, with ≥5° margin from every joint limit throughout the rollout.
- Verified on the real robot: the joint-limit freeze is gone and the full dry-run sequence executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
