### PR TITLE
CylinderShelf3D: split Pick into MoveToPreGrasp and a last-mile Grasp

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
@@ -66,13 +66,14 @@ def create_bilevel_planning_models(
     so abstract-state checks (OnFixture) are computed against the configured
     shelf rather than the dataclass default.
 
-    ``magic_skills`` names operators ("MoveToPreGrasp", "Grasp", "Place")
-    whose low-level policy is not simulated during planning. Each becomes a one-step skill emitting
-    a ``SkillCall`` whose predicted state comes from the controller's own
-    outcome model, and the transition function maps that call straight to
-    the predicted state. Plans then contain a ``SkillCall`` wherever the
-    executor must carry the skill out by other means. Only skills whose
-    controller implements ``OutcomePredictor`` can be made magic.
+    ``magic_skills`` names operators (any of "MoveToPreGrasp", "Grasp",
+    "Place") whose low-level policy is not simulated during planning. Each
+    becomes a one-step skill emitting a ``SkillCall`` whose predicted state
+    comes from the controller's own outcome model, and the transition
+    function maps that call straight to the predicted state. Plans then
+    contain a ``SkillCall`` wherever the executor must carry the skill out
+    by other means. Only skills whose controller implements
+    ``OutcomePredictor`` can be made magic.
     """
     assert isinstance(observation_space, ObjectCentricBoxSpace)
     assert isinstance(action_space, Kinematic3DRobotActionSpace)

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
@@ -25,6 +25,7 @@ from kinder.envs.kinematic3d.utils import (
 )
 from kinder_models.kinematic3d.cylinder_shelf3d.parameterized_skills import (
     create_lifted_controllers,
+    is_at_pre_grasp,
 )
 from kinder_models.magic import make_magic_lifted_controller
 from kinder_models.structs import SkillCall
@@ -42,7 +43,11 @@ from relational_structs.spaces import ObjectCentricBoxSpace, ObjectCentricStateS
 GRIPPER_OPEN_THRESHOLD = 0.01
 
 # Operator name -> key in kinder_models' create_lifted_controllers.
-_SKILL_CONTROLLER_KEYS = {"Pick": "pick", "Place": "place"}
+_SKILL_CONTROLLER_KEYS = {
+    "MoveToPreGrasp": "move_to_pre_grasp",
+    "Grasp": "grasp",
+    "Place": "place",
+}
 
 
 def create_bilevel_planning_models(
@@ -61,8 +66,8 @@ def create_bilevel_planning_models(
     so abstract-state checks (OnFixture) are computed against the configured
     shelf rather than the dataclass default.
 
-    ``magic_skills`` names operators ("Pick", "Place") whose low-level policy
-    is not simulated during planning. Each becomes a one-step skill emitting
+    ``magic_skills`` names operators ("MoveToPreGrasp", "Grasp", "Place")
+    whose low-level policy is not simulated during planning. Each becomes a one-step skill emitting
     a ``SkillCall`` whose predicted state comes from the controller's own
     outcome model, and the transition function maps that call straight to
     the predicted state. Plans then contain a ``SkillCall`` wherever the
@@ -114,7 +119,8 @@ def create_bilevel_planning_models(
     OnGround = Predicate("OnGround", [Kinematic3DCuboidType])
     Holding = Predicate("Holding", [Kinematic3DRobotType, Kinematic3DCuboidType])
     HandEmpty = Predicate("HandEmpty", [Kinematic3DRobotType])
-    predicates = {OnFixture, OnGround, Holding, HandEmpty}
+    AtPreGrasp = Predicate("AtPreGrasp", [Kinematic3DRobotType, Kinematic3DCuboidType])
+    predicates = {OnFixture, OnGround, Holding, HandEmpty, AtPreGrasp}
 
     # State abstractor.
     def state_abstractor(x: ObjectCentricState) -> RelationalAbstractState:
@@ -149,6 +155,11 @@ def create_bilevel_planning_models(
             ):
                 if target.name == x.grasped_object:
                     atoms.add(GroundAtom(Holding, [robot, target]))
+
+        # AtPreGrasp: empty gripper at the target's pre-grasp position.
+        for target in target_objects:
+            if is_at_pre_grasp(sim, x, target.name):
+                atoms.add(GroundAtom(AtPreGrasp, [robot, target]))
 
         # OnFixture: within the shelf footprint and resting above floor
         # level (a floor-standing cylinder has pose_z == half_extent_z; one
@@ -190,12 +201,28 @@ def create_bilevel_planning_models(
     robot = Variable("?robot", Kinematic3DRobotType)
     target = Variable("?target", Kinematic3DCuboidType)
 
-    PickOperator = LiftedOperator(
-        "Pick",
+    MoveToPreGraspOperator = LiftedOperator(
+        "MoveToPreGrasp",
         [robot, target],
         preconditions={LiftedAtom(HandEmpty, [robot]), LiftedAtom(OnGround, [target])},
+        add_effects={LiftedAtom(AtPreGrasp, [robot, target])},
+        delete_effects=set(),
+    )
+
+    GraspOperator = LiftedOperator(
+        "Grasp",
+        [robot, target],
+        preconditions={
+            LiftedAtom(AtPreGrasp, [robot, target]),
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [target]),
+        },
         add_effects={LiftedAtom(Holding, [robot, target])},
-        delete_effects={LiftedAtom(HandEmpty, [robot]), LiftedAtom(OnGround, [target])},
+        delete_effects={
+            LiftedAtom(AtPreGrasp, [robot, target]),
+            LiftedAtom(HandEmpty, [robot]),
+            LiftedAtom(OnGround, [target]),
+        },
     )
 
     # Get lifted controllers from kinder_models, swapping in magic versions
@@ -206,7 +233,8 @@ def create_bilevel_planning_models(
         lifted_controllers[key] = make_magic_lifted_controller(
             lifted_controllers[key], skill_name
         )
-    PickController = lifted_controllers["pick"]
+    MoveToPreGraspController = lifted_controllers["move_to_pre_grasp"]
+    GraspController = lifted_controllers["grasp"]
 
     robot = Variable("?robot", Kinematic3DRobotType)
     target = Variable("?target", Kinematic3DCuboidType)
@@ -227,7 +255,8 @@ def create_bilevel_planning_models(
 
     # Finalize the skills.
     skills = {
-        LiftedSkill(PickOperator, PickController),
+        LiftedSkill(MoveToPreGraspOperator, MoveToPreGraspController),
+        LiftedSkill(GraspOperator, GraspController),
         LiftedSkill(PlaceOperator, PlaceController),
     }
 

--- a/kinder-bilevel-planning/tests/env_models/kinematic3d/test_cylinder_shelf3d.py
+++ b/kinder-bilevel-planning/tests/env_models/kinematic3d/test_cylinder_shelf3d.py
@@ -31,30 +31,41 @@ def _make_agent(env, magic_skills):
     return env_models, agent
 
 
-def test_cylinder_shelf3d_magic_pick_planning_and_execution():
-    """With Pick magic, the plan holds exactly one SkillCall for the pick, the
-    predicted state satisfies the pick's effects, and executing the plan with the
-    SkillCall carried out as a teleport reaches the goal."""
+def _predicate(env_models, name):
+    return next(p for p in env_models.predicates if p.name == name)
+
+
+def test_cylinder_shelf3d_magic_grasp_planning_and_execution():
+    """With Grasp magic, the plan reaches the pre-grasp pose with planned motion,
+    holds exactly one SkillCall for the grasp whose predicted state satisfies
+    Holding, and executing the plan with the SkillCall carried out as a teleport
+    reaches the goal."""
     env = kinder.make("kinder/KinematicCylinderShelf3D-o1-v0", allow_state_access=True)
-    env_models, agent = _make_agent(env, magic_skills=("Pick",))
+    env_models, agent = _make_agent(env, magic_skills=("Grasp",))
     obs, info = env.reset(seed=123)
     agent.reset(obs, info)
 
     trajectory = agent.plan()
-    calls = [(x, u) for x, u in trajectory if isinstance(u, SkillCall)]
+    calls = [
+        (i, x, u) for i, (x, u) in enumerate(trajectory) if isinstance(u, SkillCall)
+    ]
     assert len(calls) == 1
-    pre_state, call = calls[0]
-    assert call.skill_name == "Pick"
+    index, pre_state, call = calls[0]
+    assert call.skill_name == "Grasp"
     assert [o.name for o in call.objects] == ["robot", "cylinder0"]
-    assert not any(isinstance(u, SkillCall) for _, u in trajectory[-1:])
+    # The approach to the pre-grasp pose is planned motion, not magic.
+    assert index > 0
+    assert all(isinstance(u, np.ndarray) for _, u in trajectory[:index])
 
-    # The predicted state carries the pick's abstract effects.
     robot = pre_state.get_object_from_name("robot")
     cylinder = pre_state.get_object_from_name("cylinder0")
-    holding = next(p for p in env_models.predicates if p.name == "Holding")
-    abstract = env_models.state_abstractor(call.predicted_state)
-    assert isinstance(abstract, RelationalAbstractState)
-    assert GroundAtom(holding, [robot, cylinder]) in abstract.atoms
+    at_pre_grasp = GroundAtom(_predicate(env_models, "AtPreGrasp"), [robot, cylinder])
+    holding = GroundAtom(_predicate(env_models, "Holding"), [robot, cylinder])
+    before = env_models.state_abstractor(pre_state)
+    after = env_models.state_abstractor(call.predicted_state)
+    assert isinstance(before, RelationalAbstractState)
+    assert at_pre_grasp in before.atoms and holding not in before.atoms
+    assert holding in after.atoms and at_pre_grasp not in after.atoms
     assert env_models.transition_fn(pre_state, call) == call.predicted_state
 
     # Execute: regular actions step the env; the SkillCall teleports it.
@@ -80,13 +91,14 @@ def test_cylinder_shelf3d_magic_skills_validation():
             "cylinder_shelf3d",
             env.observation_space,
             env.action_space,
-            magic_skills=("Fly",),
+            magic_skills=("Pick",),
         )
     env.close()
 
 
 def test_cylinder_shelf3d_without_magic_has_no_skill_calls():
-    """Without magic skills the plan is a plain low-level action sequence."""
+    """Without magic skills the plan is a plain low-level action sequence that
+    reaches the goal."""
     env = kinder.make("kinder/KinematicCylinderShelf3D-o1-v0")
     _, agent = _make_agent(env, magic_skills=())
     obs, info = env.reset(seed=123)
@@ -94,4 +106,10 @@ def test_cylinder_shelf3d_without_magic_has_no_skill_calls():
     trajectory = agent.plan()
     assert trajectory
     assert all(isinstance(u, np.ndarray) for _, u in trajectory)
+    terminated = False
+    for _, action in trajectory:
+        _, _, terminated, _, _ = env.step(action)
+        if terminated:
+            break
+    assert terminated
     env.close()

--- a/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
@@ -1,24 +1,32 @@
 """Parameterized skills for the CylinderShelf3D environment.
 
-The cylinders in this environment are tall enough that they must be
-grasped from the side: the end effector approaches near-horizontally
-(with a slight downward pitch) and the fingers straddle the cylinder.
-Because cylinders are rotationally symmetric, the approach angle around
-the cylinder axis is a free parameter, so the pick skill samples the
-full circle when choosing where to stage the base.
+Three skills cover pick-and-place of a tall cylinder with a planar side
+grasp:
 
-Neither skill uses arm motion planning. All arm motion is planar:
-joints 3, 5, and 7 stay at their retract values, joint 1 absorbs only
-the small lateral correction that keeps the arm plane through the
-target, and the motion happens in joints 2, 4, and 6 — the pitch
-joints — so the gripper travels forward, up, and down in the vertical
-plane without twisting. Joint trajectories are solved by numerical
-continuation along prescribed in-plane end-effector paths, and every
-configuration is collision-checked against the robot base, the shelf,
-and (while grasped) the held cylinder. The pick's stow and the place's
-retreat replay their approach configurations in reverse. Because the
-grasp is planar, entering the shelf at the grasp's own pitch keeps the
-cylinder upright through the placement.
+* ``MoveToPreGrasp`` stages the base around the cylinder (the approach
+  angle is a free parameter because cylinders are rotationally
+  symmetric) and reaches the arm from the retract posture to the
+  pre-grasp pose, a short standoff behind the grasp along the approach
+  axis.
+* ``Grasp`` covers the last mile: it pushes the gripper straight in from
+  the pre-grasp pose to the grasp, closes, and stows the arm to a
+  carrying pose. It takes no parameters. Splitting it out lets a planner
+  treat just this part as magic and hand it to a teleoperator or a
+  learned policy while the approach stays planned.
+* ``Place`` navigates to the shelf and slides the cylinder in upright.
+
+Neither the reach nor the place uses arm motion planning. All arm motion
+is planar: joints 3, 5, and 7 stay at their retract values, joint 1
+absorbs only the small lateral correction that keeps the arm plane
+through the target, and the motion happens in joints 2, 4, and 6 — the
+pitch joints — so the gripper travels forward, up, and down in the
+vertical plane without twisting. Joint trajectories are solved by
+numerical continuation along prescribed in-plane end-effector paths, and
+every configuration is collision-checked against the robot base, the
+shelf, and (while grasped) the held cylinder. The grasp's stow and the
+place's retreat replay their approach configurations in reverse. Because
+the grasp is planar, entering the shelf at the grasp's own pitch keeps
+the cylinder upright through the placement.
 """
 
 from typing import Any, Sequence
@@ -53,7 +61,11 @@ from pybullet_helpers.geometry import (
     set_pose,
 )
 from pybullet_helpers.inverse_kinematics import check_body_collisions
-from pybullet_helpers.joint import JointPositions, get_jointwise_difference
+from pybullet_helpers.joint import (
+    JointInfo,
+    JointPositions,
+    get_jointwise_difference,
+)
 from pybullet_helpers.motion_planning import (
     remap_joint_position_plan_to_constant_distance,
     remap_se2_pose_plan_to_constant_distance,
@@ -108,6 +120,9 @@ GRASP_AXIS_STANDOFF = 0.02
 # value down to SIDE_GRASP_PITCH before the pre-grasp, so the final
 # approach segment is a pure translation.
 PRE_GRASP_BACKOFF = 0.10
+# How close (m) the end effector must be to the pre-grasp position for the
+# robot to count as being at the pre-grasp pose.
+PRE_GRASP_POSITION_TOL = 0.03
 # The place approach's pre-place waypoint: backed off along the shelf
 # approach axis and lifted slightly, so the final segment slides the
 # cylinder in over the shelf layer.
@@ -284,12 +299,14 @@ def _interpolated_path_targets(
     mid_position: np.ndarray,
     end_position: np.ndarray,
     end_pitch: float = SIDE_GRASP_PITCH,
-) -> list[tuple[np.ndarray, float]]:
+) -> tuple[list[tuple[np.ndarray, float]], int]:
     """Dense (position, pitch) targets for the two-leg planar reach.
 
     Leg one runs from the start to the mid waypoint (the pre-grasp or
     pre-place) while the pitch ramps to ``end_pitch``; leg two pushes
-    straight in to the end position at constant pitch.
+    straight in to the end position at constant pitch. Also returns the
+    number of leg-one targets, so callers can split the path at the mid
+    waypoint.
     """
     targets: list[tuple[np.ndarray, float]] = []
     leg_one = float(np.linalg.norm(mid_position - start_position))
@@ -309,18 +326,205 @@ def _interpolated_path_targets(
         t = step / num_two
         position = mid_position + t * (end_position - mid_position)
         targets.append((position, end_pitch))
-    return targets
+    return targets, num_one
 
 
 # Controllers.
-class GroundPickController(
+def get_grasp_positions(
+    state: CylinderShelf3DObjectCentricState, target_name: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """(grasp position, pre-grasp position) of the side grasp on ``target_name``.
+
+    The approach is aligned with the base heading toward the cylinder so the
+    gripper reaches straight out from wherever the base is around it. The
+    grasp position is where the end effector sits at the grasp; the
+    pre-grasp position is PRE_GRASP_BACKOFF behind it along the approach
+    axis.
+    """
+    cylinder_pose = state.get_object_pose(target_name)
+    base_pose = state.base_pose
+    approach_yaw = np.arctan2(
+        cylinder_pose.position[1] - base_pose.y,
+        cylinder_pose.position[0] - base_pose.x,
+    )
+    target = state.get_object_from_name(target_name)
+    half_height = state.get(target, "half_extent_z")
+    approach = get_side_grasp_approach(approach_yaw)
+    grasp_point = np.array(
+        [
+            cylinder_pose.position[0],
+            cylinder_pose.position[1],
+            cylinder_pose.position[2] + half_height - GRASP_DEPTH_BELOW_TOP,
+        ]
+    )
+    grasp_position = grasp_point - GRASP_AXIS_STANDOFF * approach
+    pre_grasp_position = grasp_position - PRE_GRASP_BACKOFF * approach
+    return grasp_position, pre_grasp_position
+
+
+def is_at_pre_grasp(
+    sim: ObjectCentricCylinderShelf3DEnv,
+    state: CylinderShelf3DObjectCentricState,
+    target_name: str,
+) -> bool:
+    """Whether the (empty) gripper is within PRE_GRASP_POSITION_TOL of the pre-grasp
+    position for ``target_name``. The sim is set to ``state`` to read the end effector
+    pose."""
+    if state.grasped_object is not None:
+        return False
+    sim.set_state(state)
+    ee_position = np.array(sim.robot.arm.get_end_effector_pose().position)
+    _, pre_grasp_position = get_grasp_positions(state, target_name)
+    return bool(
+        np.linalg.norm(ee_position - pre_grasp_position) < PRE_GRASP_POSITION_TOL
+    )
+
+
+def _plan_reach(
+    sim: ObjectCentricCylinderShelf3DEnv,
+    state: CylinderShelf3DObjectCentricState,
+    target_name: str,
+) -> tuple[list[JointPositions], int]:
+    """Solve the planar reach from the retract posture to the grasp.
+
+    The sim is set to ``state`` first. Returns the reach configurations and
+    the index of the pre-grasp configuration within them; the configurations
+    after that index are the final straight-in approach. Raises
+    ``TrajectorySamplingFailure`` when the reach is infeasible.
+    """
+    sim.set_state(state)
+    grasp_position, pre_grasp_position = get_grasp_positions(state, target_name)
+    # The reach starts from the retract posture: joints 3, 5, 7 keep their
+    # retract values throughout, so the continuation must be seeded from
+    # the retract configuration.
+    home_joints = HOME_JOINT_POSITIONS.tolist()
+    sim.robot.arm.set_joints(home_joints)
+    home_ee = sim.robot.arm.get_end_effector_pose()
+    home_pitch = _approach_pitch(matrix_from_quat(home_ee.orientation))
+    path_targets, num_leg_one = _interpolated_path_targets(
+        np.array(home_ee.position),
+        home_pitch,
+        pre_grasp_position,
+        grasp_position,
+    )
+    return _plan_planar_reach(sim, home_joints, path_targets), num_leg_one - 1
+
+
+def _plan_stow(
+    sim: ObjectCentricCylinderShelf3DEnv,
+    state: CylinderShelf3DObjectCentricState,
+    reach_configurations: list[JointPositions],
+) -> list[JointPositions]:
+    """Replay the reach in reverse while the held cylinder stays clear.
+
+    The sim is set to ``state`` (which must hold the cylinder) first. The
+    stow stops at the last configuration where the cylinder stays clear of
+    the arm body and the base: that configuration is the carrying pose.
+    Continuing all the way to the retract posture would press the cylinder
+    into the lower arm.
+    """
+    sim.set_state(state)
+    grasped_object_id = sim._grasped_object_id  # pylint: disable=protected-access
+    grasped_object_transform = (
+        sim._grasped_object_transform  # pylint: disable=protected-access
+    )
+    assert grasped_object_id is not None
+    assert grasped_object_transform is not None
+    arm = sim.robot.arm
+    stow_configs: list[JointPositions] = []
+    candidates = list(reversed(reach_configurations)) + [HOME_JOINT_POSITIONS.tolist()]
+    for candidate in candidates:
+        arm.set_joints(candidate)
+        held_pose = multiply_poses(
+            arm.get_end_effector_pose(), grasped_object_transform
+        )
+        set_pose(grasped_object_id, held_pose, sim.physics_client_id)
+        if _held_object_collides(sim, grasped_object_id):
+            break
+        stow_configs.append(candidate)
+    if not stow_configs:
+        raise TrajectorySamplingFailure(
+            "No collision-free carrying pose along the stow"
+        )
+    return stow_configs
+
+
+def _predict_grasp_outcome(
+    sim: ObjectCentricCylinderShelf3DEnv,
+    x: CylinderShelf3DObjectCentricState,
+    target_name: str,
+) -> ObjectCentricState:
+    """Predict the state after grasping ``target_name`` from ``x``.
+
+    ``x`` must already have the base staged (the arm may be anywhere). The
+    planar reach is solved, the grasp is registered by the sim's own grasp
+    rule at the reach's final configuration, and the arm ends at the
+    carrying pose (the last collision-free configuration of the reversed
+    reach).
+    """
+    reach_plan, _ = _plan_reach(sim, x, target_name)
+    at_grasp = x.copy()
+    _set_arm_joints(at_grasp, reach_plan[-1])
+    sim.set_state(at_grasp)
+    close_action = np.array([0.0] * 10 + [-1.0], dtype=np.float32)
+    grasped, _, _, _, _ = sim.step(close_action)
+    assert isinstance(grasped, CylinderShelf3DObjectCentricState)
+    if grasped.grasped_object != target_name:
+        raise TrajectorySamplingFailure("Grasp did not register at the reach")
+
+    stow_configs = _plan_stow(sim, grasped, reach_plan)
+    carry_joints = stow_configs[-1]
+    grasp_transform = grasped.grasped_object_transform
+    assert grasp_transform is not None
+    arm = sim.robot.arm
+    arm.set_joints(carry_joints)
+    held_pose = multiply_poses(arm.get_end_effector_pose(), grasp_transform)
+    predicted = grasped.copy()
+    _set_arm_joints(predicted, carry_joints)
+    _set_object_pose(predicted, target_name, held_pose)
+    sim.set_state(predicted)
+    return sim.get_state()
+
+
+def _remap_joint_plan(
+    sim: ObjectCentricCylinderShelf3DEnv,
+    state: CylinderShelf3DObjectCentricState,
+    configurations: list[JointPositions],
+) -> list[JointPositions]:
+    """Remap ``[current joints] + configurations`` to the action limits, excluding the
+    current joints."""
+    current_joints = extend_joints_to_include_fingers(list(state.joint_positions))
+    joint_plan = remap_joint_position_plan_to_constant_distance(
+        [current_joints] + configurations,
+        sim.robot.arm,
+        max_distance=sim.config.max_action_mag / 2,
+    )
+    return joint_plan[1:]
+
+
+def _arm_action(
+    joint_infos: list[JointInfo],
+    target_joints: JointPositions,
+    state: CylinderShelf3DObjectCentricState,
+) -> np.ndarray:
+    """Kinder action moving the arm joints toward ``target_joints``."""
+    delta_lst = get_jointwise_difference(
+        joint_infos, target_joints[:7], state.joint_positions
+    )
+    return np.array([0.0] * 3 + delta_lst + [0.0], dtype=np.float32)
+
+
+class GroundMoveToPreGraspController(
     GroundParameterizedController[ObjectCentricState, np.ndarray],
     OutcomePredictor[ObjectCentricState],
 ):
-    """Controller for picking up a cylinder with a planar side grasp.
+    """Stage the base around a cylinder and reach the arm to its pre-grasp pose.
 
-    The controller also predicts its own outcome (:meth:`predict_outcome`),
-    so the pick can be planned as a magic skill.
+    The parameters are the base staging distance and the approach angle
+    around the cylinder. The base is motion-planned to the staged pose, then
+    the arm follows the first leg of the planar reach from the retract
+    posture to the pre-grasp waypoint. The controller also predicts its own
+    outcome (:meth:`predict_outcome`).
     """
 
     def __init__(
@@ -333,16 +537,11 @@ class GroundPickController(
         self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
         self._current_params: np.ndarray | None = None
-        self._current_arm_joint_plan: list[JointPositions] | None = None
-        self._current_retract_plan: list[JointPositions] | None = None
-        self._reach_configurations: list[JointPositions] | None = None
         self._current_plan: list[SE2Pose] | None = None
+        self._current_arm_joint_plan: list[JointPositions] | None = None
         self._current_state: ObjectCentricState | None = None
         self._navigated: bool = False
-        self._pre_grasp: bool = False
-        self._closed_gripper: bool = False
-        self._lifted: bool = False
-        self._last_gripper_state: float = 0.0
+        self._reached: bool = False
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
         """Sample the base staging distance and the approach angle."""
@@ -354,27 +553,28 @@ class GroundPickController(
     def reset(self, x: ObjectCentricState, params: Any) -> None:
         self._current_params = params
         self._current_plan = None
+        self._current_arm_joint_plan = None
         self._current_state = x
+        self._navigated = False
+        self._reached = False
 
     def terminated(self) -> bool:
-        return self._lifted
+        return self._reached
 
     def step(self) -> np.ndarray:
         assert self._current_state is not None
         assert self._current_params is not None
         assert isinstance(self._current_state, CylinderShelf3DObjectCentricState)
 
-        # Generate the motion plan if it doesn't exist yet.
+        # Generate the base motion plan if it doesn't exist yet.
         if self._current_plan is None:
             self._sim.set_state(self._current_state)
-
             target_pose = self._current_state.get_object_pose(
-                self.objects[1].name
+                self._target.name
             ).to_se2()
             target_base_pose = get_target_robot_pose_from_parameters(
                 target_pose, self._current_params[0], self._current_params[1]
             )
-            # Run base motion planning to the target pose.
             base_plan = run_single_arm_mobile_base_motion_planning(
                 self._sim.robot,
                 self._sim.robot.base.get_pose(),
@@ -382,22 +582,18 @@ class GroundPickController(
                 collision_bodies=self._sim._get_collision_object_ids(),  # pylint: disable=protected-access
                 seed=0,  # for determinism
             )
-
             if base_plan is None:
                 raise TrajectorySamplingFailure("Base motion planning failed")
-
             # Remap the plan to ensure we stay within action limits.
             base_plan = remap_se2_pose_plan_to_constant_distance(
                 base_plan,
                 max_distance=self._sim.config.max_action_mag,
             )
-
             # Store the plan (excluding the first state which is the current state).
             self._current_plan = base_plan[1:]
 
         if not self._navigated:
             # Step toward the next waypoint within action limits.
-            assert self._current_plan is not None
             delta_lst, exhausted = step_toward_se2_waypoint(
                 self._current_state.base_pose,
                 self._current_plan,
@@ -405,116 +601,29 @@ class GroundPickController(
             )
             if exhausted:
                 self._navigated = True
+            return np.array(delta_lst + [0.0] * 7 + [0.0], dtype=np.float32)
 
-            # Create action: [base_x, base_y, base_rot, joint1, ..., joint7, gripper].
-            action_lst = delta_lst + [0.0] * 7 + [0.0]
-            action = np.array(action_lst, dtype=np.float32)
-
-            return action
-
-        if self._navigated and not self._pre_grasp:
-            # Generate the planar reach plan if it doesn't exist yet.
+        if not self._reached:
+            # Generate the reach plan (leg one only) if it doesn't exist yet.
             if self._current_arm_joint_plan is None:
-                reach_plan = self._plan_reach(self._current_state)
-                # Remember the reach so the stow can replay it in reverse.
-                self._reach_configurations = reach_plan
-
-                home_joints = HOME_JOINT_POSITIONS.tolist()
-                current_joints = extend_joints_to_include_fingers(
-                    list(self._current_state.joint_positions)
+                reach_plan, pre_grasp_index = _plan_reach(
+                    self._sim, self._current_state, self._target.name
                 )
-                joint_plan = [current_joints] + reach_plan
-                if not np.allclose(current_joints[:7], home_joints[:7], atol=1e-3):
+                configurations = reach_plan[: pre_grasp_index + 1]
+                home_joints = HOME_JOINT_POSITIONS.tolist()
+                if not np.allclose(
+                    self._current_state.joint_positions, home_joints[:7], atol=1e-3
+                ):
                     # The arm is not at the retract posture; go there first
                     # so the planar reach starts from its seed.
-                    joint_plan = [current_joints, home_joints] + reach_plan
-
-                # Remap the plan to ensure we stay within action limits.
-                joint_plan = remap_joint_position_plan_to_constant_distance(
-                    joint_plan,
-                    self._sim.robot.arm,
-                    max_distance=self._sim.config.max_action_mag / 2,
+                    configurations = [home_joints] + configurations
+                self._current_arm_joint_plan = _remap_joint_plan(
+                    self._sim, self._current_state, configurations
                 )
-
-                # Store the plan (excluding the first state which is the current state).
-                self._current_arm_joint_plan = joint_plan[1:]
-            # Pop the next target joint positions from the plan.
-            assert self._current_arm_joint_plan is not None
             target_joints = self._current_arm_joint_plan.pop(0)
-            if len(self._current_arm_joint_plan) == 0:
-                self._pre_grasp = True
-            # Compute delta joint positions.
-            delta_lst = get_jointwise_difference(
-                self._joint_infos,
-                target_joints[:7],
-                self._current_state.joint_positions,
-            )
-
-            # Create action: [base_x, base_y, base_rot, joint1, ..., joint7, gripper].
-            action_lst = [0.0] * 3 + delta_lst + [0.0]
-            action = np.array(action_lst, dtype=np.float32)
-
-            return action
-
-        if self._pre_grasp and not self._closed_gripper:
-            if (
-                self._get_current_robot_gripper_pose() > GRIPPER_CLOSE_THRESHOLD
-                and np.isclose(
-                    self._get_current_robot_gripper_pose(),
-                    self._last_gripper_state,
-                    atol=0.02,
-                )
-            ):
-                self._closed_gripper = True
-            action_lst = [0.0] * 10 + [-1.0]
-            action = np.array(action_lst, dtype=np.float32)
-            self._last_gripper_state = self._get_current_robot_gripper_pose()
-            return action
-
-        if self._closed_gripper and not self._lifted:
-            # Generate the stow plan if it doesn't exist yet: the reach
-            # configurations replayed in reverse (so the cylinder retraces
-            # the same planar path out of the grasp region), stopping at
-            # the last configuration where the held cylinder stays clear
-            # of the arm body and the base. That configuration is the
-            # carrying pose — continuing all the way to the retract
-            # posture would press the cylinder into the lower arm.
-            if self._current_retract_plan is None:
-                assert self._reach_configurations is not None
-                stow_configs = self._plan_stow(
-                    self._current_state, self._reach_configurations
-                )
-                current_joints = extend_joints_to_include_fingers(
-                    list(self._current_state.joint_positions)
-                )
-                joint_plan = [current_joints] + stow_configs
-
-                # Remap the plan to ensure we stay within action limits.
-                joint_plan = remap_joint_position_plan_to_constant_distance(
-                    joint_plan,
-                    self._sim.robot.arm,
-                    max_distance=self._sim.config.max_action_mag / 2,
-                )
-
-                # Store the plan (excluding the first state which is the current state).
-                self._current_retract_plan = joint_plan[1:]
-            # Pop the next target joint positions from the plan.
-            assert self._current_retract_plan is not None
-            target_joints = self._current_retract_plan.pop(0)
-            if len(self._current_retract_plan) == 0:
-                self._lifted = True
-            # Compute delta joint positions.
-            delta_lst = get_jointwise_difference(
-                self._joint_infos,
-                target_joints[:7],
-                self._current_state.joint_positions,
-            )
-
-            # Create action: [base_x, base_y, base_rot, joint1, ..., joint7, gripper].
-            action_lst = [0.0] * 3 + delta_lst + [0.0]
-            action = np.array(action_lst, dtype=np.float32)
-
-            return action
+            if not self._current_arm_joint_plan:
+                self._reached = True
+            return _arm_action(self._joint_infos, target_joints, self._current_state)
 
         raise ValueError("Invalid state")
 
@@ -522,19 +631,14 @@ class GroundPickController(
         self._current_state = x
 
     def predict_outcome(self, x: ObjectCentricState, params: Any) -> ObjectCentricState:
-        """Predict the post-pick state without simulating the motion.
+        """Predict the state at the pre-grasp pose without simulating the motion.
 
-        The prediction follows the same geometry the controller executes:
-        the base is staged where ``params`` put it, the planar reach is
-        solved from the retract posture, the grasp is registered by the
-        sim's own grasp rule at the reach's final configuration, and the
-        arm ends at the carrying pose (the last collision-free
-        configuration of the reversed reach). Base motion planning is
-        skipped; the staged pose only has to be collision-free.
+        The base is staged where ``params`` put it (base motion planning is
+        skipped; the staged pose only has to be collision-free) and the arm is
+        set to the pre-grasp configuration of the planar reach.
         """
         assert isinstance(x, CylinderShelf3DObjectCentricState)
-        target_name = self._target.name
-        target_se2 = x.get_object_pose(target_name).to_se2()
+        target_se2 = x.get_object_pose(self._target.name).to_se2()
         staged_base_pose = get_target_robot_pose_from_parameters(
             target_se2, params[0], params[1]
         )
@@ -546,121 +650,120 @@ class GroundPickController(
             self._sim._robot_or_held_object_collision_exists()  # pylint: disable=protected-access
         ):
             raise TrajectorySamplingFailure("Staged base pose is in collision")
-
-        reach_plan = self._plan_reach(staged)
-        at_grasp = staged.copy()
-        _set_arm_joints(at_grasp, reach_plan[-1])
-        self._sim.set_state(at_grasp)
-        close_action = np.array([0.0] * 10 + [-1.0], dtype=np.float32)
-        grasped, _, _, _, _ = self._sim.step(close_action)
-        assert isinstance(grasped, CylinderShelf3DObjectCentricState)
-        if grasped.grasped_object != target_name:
-            raise TrajectorySamplingFailure("Grasp did not register at the reach")
-
-        stow_configs = self._plan_stow(grasped, reach_plan)
-        carry_joints = stow_configs[-1]
-        grasp_transform = grasped.grasped_object_transform
-        assert grasp_transform is not None
-        arm = self._sim.robot.arm
-        arm.set_joints(carry_joints)
-        held_pose = multiply_poses(arm.get_end_effector_pose(), grasp_transform)
-        predicted = grasped.copy()
-        _set_arm_joints(predicted, carry_joints)
-        _set_object_pose(predicted, target_name, held_pose)
+        reach_plan, pre_grasp_index = _plan_reach(self._sim, staged, self._target.name)
+        predicted = staged.copy()
+        _set_arm_joints(predicted, reach_plan[pre_grasp_index])
         self._sim.set_state(predicted)
         return self._sim.get_state()
 
-    def _plan_reach(
-        self, state: CylinderShelf3DObjectCentricState
-    ) -> list[JointPositions]:
-        """Solve the planar reach from the retract posture to the grasp.
 
-        The sim is set to ``state`` first; the reach is aligned with the
-        base heading so the gripper reaches straight out from wherever the
-        base is around the cylinder. Raises ``TrajectorySamplingFailure``
-        when the reach is infeasible.
-        """
-        self._sim.set_state(state)
-        cylinder_pose = state.get_object_pose(self._target.name)
-        base_pose = state.base_pose
-        approach_yaw = np.arctan2(
-            cylinder_pose.position[1] - base_pose.y,
-            cylinder_pose.position[0] - base_pose.x,
-        )
-        half_height = state.get(self._target, "half_extent_z")
-        approach = get_side_grasp_approach(approach_yaw)
-        grasp_point = np.array(
-            [
-                cylinder_pose.position[0],
-                cylinder_pose.position[1],
-                cylinder_pose.position[2] + half_height - GRASP_DEPTH_BELOW_TOP,
-            ]
-        )
-        grasp_position = grasp_point - GRASP_AXIS_STANDOFF * approach
-        pre_grasp_position = grasp_position - PRE_GRASP_BACKOFF * approach
+class GroundGraspController(
+    GroundParameterizedController[ObjectCentricState, np.ndarray],
+    OutcomePredictor[ObjectCentricState],
+):
+    """Close the last mile of a side grasp from the pre-grasp pose.
 
-        # The reach starts from the retract posture: joints 3, 5, 7 keep
-        # their retract values throughout, so the continuation must be
-        # seeded from the retract configuration.
-        home_joints = HOME_JOINT_POSITIONS.tolist()
-        self._sim.robot.arm.set_joints(home_joints)
-        home_ee = self._sim.robot.arm.get_end_effector_pose()
-        home_pitch = _approach_pitch(matrix_from_quat(home_ee.orientation))
-        path_targets = _interpolated_path_targets(
-            np.array(home_ee.position),
-            home_pitch,
-            pre_grasp_position,
-            grasp_position,
-        )
-        return _plan_planar_reach(self._sim, home_joints, path_targets)
+    Takes no parameters. The arm pushes straight in along the approach axis
+    from the pre-grasp pose to the grasp (the final leg of the planar reach,
+    re-solved from the current state), closes the gripper, then stows: the
+    reach configurations are replayed in reverse, stopping at the last
+    configuration where the held cylinder stays clear of the arm body and
+    the base — the carrying pose. The controller also predicts its own
+    outcome (:meth:`predict_outcome`), which is what lets a planner treat
+    the grasp as a magic skill and hand it to a teleoperator.
+    """
 
-    def _plan_stow(
+    def __init__(
         self,
-        state: CylinderShelf3DObjectCentricState,
-        reach_configurations: list[JointPositions],
-    ) -> list[JointPositions]:
-        """Replay the reach in reverse while the held cylinder stays clear.
+        objects: Sequence[Object],
+        sim: ObjectCentricCylinderShelf3DEnv,
+    ) -> None:
+        super().__init__(objects)
+        self._sim = sim
+        self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
+        self._robot, self._target = objects
+        self._current_approach_plan: list[JointPositions] | None = None
+        self._current_stow_plan: list[JointPositions] | None = None
+        self._reach_configurations: list[JointPositions] | None = None
+        self._current_state: ObjectCentricState | None = None
+        self._approached: bool = False
+        self._closed_gripper: bool = False
+        self._lifted: bool = False
+        self._last_gripper_state: float = 0.0
 
-        The sim is set to ``state`` (which must hold the cylinder) first.
-        The stow stops at the last configuration where the cylinder stays
-        clear of the arm body and the base: that configuration is the
-        carrying pose. Continuing all the way to the retract posture would
-        press the cylinder into the lower arm.
-        """
-        self._sim.set_state(state)
-        grasped_object_id = (
-            self._sim._grasped_object_id  # pylint: disable=protected-access
-        )
-        grasped_object_transform = (
-            self._sim._grasped_object_transform  # pylint: disable=protected-access
-        )
-        assert grasped_object_id is not None
-        assert grasped_object_transform is not None
-        arm = self._sim.robot.arm
-        stow_configs: list[JointPositions] = []
-        candidates = list(reversed(reach_configurations)) + [
-            HOME_JOINT_POSITIONS.tolist()
-        ]
-        for candidate in candidates:
-            arm.set_joints(candidate)
-            held_pose = multiply_poses(
-                arm.get_end_effector_pose(), grasped_object_transform
-            )
-            set_pose(grasped_object_id, held_pose, self._sim.physics_client_id)
-            if _held_object_collides(self._sim, grasped_object_id):
-                break
-            stow_configs.append(candidate)
-        if not stow_configs:
-            raise TrajectorySamplingFailure(
-                "No collision-free carrying pose along the stow"
-            )
-        return stow_configs
+    def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
+        """The grasp has no free parameters."""
+        del x, rng
+        return np.zeros(0)
 
-    def _get_current_robot_gripper_pose(self) -> float:
-        x = self._current_state
-        assert x is not None
-        robot_obj = x.get_object_from_name("robot")
-        return x.get(robot_obj, "finger_state")
+    def reset(self, x: ObjectCentricState, params: Any) -> None:
+        del params
+        self._current_approach_plan = None
+        self._current_stow_plan = None
+        self._reach_configurations = None
+        self._current_state = x
+        self._approached = False
+        self._closed_gripper = False
+        self._lifted = False
+        self._last_gripper_state = 0.0
+
+    def terminated(self) -> bool:
+        return self._lifted
+
+    def step(self) -> np.ndarray:
+        assert self._current_state is not None
+        assert isinstance(self._current_state, CylinderShelf3DObjectCentricState)
+
+        if not self._approached:
+            # Generate the final approach if it doesn't exist yet: the
+            # configurations after the pre-grasp waypoint of the planar
+            # reach. The full reach is kept so the stow can replay it.
+            if self._current_approach_plan is None:
+                reach_plan, pre_grasp_index = _plan_reach(
+                    self._sim, self._current_state, self._target.name
+                )
+                self._reach_configurations = reach_plan
+                self._current_approach_plan = _remap_joint_plan(
+                    self._sim, self._current_state, reach_plan[pre_grasp_index + 1 :]
+                )
+            target_joints = self._current_approach_plan.pop(0)
+            if not self._current_approach_plan:
+                self._approached = True
+            return _arm_action(self._joint_infos, target_joints, self._current_state)
+
+        if not self._closed_gripper:
+            finger_state = self._current_state.finger_state
+            if finger_state > GRIPPER_CLOSE_THRESHOLD and np.isclose(
+                finger_state, self._last_gripper_state, atol=0.02
+            ):
+                self._closed_gripper = True
+            self._last_gripper_state = finger_state
+            return np.array([0.0] * 10 + [-1.0], dtype=np.float32)
+
+        if not self._lifted:
+            if self._current_stow_plan is None:
+                assert self._reach_configurations is not None
+                stow_configs = _plan_stow(
+                    self._sim, self._current_state, self._reach_configurations
+                )
+                self._current_stow_plan = _remap_joint_plan(
+                    self._sim, self._current_state, stow_configs
+                )
+            target_joints = self._current_stow_plan.pop(0)
+            if not self._current_stow_plan:
+                self._lifted = True
+            return _arm_action(self._joint_infos, target_joints, self._current_state)
+
+        raise ValueError("Invalid state")
+
+    def observe(self, x: ObjectCentricState) -> None:
+        self._current_state = x
+
+    def predict_outcome(self, x: ObjectCentricState, params: Any) -> ObjectCentricState:
+        """Predict the post-grasp state (holding, at the carrying pose) from ``x``."""
+        del params
+        assert isinstance(x, CylinderShelf3DObjectCentricState)
+        return _predict_grasp_outcome(self._sim, x, self._target.name)
 
 
 def _set_base_pose(state: ObjectCentricState, base_pose: SE2Pose) -> None:
@@ -885,7 +988,7 @@ class GroundPlaceController(
 
                 ee_start = self._sim.robot.arm.get_end_effector_pose()
                 start_pitch = _approach_pitch(matrix_from_quat(ee_start.orientation))
-                path_targets = _interpolated_path_targets(
+                path_targets, _ = _interpolated_path_targets(
                     np.array(ee_start.position),
                     start_pitch,
                     pre_place_position,
@@ -1009,8 +1112,14 @@ def create_lifted_controllers(
     del action_space
 
     # Create partial controller classes that include the sim
-    class PickController(GroundPickController):
-        """Controller for picking up a cylinder."""
+    class MoveToPreGraspController(GroundMoveToPreGraspController):
+        """Controller for staging the base and reaching the pre-grasp pose."""
+
+        def __init__(self, objects):
+            super().__init__(objects, sim)
+
+    class GraspController(GroundGraspController):
+        """Controller for the last mile of the grasp."""
 
         def __init__(self, objects):
             super().__init__(objects, sim)
@@ -1026,23 +1135,28 @@ def create_lifted_controllers(
     target = Variable("?target", Kinematic3DCuboidType)
 
     # Lifted controllers
-    pick_controller: LiftedParameterizedController = LiftedParameterizedController(
-        [robot, target],
-        PickController,
-        Box(
-            low=np.array(
-                [
-                    MOVE_TO_TARGET_DISTANCE_BOUNDS[0],
-                    MOVE_TO_TARGET_ROT_BOUNDS[0],
-                ]
+    move_to_pre_grasp_controller: LiftedParameterizedController = (
+        LiftedParameterizedController(
+            [robot, target],
+            MoveToPreGraspController,
+            Box(
+                low=np.array(
+                    [
+                        MOVE_TO_TARGET_DISTANCE_BOUNDS[0],
+                        MOVE_TO_TARGET_ROT_BOUNDS[0],
+                    ]
+                ),
+                high=np.array(
+                    [
+                        MOVE_TO_TARGET_DISTANCE_BOUNDS[1],
+                        MOVE_TO_TARGET_ROT_BOUNDS[1],
+                    ]
+                ),
             ),
-            high=np.array(
-                [
-                    MOVE_TO_TARGET_DISTANCE_BOUNDS[1],
-                    MOVE_TO_TARGET_ROT_BOUNDS[1],
-                ]
-            ),
-        ),
+        )
+    )
+    grasp_controller: LiftedParameterizedController = LiftedParameterizedController(
+        [robot, target], GraspController
     )
 
     # Create variables for lifted controllers
@@ -1073,6 +1187,7 @@ def create_lifted_controllers(
     )
 
     return {
-        "pick": pick_controller,
+        "move_to_pre_grasp": move_to_pre_grasp_controller,
+        "grasp": grasp_controller,
         "place": place_controller,
     }

--- a/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
@@ -12,12 +12,17 @@ from kinder.envs.kinematic3d.cylinder_shelf3d import ObjectCentricCylinderShelf3
 from relational_structs.spaces import ObjectCentricBoxSpace
 
 from kinder_models.kinematic3d.cylinder_shelf3d.parameterized_skills import (
+    PRE_GRASP_POSITION_TOL,
     create_lifted_controllers,
+    get_grasp_positions,
+    is_at_pre_grasp,
 )
 from kinder_models.magic import make_magic_lifted_controller
 from kinder_models.structs import SkillCall
 
 kinder.register_all_environments()
+
+_STAGING_PARAMS = np.array([0.8, 0.0])
 
 
 def _run_controller(env, controller, state, max_steps=600):
@@ -31,26 +36,149 @@ def _run_controller(env, controller, state, max_steps=600):
     raise AssertionError("Controller did not terminate")
 
 
-def test_pick_predict_outcome_matches_rollout():
-    """The pick's outcome model agrees with actually running the pick controller."""
+def _make_env_and_controllers(seed=456):
     env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
-    init_state, _ = env.reset(seed=456)
+    init_state, _ = env.reset(seed=seed)
     sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
     controllers = create_lifted_controllers(env.action_space, sim)
-    robot = init_state.get_object_from_name("robot")
-    target = init_state.get_object_from_name("cylinder0")
-    params = np.array([0.8, 0.0])
+    return env, sim, controllers, init_state
 
-    controller = controllers["pick"].ground((robot, target))
-    predicted = controller.predict_outcome(init_state, params)
 
-    controller = controllers["pick"].ground((robot, target))
-    controller.reset(init_state, params)
-    actual = _run_controller(env, controller, init_state)
+def _move_to_pre_grasp(env, controllers, state, params=_STAGING_PARAMS):
+    robot = state.get_object_from_name("robot")
+    target = state.get_object_from_name("cylinder0")
+    controller = controllers["move_to_pre_grasp"].ground((robot, target))
+    controller.reset(state, params)
+    return _run_controller(env, controller, state)
 
-    assert predicted.grasped_object == "cylinder0"
-    assert actual.grasped_object == "cylinder0"
-    assert predicted.get(target, "pose_z") > 0.3
+
+def _grasp(env, controllers, state):
+    robot = state.get_object_from_name("robot")
+    target = state.get_object_from_name("cylinder0")
+    controller = controllers["grasp"].ground((robot, target))
+    controller.reset(
+        state, controller.sample_parameters(state, np.random.default_rng(0))
+    )
+    return _run_controller(env, controller, state)
+
+
+def _place(env, controllers, state, rng):
+    """Run the place, resampling on infeasible draws just as the planner does."""
+    robot = state.get_object_from_name("robot")
+    target = state.get_object_from_name("cylinder0")
+    shelf = state.get_object_from_name("shelf")
+    for _ in range(8):
+        controller = controllers["place"].ground((robot, target, shelf))
+        controller.reset(state, controller.sample_parameters(state, rng))
+        try:
+            return _run_controller(env, controller, state)
+        except TrajectorySamplingFailure:
+            continue
+    raise AssertionError("Place controller never terminated")
+
+
+def _assert_on_shelf(sim, state):
+    target = state.get_object_from_name("cylinder0")
+    half_height = state.get(target, "half_extent_z")
+    resting_zs = [z + half_height for z in sim.config.get_layer_surface_zs()]
+    cylinder_z = state.get(target, "pose_z")
+    assert any(
+        abs(cylinder_z - resting_z) < 0.05 for resting_z in resting_zs
+    ), f"Cylinder z {cylinder_z} is not resting on a shelf board"
+    assert state.grasped_object is None
+
+
+def test_move_to_pre_grasp_reaches_pre_grasp_pose():
+    """MoveToPreGrasp ends with the empty gripper at the pre-grasp position."""
+    env, sim, controllers, init_state = _make_env_and_controllers()
+    assert not is_at_pre_grasp(sim, init_state, "cylinder0")
+    state = _move_to_pre_grasp(env, controllers, init_state)
+    assert state.grasped_object is None
+    assert is_at_pre_grasp(sim, state, "cylinder0")
+    sim.set_state(state)
+    ee_position = np.array(sim.robot.arm.get_end_effector_pose().position)
+    _, pre_grasp_position = get_grasp_positions(state, "cylinder0")
+    assert np.linalg.norm(ee_position - pre_grasp_position) < PRE_GRASP_POSITION_TOL
+    env.close()
+    sim.close()
+
+
+def test_move_to_pre_grasp_grasp_and_place():
+    """The three skills in sequence pick the cylinder off the floor and place it on a
+    shelf board."""
+    env = kinder.make(
+        "kinder/KinematicCylinderShelf3D-o1-v0",
+        render_mode="rgb_array",
+        use_gui=False,
+        realistic_bg=True,
+    )
+    if MAKE_VIDEOS:
+        env = RecordVideo(env, "unit_test_videos", name_prefix="CylinderShelf3D")
+    obs, _ = env.reset(seed=123)
+    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+    state = env.observation_space.devectorize(obs)
+    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    controllers = create_lifted_controllers(env.action_space, sim)
+    robot = state.get_object_from_name("robot")
+    target = state.get_object_from_name("cylinder0")
+    shelf = state.get_object_from_name("shelf")
+    rng = np.random.default_rng(123)
+
+    def _run(controller, state):
+        for _ in range(500):
+            action = controller.step()
+            obs, _, _, _, _ = env.step(action)
+            state = env.observation_space.devectorize(obs)
+            controller.observe(state)
+            if controller.terminated():
+                return state
+        raise AssertionError("Controller did not terminate")
+
+    stage = controllers["move_to_pre_grasp"].ground((robot, target))
+    stage.reset(state, stage.sample_parameters(state, rng))
+    state = _run(stage, state)
+    assert is_at_pre_grasp(sim, state, "cylinder0")
+
+    grasp = controllers["grasp"].ground((robot, target))
+    grasp.reset(state, grasp.sample_parameters(state, rng))
+    state = _run(grasp, state)
+    assert state.grasped_object == "cylinder0"
+    assert state.get(target, "pose_z") > 0.3, "Cylinder was not lifted"
+    assert not is_at_pre_grasp(sim, state, "cylinder0")
+
+    # The place resamples on infeasible draws, just as the planner does.
+    rng = np.random.default_rng(123)
+    placed = False
+    for _ in range(8):
+        place = controllers["place"].ground((robot, target, shelf))
+        place.reset(state, place.sample_parameters(state, rng))
+        try:
+            state = _run(place, state)
+            placed = True
+            break
+        except TrajectorySamplingFailure:
+            continue
+    assert placed, "Place controller never terminated"
+    _assert_on_shelf(sim, state)
+    env.close()
+
+
+def test_grasp_any_approach_angle():
+    """The side grasp works from arbitrary approach angles around the cylinder."""
+    env, sim, controllers, _ = _make_env_and_controllers()
+    for approach_rot in [-2.5, 0.0, 2.5]:
+        state, _ = env.reset(seed=456)
+        state = _move_to_pre_grasp(
+            env, controllers, state, params=np.array([0.8, approach_rot])
+        )
+        state = _grasp(env, controllers, state)
+        target = state.get_object_from_name("cylinder0")
+        assert state.get(target, "pose_z") > 0.3, f"No lift for rot={approach_rot}"
+    env.close()
+    sim.close()
+
+
+def _assert_robot_close(predicted, actual, target):
     assert np.allclose(
         [predicted.base_pose.x, predicted.base_pose.y, predicted.base_pose.rot],
         [actual.base_pose.x, actual.base_pose.y, actual.base_pose.rot],
@@ -64,23 +192,50 @@ def test_pick_predict_outcome_matches_rollout():
     assert np.allclose(joint_error, 0.0, atol=2e-2)
     assert np.isclose(predicted.finger_state, actual.finger_state, atol=1e-2)
     assert np.allclose(
-        predicted.get_object_pose("cylinder0").position,
-        actual.get_object_pose("cylinder0").position,
+        predicted.get_object_pose(target.name).position,
+        actual.get_object_pose(target.name).position,
         atol=2e-2,
     )
+
+
+def test_move_to_pre_grasp_predict_outcome_matches_rollout():
+    """MoveToPreGrasp's outcome model agrees with actually running the controller."""
+    env, sim, controllers, init_state = _make_env_and_controllers()
+    robot = init_state.get_object_from_name("robot")
+    target = init_state.get_object_from_name("cylinder0")
+    controller = controllers["move_to_pre_grasp"].ground((robot, target))
+    predicted = controller.predict_outcome(init_state, _STAGING_PARAMS)
+    actual = _move_to_pre_grasp(env, controllers, init_state)
+    assert is_at_pre_grasp(sim, predicted, "cylinder0")
+    _assert_robot_close(predicted, actual, target)
     env.close()
     sim.close()
 
 
-def test_pick_predict_outcome_rejects_infeasible_parameters():
-    """Staging the base inside the shelf fails the prediction like a real sample."""
-    env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
-    init_state, _ = env.reset(seed=456)
-    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
-    controllers = create_lifted_controllers(env.action_space, sim)
+def test_grasp_predict_outcome_matches_rollout():
+    """Grasp's outcome model agrees with actually running the grasp from the pre-grasp
+    pose."""
+    env, sim, controllers, init_state = _make_env_and_controllers()
     robot = init_state.get_object_from_name("robot")
     target = init_state.get_object_from_name("cylinder0")
-    controller = controllers["pick"].ground((robot, target))
+    staged = _move_to_pre_grasp(env, controllers, init_state)
+    controller = controllers["grasp"].ground((robot, target))
+    predicted = controller.predict_outcome(staged, np.zeros(0))
+    actual = _grasp(env, controllers, staged)
+    assert predicted.grasped_object == "cylinder0"
+    assert actual.grasped_object == "cylinder0"
+    assert predicted.get(target, "pose_z") > 0.3
+    _assert_robot_close(predicted, actual, target)
+    env.close()
+    sim.close()
+
+
+def test_move_to_pre_grasp_predict_outcome_rejects_infeasible_parameters():
+    """Staging the base inside the shelf fails the prediction like a real sample."""
+    env, sim, controllers, init_state = _make_env_and_controllers()
+    robot = init_state.get_object_from_name("robot")
+    target = init_state.get_object_from_name("cylinder0")
+    controller = controllers["move_to_pre_grasp"].ground((robot, target))
 
     # Put the cylinder 0.8 m in front of the shelf and stage the base 0.8 m
     # behind the cylinder, i.e. at the shelf's own position.
@@ -96,175 +251,28 @@ def test_pick_predict_outcome_rejects_infeasible_parameters():
     sim.close()
 
 
-def test_magic_pick_then_real_place():
-    """A magic pick's predicted state is a valid start for the real place skill."""
-    env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
-    init_state, _ = env.reset(seed=456)
-    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
-    controllers = create_lifted_controllers(env.action_space, sim)
+def test_magic_grasp_then_real_place():
+    """After a real MoveToPreGrasp, a magic Grasp's predicted state is a valid start for
+    the real place skill."""
+    env, sim, controllers, init_state = _make_env_and_controllers()
     robot = init_state.get_object_from_name("robot")
     target = init_state.get_object_from_name("cylinder0")
-    shelf = init_state.get_object_from_name("shelf")
+    staged = _move_to_pre_grasp(env, controllers, init_state)
 
-    magic_pick = make_magic_lifted_controller(controllers["pick"], "Pick")
-    rng = np.random.default_rng(456)
-    pick = magic_pick.ground((robot, target))
-    pick.reset(init_state, np.array([0.8, 0.0]))
-    call = pick.step()
-    assert pick.terminated()
+    magic_grasp = make_magic_lifted_controller(controllers["grasp"], "Grasp")
+    grasp = magic_grasp.ground((robot, target))
+    grasp.reset(staged, grasp.sample_parameters(staged, np.random.default_rng(0)))
+    call = grasp.step()
+    assert grasp.terminated()
     assert isinstance(call, SkillCall)
-    assert call.skill_name == "Pick"
+    assert call.skill_name == "Grasp"
     assert call.objects == (robot, target)
-    state = call.predicted_state
-    assert state.grasped_object == "cylinder0"
+    assert call.predicted_state.grasped_object == "cylinder0"
 
-    # Execute the magic pick by teleporting the env to the predicted state.
-    env.set_state(state)
+    # Execute the magic grasp by teleporting the env to the predicted state.
+    env.set_state(call.predicted_state)
     state = env.get_state()
-
-    placed = False
-    for _ in range(8):
-        place = controllers["place"].ground((robot, target, shelf))
-        place.reset(state, place.sample_parameters(state, rng))
-        try:
-            state = _run_controller(env, place, state)
-            placed = True
-            break
-        except TrajectorySamplingFailure:
-            continue
-    assert placed, "Place controller never terminated from the predicted state"
-
-    half_height = state.get(target, "half_extent_z")
-    resting_zs = [z + half_height for z in sim.config.get_layer_surface_zs()]
-    cylinder_z = state.get(target, "pose_z")
-    assert any(abs(cylinder_z - z) < 0.05 for z in resting_zs)
-    assert state.grasped_object is None
+    state = _place(env, controllers, state, np.random.default_rng(456))
+    _assert_on_shelf(sim, state)
     env.close()
     sim.close()
-
-
-def test_pick_and_place_controller():
-    """Test pick and place controllers in the CylinderShelf3D environment."""
-    env = kinder.make(
-        "kinder/KinematicCylinderShelf3D-o1-v0",
-        render_mode="rgb_array",
-        use_gui=False,
-        realistic_bg=True,
-    )
-    if MAKE_VIDEOS:
-        env = RecordVideo(env, "unit_test_videos", name_prefix="CylinderShelf3D")
-
-    obs, _ = env.reset(seed=123)
-    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
-    state = env.observation_space.devectorize(obs)
-
-    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
-    controllers = create_lifted_controllers(
-        env.action_space,
-        sim,
-    )
-    lifted_controller = controllers["pick"]
-    robot = state.get_object_from_name("robot")
-    target = state.get_object_from_name("cylinder0")
-    object_parameters = (robot, target)
-    controller = lifted_controller.ground(object_parameters)
-
-    rng = np.random.default_rng(123)
-    params = controller.sample_parameters(state, rng)
-
-    controller.reset(state, params)
-    for _ in range(500):
-        action = controller.step()
-        obs, _, _, _, _ = env.step(action)
-        next_state = env.observation_space.devectorize(obs)
-        controller.observe(next_state)
-        state = next_state
-        if controller.terminated():
-            break
-    else:
-        assert False, "Controller did not terminate"
-
-    # The cylinder should have been picked up: it is well above the ground.
-    target = state.get_object_from_name("cylinder0")
-    assert state.get(target, "pose_z") > 0.3, "Cylinder was not lifted"
-
-    lifted_controller = controllers["place"]
-    robot = state.get_object_from_name("robot")
-    target = state.get_object_from_name("cylinder0")
-    target_shelf = state.get_object_from_name("shelf")
-    object_parameters = (robot, target, target_shelf)
-
-    # The place resamples on infeasible draws (e.g. a staging distance
-    # whose reach or collision checks fail), just as the planner does.
-    rng = np.random.default_rng(123)
-    placed = False
-    for _ in range(8):
-        controller = lifted_controller.ground(object_parameters)
-        params = controller.sample_parameters(state, rng)
-        controller.reset(state, params)
-        try:
-            for _ in range(500):
-                action = controller.step()
-                obs, _, _, _, _ = env.step(action)
-                next_state = env.observation_space.devectorize(obs)
-                controller.observe(next_state)
-                state = next_state
-                if controller.terminated():
-                    placed = True
-                    break
-            if placed:
-                break
-        except TrajectorySamplingFailure:
-            continue
-    assert placed, "Place controller never terminated"
-
-    # The cylinder should be standing on a shelf board at resting height.
-    config = sim.config
-    target = state.get_object_from_name("cylinder0")
-    half_height = state.get(target, "half_extent_z")
-    resting_zs = [z + half_height for z in config.get_layer_surface_zs()]
-    cylinder_z = state.get(target, "pose_z")
-    assert any(
-        abs(cylinder_z - resting_z) < 0.05 for resting_z in resting_zs
-    ), f"Cylinder z {cylinder_z} is not resting on a shelf board"
-
-    env.close()
-
-
-def test_pick_controller_any_approach_angle():
-    """The side grasp works from arbitrary approach angles around the cylinder."""
-    env = kinder.make(
-        "kinder/KinematicCylinderShelf3D-o1-v0",
-        use_gui=False,
-        realistic_bg=False,
-    )
-    obs, _ = env.reset(seed=456)
-    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
-    init_state = env.observation_space.devectorize(obs)
-
-    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
-    controllers = create_lifted_controllers(env.action_space, sim)
-    lifted_controller = controllers["pick"]
-    robot = init_state.get_object_from_name("robot")
-    target = init_state.get_object_from_name("cylinder0")
-
-    for approach_rot in [-2.5, 0.0, 2.5]:
-        obs, _ = env.reset(seed=456)
-        state = env.observation_space.devectorize(obs)
-        controller = lifted_controller.ground((robot, target))
-        params = np.array([0.8, approach_rot])
-        controller.reset(state, params)
-        for _ in range(500):
-            action = controller.step()
-            obs, _, _, _, _ = env.step(action)
-            next_state = env.observation_space.devectorize(obs)
-            controller.observe(next_state)
-            state = next_state
-            if controller.terminated():
-                break
-        else:
-            assert False, f"Controller did not terminate for rot={approach_rot}"
-        target = state.get_object_from_name("cylinder0")
-        assert state.get(target, "pose_z") > 0.3, f"No lift for rot={approach_rot}"
-
-    env.close()


### PR DESCRIPTION
## Summary

Splits the CylinderShelf3D pick into two skills so that only the last mile can be planned as magic while the approach stays planned motion:

- **`MoveToPreGrasp(robot, target)`**: parameters are the base staging distance and the approach angle around the cylinder (as the old pick). It motion-plans the base to the staged pose, then reaches the arm along leg one of the planar reach to the pre-grasp pose (10 cm behind the grasp along the approach axis). Effect: `AtPreGrasp(robot, target)`.
- **`Grasp(robot, target)`**: no parameters. From the pre-grasp pose it pushes straight in to the grasp (leg two of the reach, re-solved from the current state), closes the gripper, and stows to the carrying pose by replaying the reach in reverse until the held cylinder would collide. Preconditions: `AtPreGrasp`, `HandEmpty`, `OnGround`; effect `Holding`.

`AtPreGrasp` is computed geometrically: nothing grasped and the end effector within `PRE_GRASP_POSITION_TOL` (3 cm) of the pre-grasp position (`get_grasp_positions` / `is_at_pre_grasp` in kinder_models). It is false again after the grasp because something is held, so the operator's delete effect checks out even when the carrying pose happens to coincide with the pre-grasp configuration.

Both controllers implement `OutcomePredictor`. `Grasp.predict_outcome` is the old pick outcome model minus the staging (grasp registered by the sim's own grasp rule at the reach's final configuration, arm at the carrying pose), so `magic_skills=("Grasp",)` in the planning models yields a plan that drives to the pre-grasp pose with planned motion and holds a single `SkillCall` for the grasp. `magic_skills=("MoveToPreGrasp", "Grasp")` reproduces the previous fully magic pick. The reach and stow planning are now module-level helpers shared by the controllers and the outcome models.

`create_lifted_controllers` returns `move_to_pre_grasp`, `grasp`, and `place`; the `pick` key is gone.

## Tests

kinder-models (`tests/kinematic3d/cylinder_shelf3d/…`): end effector lands within tolerance of the pre-grasp position and `is_at_pre_grasp` is true only there; the three skills in sequence place the cylinder on a shelf board; grasps from three approach angles; both outcome models match rollouts (base pose, joints mod 2π, finger state, cylinder pose); infeasible staging raises; a magic grasp after a real MoveToPreGrasp is a valid start for the real place.

kinder-bilevel-planning (`tests/env_models/kinematic3d/test_cylinder_shelf3d.py`): with `magic_skills=("Grasp",)` the plan has planned actions up to the gap and exactly one `SkillCall`; `AtPreGrasp` holds before the call and `Holding` after; executing with the call as a teleport reaches the goal. The no-magic plan also executes to the goal.

Follow-up in prpl-tidybot: switch the config example and tests from `env.magic_skills=[Pick]` to `[Grasp]`, then the gamepad teleop gap executor for the last mile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
