### PR TITLE
kinder_models: SkillCall, MagicController, and a pick outcome model

### DIFF
--- a/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
@@ -76,6 +76,7 @@ from kinder_models.kinematic3d.utils import (
     get_target_robot_pose_from_parameters,
     step_toward_se2_waypoint,
 )
+from kinder_models.magic import OutcomePredictor
 
 # constants
 MOVE_TO_TARGET_DISTANCE_BOUNDS = (0.78, 0.88)
@@ -313,9 +314,14 @@ def _interpolated_path_targets(
 
 # Controllers.
 class GroundPickController(
-    GroundParameterizedController[ObjectCentricState, np.ndarray]
+    GroundParameterizedController[ObjectCentricState, np.ndarray],
+    OutcomePredictor[ObjectCentricState],
 ):
-    """Controller for picking up a cylinder with a planar side grasp."""
+    """Controller for picking up a cylinder with a planar side grasp.
+
+    The controller also predicts its own outcome (:meth:`predict_outcome`),
+    so the pick can be planned as a magic skill.
+    """
 
     def __init__(
         self,
@@ -409,52 +415,11 @@ class GroundPickController(
         if self._navigated and not self._pre_grasp:
             # Generate the planar reach plan if it doesn't exist yet.
             if self._current_arm_joint_plan is None:
-                self._sim.set_state(self._current_state)
-
-                # Side grasp aligned with the achieved base heading, so the
-                # gripper reaches straight out from wherever the base ended
-                # up around the cylinder.
-                cylinder_pose = self._current_state.get_object_pose(
-                    self.objects[1].name
-                )
-                base_pose = self._current_state.base_pose
-                approach_yaw = np.arctan2(
-                    cylinder_pose.position[1] - base_pose.y,
-                    cylinder_pose.position[0] - base_pose.x,
-                )
-                half_height = self._current_state.get(self.objects[1], "half_extent_z")
-                approach = get_side_grasp_approach(approach_yaw)
-                grasp_point = np.array(
-                    [
-                        cylinder_pose.position[0],
-                        cylinder_pose.position[1],
-                        cylinder_pose.position[2] + half_height - GRASP_DEPTH_BELOW_TOP,
-                    ]
-                )
-                grasp_position = grasp_point - GRASP_AXIS_STANDOFF * approach
-                pre_grasp_position = grasp_position - PRE_GRASP_BACKOFF * approach
-
-                # The reach starts from the retract posture: joints 3, 5, 7
-                # keep their retract values throughout, so the continuation
-                # must be seeded from the retract configuration.
-                home_joints = HOME_JOINT_POSITIONS.tolist()
-                self._sim.robot.arm.set_joints(home_joints)
-                home_ee = self._sim.robot.arm.get_end_effector_pose()
-                home_pitch = _approach_pitch(matrix_from_quat(home_ee.orientation))
-                path_targets = _interpolated_path_targets(
-                    np.array(home_ee.position),
-                    home_pitch,
-                    pre_grasp_position,
-                    grasp_position,
-                )
-                reach_plan = _plan_planar_reach(
-                    self._sim,
-                    home_joints,
-                    path_targets,
-                )
+                reach_plan = self._plan_reach(self._current_state)
                 # Remember the reach so the stow can replay it in reverse.
                 self._reach_configurations = reach_plan
 
+                home_joints = HOME_JOINT_POSITIONS.tolist()
                 current_joints = extend_joints_to_include_fingers(
                     list(self._current_state.joint_positions)
                 )
@@ -515,34 +480,10 @@ class GroundPickController(
             # carrying pose — continuing all the way to the retract
             # posture would press the cylinder into the lower arm.
             if self._current_retract_plan is None:
-                self._sim.set_state(self._current_state)
                 assert self._reach_configurations is not None
-                grasped_object_id = (
-                    self._sim._grasped_object_id  # pylint: disable=protected-access
+                stow_configs = self._plan_stow(
+                    self._current_state, self._reach_configurations
                 )
-                grasped_object_transform = (
-                    self._sim._grasped_object_transform  # pylint: disable=protected-access
-                )
-                assert grasped_object_id is not None
-                assert grasped_object_transform is not None
-                arm = self._sim.robot.arm
-                stow_configs: list[JointPositions] = []
-                candidates = list(reversed(self._reach_configurations)) + [
-                    HOME_JOINT_POSITIONS.tolist()
-                ]
-                for candidate in candidates:
-                    arm.set_joints(candidate)
-                    held_pose = multiply_poses(
-                        arm.get_end_effector_pose(), grasped_object_transform
-                    )
-                    set_pose(grasped_object_id, held_pose, self._sim.physics_client_id)
-                    if _held_object_collides(self._sim, grasped_object_id):
-                        break
-                    stow_configs.append(candidate)
-                if not stow_configs:
-                    raise TrajectorySamplingFailure(
-                        "No collision-free carrying pose along the stow"
-                    )
                 current_joints = extend_joints_to_include_fingers(
                     list(self._current_state.joint_positions)
                 )
@@ -580,11 +521,172 @@ class GroundPickController(
     def observe(self, x: ObjectCentricState) -> None:
         self._current_state = x
 
+    def predict_outcome(self, x: ObjectCentricState, params: Any) -> ObjectCentricState:
+        """Predict the post-pick state without simulating the motion.
+
+        The prediction follows the same geometry the controller executes:
+        the base is staged where ``params`` put it, the planar reach is
+        solved from the retract posture, the grasp is registered by the
+        sim's own grasp rule at the reach's final configuration, and the
+        arm ends at the carrying pose (the last collision-free
+        configuration of the reversed reach). Base motion planning is
+        skipped; the staged pose only has to be collision-free.
+        """
+        assert isinstance(x, CylinderShelf3DObjectCentricState)
+        target_name = self._target.name
+        target_se2 = x.get_object_pose(target_name).to_se2()
+        staged_base_pose = get_target_robot_pose_from_parameters(
+            target_se2, params[0], params[1]
+        )
+        staged = x.copy()
+        _set_base_pose(staged, staged_base_pose)
+        _set_arm_joints(staged, HOME_JOINT_POSITIONS.tolist())
+        self._sim.set_state(staged)
+        if (
+            self._sim._robot_or_held_object_collision_exists()  # pylint: disable=protected-access
+        ):
+            raise TrajectorySamplingFailure("Staged base pose is in collision")
+
+        reach_plan = self._plan_reach(staged)
+        at_grasp = staged.copy()
+        _set_arm_joints(at_grasp, reach_plan[-1])
+        self._sim.set_state(at_grasp)
+        close_action = np.array([0.0] * 10 + [-1.0], dtype=np.float32)
+        grasped, _, _, _, _ = self._sim.step(close_action)
+        assert isinstance(grasped, CylinderShelf3DObjectCentricState)
+        if grasped.grasped_object != target_name:
+            raise TrajectorySamplingFailure("Grasp did not register at the reach")
+
+        stow_configs = self._plan_stow(grasped, reach_plan)
+        carry_joints = stow_configs[-1]
+        grasp_transform = grasped.grasped_object_transform
+        assert grasp_transform is not None
+        arm = self._sim.robot.arm
+        arm.set_joints(carry_joints)
+        held_pose = multiply_poses(arm.get_end_effector_pose(), grasp_transform)
+        predicted = grasped.copy()
+        _set_arm_joints(predicted, carry_joints)
+        _set_object_pose(predicted, target_name, held_pose)
+        self._sim.set_state(predicted)
+        return self._sim.get_state()
+
+    def _plan_reach(
+        self, state: CylinderShelf3DObjectCentricState
+    ) -> list[JointPositions]:
+        """Solve the planar reach from the retract posture to the grasp.
+
+        The sim is set to ``state`` first; the reach is aligned with the
+        base heading so the gripper reaches straight out from wherever the
+        base is around the cylinder. Raises ``TrajectorySamplingFailure``
+        when the reach is infeasible.
+        """
+        self._sim.set_state(state)
+        cylinder_pose = state.get_object_pose(self._target.name)
+        base_pose = state.base_pose
+        approach_yaw = np.arctan2(
+            cylinder_pose.position[1] - base_pose.y,
+            cylinder_pose.position[0] - base_pose.x,
+        )
+        half_height = state.get(self._target, "half_extent_z")
+        approach = get_side_grasp_approach(approach_yaw)
+        grasp_point = np.array(
+            [
+                cylinder_pose.position[0],
+                cylinder_pose.position[1],
+                cylinder_pose.position[2] + half_height - GRASP_DEPTH_BELOW_TOP,
+            ]
+        )
+        grasp_position = grasp_point - GRASP_AXIS_STANDOFF * approach
+        pre_grasp_position = grasp_position - PRE_GRASP_BACKOFF * approach
+
+        # The reach starts from the retract posture: joints 3, 5, 7 keep
+        # their retract values throughout, so the continuation must be
+        # seeded from the retract configuration.
+        home_joints = HOME_JOINT_POSITIONS.tolist()
+        self._sim.robot.arm.set_joints(home_joints)
+        home_ee = self._sim.robot.arm.get_end_effector_pose()
+        home_pitch = _approach_pitch(matrix_from_quat(home_ee.orientation))
+        path_targets = _interpolated_path_targets(
+            np.array(home_ee.position),
+            home_pitch,
+            pre_grasp_position,
+            grasp_position,
+        )
+        return _plan_planar_reach(self._sim, home_joints, path_targets)
+
+    def _plan_stow(
+        self,
+        state: CylinderShelf3DObjectCentricState,
+        reach_configurations: list[JointPositions],
+    ) -> list[JointPositions]:
+        """Replay the reach in reverse while the held cylinder stays clear.
+
+        The sim is set to ``state`` (which must hold the cylinder) first.
+        The stow stops at the last configuration where the cylinder stays
+        clear of the arm body and the base: that configuration is the
+        carrying pose. Continuing all the way to the retract posture would
+        press the cylinder into the lower arm.
+        """
+        self._sim.set_state(state)
+        grasped_object_id = (
+            self._sim._grasped_object_id  # pylint: disable=protected-access
+        )
+        grasped_object_transform = (
+            self._sim._grasped_object_transform  # pylint: disable=protected-access
+        )
+        assert grasped_object_id is not None
+        assert grasped_object_transform is not None
+        arm = self._sim.robot.arm
+        stow_configs: list[JointPositions] = []
+        candidates = list(reversed(reach_configurations)) + [
+            HOME_JOINT_POSITIONS.tolist()
+        ]
+        for candidate in candidates:
+            arm.set_joints(candidate)
+            held_pose = multiply_poses(
+                arm.get_end_effector_pose(), grasped_object_transform
+            )
+            set_pose(grasped_object_id, held_pose, self._sim.physics_client_id)
+            if _held_object_collides(self._sim, grasped_object_id):
+                break
+            stow_configs.append(candidate)
+        if not stow_configs:
+            raise TrajectorySamplingFailure(
+                "No collision-free carrying pose along the stow"
+            )
+        return stow_configs
+
     def _get_current_robot_gripper_pose(self) -> float:
         x = self._current_state
         assert x is not None
         robot_obj = x.get_object_from_name("robot")
         return x.get(robot_obj, "finger_state")
+
+
+def _set_base_pose(state: ObjectCentricState, base_pose: SE2Pose) -> None:
+    """Write an SE2 base pose into the robot's features."""
+    robot = state.get_object_from_name("robot")
+    state.set(robot, "pos_base_x", base_pose.x)
+    state.set(robot, "pos_base_y", base_pose.y)
+    state.set(robot, "pos_base_rot", base_pose.rot)
+
+
+def _set_arm_joints(state: ObjectCentricState, joints: JointPositions) -> None:
+    """Write the first seven entries of ``joints`` into the robot's features."""
+    robot = state.get_object_from_name("robot")
+    for index, value in enumerate(joints[:7]):
+        state.set(robot, f"joint_{index + 1}", value)
+
+
+def _set_object_pose(state: ObjectCentricState, name: str, pose: Pose) -> None:
+    """Write a pose into an object's pose features."""
+    obj = state.get_object_from_name(name)
+    for feature, value in zip(("pose_x", "pose_y", "pose_z"), pose.position):
+        state.set(obj, feature, value)
+    for feature, value in zip(
+        ("pose_qx", "pose_qy", "pose_qz", "pose_qw"), pose.orientation
+    ):
+        state.set(obj, feature, value)
 
 
 class GroundPlaceController(

--- a/kinder-models/src/kinder_models/magic.py
+++ b/kinder-models/src/kinder_models/magic.py
@@ -1,0 +1,128 @@
+"""Magic skills: controllers that replace a skill's execution with one SkillCall.
+
+A regular parameterized controller produces a low-level action sequence that
+the planner simulates step by step. A magic controller instead asks the
+underlying controller to *predict* the state it would end in
+(:class:`OutcomePredictor`) and emits a single :class:`SkillCall` carrying
+that prediction. Planning then treats the skill as one transition, and the
+executor decides how the skill is actually performed.
+
+Use :func:`make_magic_lifted_controller` to turn an existing lifted controller
+into its magic counterpart without touching the skill's operator or sampler.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, Generic, Sequence, TypeVar
+
+import numpy as np
+from bilevel_planning.structs import (
+    GroundParameterizedController,
+    LiftedParameterizedController,
+)
+from relational_structs import Object
+
+from kinder_models.structs import SkillCall
+
+_X = TypeVar("_X")
+
+
+class OutcomePredictor(abc.ABC, Generic[_X]):
+    """A controller that can predict its terminal state without running.
+
+    Mix this into a :class:`GroundParameterizedController` to make the skill
+    eligible for :class:`MagicController`. The prediction is the skill's
+    option model: given the start state and the sampled parameters, return
+    the state the skill is expected to end in. Implementations may raise
+    ``TrajectorySamplingFailure`` when the parameters are infeasible, just
+    as ``step`` would.
+    """
+
+    @abc.abstractmethod
+    def predict_outcome(self, x: _X, params: Any) -> _X:
+        """Predict the state after executing the skill from ``x`` with ``params``."""
+
+
+class MagicController(GroundParameterizedController[_X, SkillCall[_X]]):
+    """A one-step controller that emits a SkillCall for an inner controller.
+
+    Parameters are sampled by the inner controller, so the magic skill
+    explores the same parameter space as the real one. The single action is
+    a :class:`SkillCall` whose ``predicted_state`` comes from the inner
+    controller's :meth:`OutcomePredictor.predict_outcome`.
+    """
+
+    def __init__(
+        self,
+        objects: Sequence[Object],
+        inner: GroundParameterizedController[_X, Any],
+        skill_name: str,
+    ) -> None:
+        super().__init__(objects)
+        if not isinstance(inner, OutcomePredictor):
+            raise TypeError(
+                f"{type(inner).__name__} cannot be made magic: it does not "
+                "implement OutcomePredictor.predict_outcome"
+            )
+        self._inner = inner
+        self._skill_name = skill_name
+        self._current_state: _X | None = None
+        self._current_params: Any = None
+        self._called = False
+
+    def sample_parameters(self, x: _X, rng: np.random.Generator) -> Any:
+        return self._inner.sample_parameters(x, rng)
+
+    def reset(self, x: _X, params: Any) -> None:
+        self._current_state = x
+        self._current_params = params
+        self._called = False
+
+    def terminated(self) -> bool:
+        return self._called
+
+    def step(self) -> SkillCall[_X]:
+        assert self._current_state is not None
+        assert isinstance(self._inner, OutcomePredictor)
+        predicted = self._inner.predict_outcome(
+            self._current_state, self._current_params
+        )
+        self._called = True
+        return SkillCall(
+            skill_name=self._skill_name,
+            objects=tuple(self.objects),
+            params=self._current_params,
+            predicted_state=predicted,
+        )
+
+    def observe(self, x: _X) -> None:
+        self._current_state = x
+
+
+def make_magic_lifted_controller(
+    lifted: LiftedParameterizedController[_X, Any], skill_name: str
+) -> LiftedParameterizedController[_X, SkillCall[_X]]:
+    """Wrap a lifted controller so grounding it yields a MagicController.
+
+    The returned lifted controller shares the original's variables and
+    parameter space; only the ground controller class changes. The inner
+    ground controller class must implement :class:`OutcomePredictor`.
+    """
+    inner_cls = lifted.controller_cls
+    if not issubclass(inner_cls, OutcomePredictor):
+        raise TypeError(
+            f"{inner_cls.__name__} cannot be made magic: it does not implement "
+            "OutcomePredictor.predict_outcome"
+        )
+
+    class _Magic(MagicController[_X]):
+        def __init__(self, objects: Sequence[Object]) -> None:
+            super().__init__(objects, inner_cls(objects), skill_name)
+
+    _Magic.__name__ = f"Magic{inner_cls.__name__}"
+    _Magic.__qualname__ = _Magic.__name__
+    _Magic.__doc__ = f"Magic version of {inner_cls.__name__}."
+    return LiftedParameterizedController(
+        lifted.variables, _Magic, params_space=lifted.params_space
+    )

--- a/kinder-models/src/kinder_models/structs.py
+++ b/kinder-models/src/kinder_models/structs.py
@@ -1,1 +1,47 @@
 """Common data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from relational_structs import Object
+
+_X = TypeVar("_X")
+
+
+@dataclass(frozen=True, eq=False)
+class SkillCall(Generic[_X]):
+    """One action that stands in for an entire skill execution.
+
+    A planner that treats a skill as magic emits a single ``SkillCall`` where
+    the skill's low-level action sequence would otherwise go. The transition
+    function maps the call straight to ``predicted_state`` (the skill's option
+    model), and whatever executes the plan decides how the skill is really
+    carried out: teleporting a simulator, handing control to a human
+    teleoperator, or running a learned policy.
+
+    Equality is by identity and the class is hashed through ``repr`` (see
+    ``prpl_utils.utils.consistent_hash``), so ``__repr__`` must be
+    deterministic and must pin down every field. ``params`` may be a numpy
+    array; it is rendered through ``repr`` of its tuple form for that reason.
+    """
+
+    skill_name: str
+    objects: tuple[Object, ...]
+    params: Any
+    predicted_state: _X
+
+    def __repr__(self) -> str:
+        params = self.params
+        if hasattr(params, "tolist"):
+            params = tuple(params.tolist())
+        object_names = tuple(o.name for o in self.objects)
+        return (
+            f"SkillCall(skill_name={self.skill_name!r}, objects={object_names!r}, "
+            f"params={params!r}, predicted_state_hash={hash(self.predicted_state)})"
+        )
+
+    def __str__(self) -> str:
+        object_names = ", ".join(o.name for o in self.objects)
+        return f"{self.skill_name}({object_names})"

--- a/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
@@ -2,6 +2,7 @@
 
 import kinder
 import numpy as np
+import pytest
 from bilevel_planning.trajectory_samplers.trajectory_sampler import (
     TrajectorySamplingFailure,
 )
@@ -13,8 +14,133 @@ from relational_structs.spaces import ObjectCentricBoxSpace
 from kinder_models.kinematic3d.cylinder_shelf3d.parameterized_skills import (
     create_lifted_controllers,
 )
+from kinder_models.magic import make_magic_lifted_controller
+from kinder_models.structs import SkillCall
 
 kinder.register_all_environments()
+
+
+def _run_controller(env, controller, state, max_steps=600):
+    """Step ``controller`` in ``env`` (an object-centric env) until it terminates."""
+    for _ in range(max_steps):
+        action = controller.step()
+        state, _, _, _, _ = env.step(action)
+        controller.observe(state)
+        if controller.terminated():
+            return state
+    raise AssertionError("Controller did not terminate")
+
+
+def test_pick_predict_outcome_matches_rollout():
+    """The pick's outcome model agrees with actually running the pick controller."""
+    env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    init_state, _ = env.reset(seed=456)
+    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    controllers = create_lifted_controllers(env.action_space, sim)
+    robot = init_state.get_object_from_name("robot")
+    target = init_state.get_object_from_name("cylinder0")
+    params = np.array([0.8, 0.0])
+
+    controller = controllers["pick"].ground((robot, target))
+    predicted = controller.predict_outcome(init_state, params)
+
+    controller = controllers["pick"].ground((robot, target))
+    controller.reset(init_state, params)
+    actual = _run_controller(env, controller, init_state)
+
+    assert predicted.grasped_object == "cylinder0"
+    assert actual.grasped_object == "cylinder0"
+    assert predicted.get(target, "pose_z") > 0.3
+    assert np.allclose(
+        [predicted.base_pose.x, predicted.base_pose.y, predicted.base_pose.rot],
+        [actual.base_pose.x, actual.base_pose.y, actual.base_pose.rot],
+        atol=1e-2,
+    )
+    # Compare joints modulo 2*pi: the continuous joints may report an
+    # equivalent angle on the other side of the wrap.
+    joint_error = np.angle(
+        np.exp(1j * (np.array(predicted.joint_positions) - actual.joint_positions))
+    )
+    assert np.allclose(joint_error, 0.0, atol=2e-2)
+    assert np.isclose(predicted.finger_state, actual.finger_state, atol=1e-2)
+    assert np.allclose(
+        predicted.get_object_pose("cylinder0").position,
+        actual.get_object_pose("cylinder0").position,
+        atol=2e-2,
+    )
+    env.close()
+    sim.close()
+
+
+def test_pick_predict_outcome_rejects_infeasible_parameters():
+    """Staging the base inside the shelf fails the prediction like a real sample."""
+    env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    init_state, _ = env.reset(seed=456)
+    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    controllers = create_lifted_controllers(env.action_space, sim)
+    robot = init_state.get_object_from_name("robot")
+    target = init_state.get_object_from_name("cylinder0")
+    controller = controllers["pick"].ground((robot, target))
+
+    # Put the cylinder 0.8 m in front of the shelf and stage the base 0.8 m
+    # behind the cylinder, i.e. at the shelf's own position.
+    state = init_state.copy()
+    shelf_pose = state.get_object_pose("shelf")
+    half_height = state.get(target, "half_extent_z")
+    state.set(target, "pose_x", shelf_pose.position[0])
+    state.set(target, "pose_y", shelf_pose.position[1] - 0.8)
+    state.set(target, "pose_z", half_height)
+    with pytest.raises(TrajectorySamplingFailure):
+        controller.predict_outcome(state, np.array([0.8, -np.pi / 2]))
+    env.close()
+    sim.close()
+
+
+def test_magic_pick_then_real_place():
+    """A magic pick's predicted state is a valid start for the real place skill."""
+    env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    init_state, _ = env.reset(seed=456)
+    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    controllers = create_lifted_controllers(env.action_space, sim)
+    robot = init_state.get_object_from_name("robot")
+    target = init_state.get_object_from_name("cylinder0")
+    shelf = init_state.get_object_from_name("shelf")
+
+    magic_pick = make_magic_lifted_controller(controllers["pick"], "Pick")
+    rng = np.random.default_rng(456)
+    pick = magic_pick.ground((robot, target))
+    pick.reset(init_state, np.array([0.8, 0.0]))
+    call = pick.step()
+    assert pick.terminated()
+    assert isinstance(call, SkillCall)
+    assert call.skill_name == "Pick"
+    assert call.objects == (robot, target)
+    state = call.predicted_state
+    assert state.grasped_object == "cylinder0"
+
+    # Execute the magic pick by teleporting the env to the predicted state.
+    env.set_state(state)
+    state = env.get_state()
+
+    placed = False
+    for _ in range(8):
+        place = controllers["place"].ground((robot, target, shelf))
+        place.reset(state, place.sample_parameters(state, rng))
+        try:
+            state = _run_controller(env, place, state)
+            placed = True
+            break
+        except TrajectorySamplingFailure:
+            continue
+    assert placed, "Place controller never terminated from the predicted state"
+
+    half_height = state.get(target, "half_extent_z")
+    resting_zs = [z + half_height for z in sim.config.get_layer_surface_zs()]
+    cylinder_z = state.get(target, "pose_z")
+    assert any(abs(cylinder_z - z) < 0.05 for z in resting_zs)
+    assert state.grasped_object is None
+    env.close()
+    sim.close()
 
 
 def test_pick_and_place_controller():

--- a/kinder-models/tests/test_magic.py
+++ b/kinder-models/tests/test_magic.py
@@ -1,0 +1,132 @@
+"""Tests for kinder_models.magic."""
+
+from typing import Any, Sequence
+
+import numpy as np
+import pytest
+from bilevel_planning.structs import (
+    GroundParameterizedController,
+    LiftedParameterizedController,
+)
+from gymnasium.spaces import Box
+from relational_structs import Object, Type, Variable
+
+from kinder_models.magic import (
+    MagicController,
+    OutcomePredictor,
+    make_magic_lifted_controller,
+)
+from kinder_models.structs import SkillCall
+
+_COUNTER_TYPE = Type("counter")
+
+
+class _IncrementController(
+    GroundParameterizedController[int, int], OutcomePredictor[int]
+):
+    """Adds ``params`` to the state one unit per step; predicts the sum outright."""
+
+    def __init__(self, objects: Sequence[Object]) -> None:
+        super().__init__(objects)
+        self._remaining = 0
+        self._state = 0
+
+    def sample_parameters(self, x: int, rng: np.random.Generator) -> Any:
+        del x
+        return int(rng.integers(1, 4))
+
+    def reset(self, x: int, params: Any) -> None:
+        self._state = x
+        self._remaining = int(params)
+
+    def terminated(self) -> bool:
+        return self._remaining == 0
+
+    def step(self) -> int:
+        self._remaining -= 1
+        return 1
+
+    def observe(self, x: int) -> None:
+        self._state = x
+
+    def predict_outcome(self, x: int, params: Any) -> int:
+        return x + int(params)
+
+
+class _PlainController(GroundParameterizedController[int, int]):
+    """A controller with no outcome model."""
+
+    def sample_parameters(self, x: int, rng: np.random.Generator) -> Any:
+        return 0
+
+    def reset(self, x: int, params: Any) -> None:
+        pass
+
+    def terminated(self) -> bool:
+        return True
+
+    def step(self) -> int:
+        return 0
+
+    def observe(self, x: int) -> None:
+        pass
+
+
+def test_magic_controller_emits_one_skill_call():
+    """The magic controller samples through the inner controller and terminates after a
+    single SkillCall carrying the inner controller's prediction."""
+    obj = Object("c", _COUNTER_TYPE)
+    inner = _IncrementController([obj])
+    controller = MagicController([obj], inner, "Increment")
+
+    rng = np.random.default_rng(0)
+    params = controller.sample_parameters(5, rng)
+    assert 1 <= params <= 3
+
+    controller.reset(5, params)
+    assert not controller.terminated()
+    action = controller.step()
+    assert isinstance(action, SkillCall)
+    assert action.skill_name == "Increment"
+    assert action.objects == (obj,)
+    assert action.params == params
+    assert action.predicted_state == 5 + params
+    assert controller.terminated()
+
+    # Resetting clears the termination.
+    controller.reset(10, 2)
+    assert not controller.terminated()
+    assert controller.step().predicted_state == 12
+
+
+def test_magic_controller_rejects_inner_without_outcome_model():
+    """Wrapping a controller that cannot predict its outcome is a TypeError."""
+    obj = Object("c", _COUNTER_TYPE)
+    with pytest.raises(TypeError, match="OutcomePredictor"):
+        MagicController([obj], _PlainController([obj]), "Plain")
+
+
+def test_make_magic_lifted_controller():
+    """The wrapped lifted controller keeps the variables and parameter space and grounds
+    to a MagicController around the original ground controller."""
+    var = Variable("?c", _COUNTER_TYPE)
+    params_space = Box(low=np.array([1.0]), high=np.array([3.0]))
+    lifted: LiftedParameterizedController = LiftedParameterizedController(
+        [var], _IncrementController, params_space
+    )
+    magic = make_magic_lifted_controller(lifted, "Increment")
+    assert magic.variables == lifted.variables
+    assert magic.params_space is params_space
+    assert magic.name == "Magic_IncrementController"
+
+    obj = Object("c", _COUNTER_TYPE)
+    ground = magic.ground([obj])
+    assert isinstance(ground, MagicController)
+    ground.reset(1, 3)
+    assert ground.step().predicted_state == 4
+
+    plain: LiftedParameterizedController = LiftedParameterizedController(
+        [var], _PlainController
+    )
+    with pytest.raises(TypeError, match="OutcomePredictor"):
+        make_magic_lifted_controller(plain, "Plain")

--- a/kinder-models/tests/test_structs.py
+++ b/kinder-models/tests/test_structs.py
@@ -1,0 +1,38 @@
+"""Tests for kinder_models.structs."""
+
+import numpy as np
+from relational_structs import Object, Type
+
+from kinder_models.structs import SkillCall
+
+
+def test_skill_call_repr_is_deterministic_and_complete():
+    """Two calls with equal contents share a repr; changing any field changes it."""
+    robot_type = Type("robot")
+    robot = Object("robot", robot_type)
+    target = Object("cylinder0", robot_type)
+    call = SkillCall("Pick", (robot, target), np.array([0.8, 0.1]), 7)
+    same = SkillCall("Pick", (robot, target), np.array([0.8, 0.1]), 7)
+    assert repr(call) == repr(same)
+    assert "Pick" in repr(call) and "cylinder0" in repr(call)
+    assert str(call) == "Pick(robot, cylinder0)"
+
+    other_params = SkillCall("Pick", (robot, target), np.array([0.8, 0.2]), 7)
+    other_state = SkillCall("Pick", (robot, target), np.array([0.8, 0.1]), 8)
+    other_name = SkillCall("Place", (robot, target), np.array([0.8, 0.1]), 7)
+    other_objects = SkillCall("Pick", (robot,), np.array([0.8, 0.1]), 7)
+    reprs = {
+        repr(call),
+        repr(other_params),
+        repr(other_state),
+        repr(other_name),
+        repr(other_objects),
+    }
+    assert len(reprs) == 5
+
+
+def test_skill_call_accepts_non_array_params():
+    """Scalar and tuple parameters are rendered without a tolist() conversion."""
+    obj = Object("robot", Type("robot"))
+    assert "params=0.5" in repr(SkillCall("Push", (obj,), 0.5, None))
+    assert "params=(1, 2)" in repr(SkillCall("Push", (obj,), (1, 2), None))


### PR DESCRIPTION
## Summary

First step toward planning with "magic" skills: skills whose low-level policy is not simulated during planning and is instead carried out at execution time by a teleoperator, a learned policy, or a sim teleport. Planning only needs an option model that predicts the skill's terminal state.

This PR adds the kinder-models side:

- **`SkillCall`** (`kinder_models/structs.py`): one action that stands in for a whole skill execution. Carries the skill name, objects, sampled parameters, and the predicted terminal state, so a plan can be walked to find the gaps and what the planner assumed after each one. The repr is deterministic (params via `tolist`, predicted state via its hash) because the bilevel planning graph hashes transitions through `repr`.
- **`OutcomePredictor` / `MagicController`** (`kinder_models/magic.py`): a ground controller that samples parameters through the wrapped controller and then emits a single `SkillCall` whose `predicted_state` is the wrapped controller's `predict_outcome(x, params)`. `make_magic_lifted_controller` swaps the ground controller class of an existing `LiftedParameterizedController`, keeping its variables and parameter space. Wrapping a controller that does not implement `OutcomePredictor` raises `TypeError` when grounded.
- **`GroundPickController.predict_outcome`** for CylinderShelf3D: the pick's option model. It stages the base where the parameters put it (collision-checked, no base motion planning), solves the same planar reach the controller executes, registers the grasp with the sim's own grasp rule via a single close step, and ends at the carrying pose from the reversed reach. The reach and stow planning are factored out of `step` into `_plan_reach` / `_plan_stow` so the executed and predicted paths share the same geometry.

Nothing in `bilevel_planning` changes: a magic skill is just a controller that terminates after one step, and the sampler's abstract-effect check still applies to the predicted state.

## Tests

- `tests/test_structs.py`: `SkillCall` repr is deterministic and distinguishes every field.
- `tests/test_magic.py`: `MagicController` samples through the inner controller, emits one call, terminates, and rejects inner controllers without an outcome model; `make_magic_lifted_controller` preserves variables/params space.
- `tests/kinematic3d/cylinder_shelf3d/…`: the pick's predicted state matches an actual pick rollout (base pose, joints modulo 2π, finger state, cylinder pose); staging the base inside the shelf raises `TrajectorySamplingFailure`; the real place skill runs to completion from the magic pick's predicted state.

Follow-ups (separate PRs): `magic_skills` in the kinder-bilevel-planning cylinder-shelf models, then the prpl-tidybot executor/preview side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
