### PR TITLE
CylinderShelf3D: base_clearance for the skills' base motion planning

### DIFF
--- a/kinder-bilevel-planning/pyproject.toml
+++ b/kinder-bilevel-planning/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
    "prpl_utils>=0.0.7",
    "relational_structs>=0.0.1",
    "tomsgeoms2d>=0.0.1",
-   "pybullet_helpers>=0.0.1",
+   "pybullet_helpers>=0.1.2",
    "bilevel_planning>=0.1.4",
 ]
 

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/kinematic3d/cylinder_shelf3d.py
@@ -57,6 +57,7 @@ def create_bilevel_planning_models(
     config: CylinderShelf3DEnvConfig | None = None,
     magic_skills: Collection[str] = (),
     place_params: Sequence[Sequence[float] | None] | None = None,
+    base_clearance: float = 0.0,
 ) -> SesameModels:
     """Create the env models for cylinder shelf 3D.
 
@@ -83,6 +84,11 @@ def create_bilevel_planning_models(
     (see ``GroundPlaceController``); ``None`` keeps sampling everything for
     that cylinder. Fixed placements make planning with several cylinders
     faster and their layout on the shelf predictable.
+
+    ``base_clearance`` is the distance (m) the base must keep from the shelf
+    and the cylinders along its planned paths (the planner's collision check
+    is otherwise contact-only). A few centimetres covers a real base whose
+    cables stick out past its chassis, plus its tracking error.
     """
     assert isinstance(observation_space, ObjectCentricBoxSpace)
     assert isinstance(action_space, Kinematic3DRobotActionSpace)
@@ -264,7 +270,7 @@ def create_bilevel_planning_models(
         if params is not None
     }
     lifted_controllers = create_lifted_controllers(
-        action_space, sim, fixed_place_params
+        action_space, sim, fixed_place_params, base_clearance
     )
     for skill_name in magic_skills:
         key = _SKILL_CONTROLLER_KEYS[skill_name]

--- a/kinder-bilevel-planning/tests/env_models/kinematic3d/test_cylinder_shelf3d.py
+++ b/kinder-bilevel-planning/tests/env_models/kinematic3d/test_cylinder_shelf3d.py
@@ -189,3 +189,14 @@ def test_cylinder_shelf3d_two_cylinders_first_skeleton():
     assert [c.skill_name for c in calls] == ["MoveToPreGrasp", "Grasp"] * 2
     assert {c.objects[1].name for c in calls} == {"cylinder0", "cylinder1"}
     env.close()
+
+
+def test_cylinder_shelf3d_plans_with_base_clearance():
+    """base_clearance reaches the skills' base motion planner and planning still
+    succeeds with a few centimetres of it."""
+    env = kinder.make("kinder/KinematicCylinderShelf3D-o1-v0", allow_state_access=True)
+    _, agent = _make_agent(env, magic_skills=("Grasp",), base_clearance=0.05)
+    obs, info = env.reset(seed=123)
+    agent.reset(obs, info)
+    assert len(agent.plan()) > 0
+    env.close()

--- a/kinder-models/pyproject.toml
+++ b/kinder-models/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
    "flask-socketio",
    "opencv-python>=4.9.0",
    "kindergarden>=0.2.4",
+   "pybullet_helpers>=0.1.2",
    "relational_structs>=0.0.1",
    "bilevel_planning>=0.1.2",
 ]

--- a/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
@@ -67,6 +67,7 @@ from pybullet_helpers.joint import (
     get_jointwise_difference,
 )
 from pybullet_helpers.motion_planning import (
+    MotionPlanningHyperparameters,
     remap_joint_position_plan_to_constant_distance,
     remap_se2_pose_plan_to_constant_distance,
     run_single_arm_mobile_base_motion_planning,
@@ -533,11 +534,18 @@ class GroundMoveToPreGraspController(
         self,
         objects: Sequence[Object],
         sim: ObjectCentricCylinderShelf3DEnv,
+        base_clearance: float = 0.0,
     ) -> None:
+        """``base_clearance`` is the distance (m) the base must keep from the
+        shelf and the cylinders along its planned path (see
+        ``MotionPlanningHyperparameters.platform_clearance``)."""
         super().__init__(objects)
         self._sim = sim
         self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
+        self._base_motion_hyperparameters = MotionPlanningHyperparameters(
+            platform_clearance=base_clearance
+        )
         self._current_params: np.ndarray | None = None
         self._current_plan: list[SE2Pose] | None = None
         self._current_arm_joint_plan: list[JointPositions] | None = None
@@ -583,6 +591,7 @@ class GroundMoveToPreGraspController(
                 target_base_pose,
                 collision_bodies=self._sim._get_collision_object_ids(),  # pylint: disable=protected-access
                 seed=0,  # for determinism
+                hyperparameters=self._base_motion_hyperparameters,
             )
             if base_plan is None:
                 raise TrajectorySamplingFailure("Base motion planning failed")
@@ -812,15 +821,21 @@ class GroundPlaceController(
         objects: Sequence[Object],
         sim: ObjectCentricCylinderShelf3DEnv,
         place_params: Sequence[float] | None = None,
+        base_clearance: float = 0.0,
     ) -> None:
         """``place_params`` fixes the placement instead of sampling it: ``(x, y)``
         fixes the offset on the shelf and leaves the base staging distance to
         the sampler; ``(x, y, base_distance)`` fixes all three, so the skill has
-        nothing left to sample."""
+        nothing left to sample. ``base_clearance`` is the distance (m) the base
+        must keep from the shelf and the other cylinders along its planned path
+        (see ``MotionPlanningHyperparameters.platform_clearance``)."""
         super().__init__(objects)
         self._sim = sim
         self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target, self._target_shelf = objects
+        self._base_motion_hyperparameters = MotionPlanningHyperparameters(
+            platform_clearance=base_clearance
+        )
         if place_params is not None and len(place_params) not in (2, 3):
             raise ValueError(
                 f"place_params must be (x, y) or (x, y, base_distance), got "
@@ -904,6 +919,7 @@ class GroundPlaceController(
                 seed=0,  # for determinism
                 held_object=grasped_object_id,
                 base_link_to_held_obj=grasped_object_transform,
+                hyperparameters=self._base_motion_hyperparameters,
             )
 
             if base_plan is None:
@@ -1130,12 +1146,15 @@ def create_lifted_controllers(
     action_space: Kinematic3DRobotActionSpace,
     sim: ObjectCentricCylinderShelf3DEnv,
     place_params: Mapping[str, Sequence[float]] | None = None,
+    base_clearance: float = 0.0,
 ) -> dict[str, LiftedParameterizedController]:
     """Create lifted parameterized controllers for CylinderShelf3D.
 
     ``place_params`` maps a cylinder name to its fixed placement, ``(x, y)``
     or ``(x, y, base_distance)`` (see ``GroundPlaceController``); cylinders
-    not in the mapping get sampled placements.
+    not in the mapping get sampled placements. ``base_clearance`` is the
+    distance (m) the base keeps from the shelf and the cylinders along its
+    planned paths.
     """
     del action_space
     fixed_place_params = dict(place_params or {})
@@ -1145,7 +1164,7 @@ def create_lifted_controllers(
         """Controller for staging the base and reaching the pre-grasp pose."""
 
         def __init__(self, objects):
-            super().__init__(objects, sim)
+            super().__init__(objects, sim, base_clearance)
 
     class GraspController(GroundGraspController):
         """Controller for the last mile of the grasp."""
@@ -1157,7 +1176,9 @@ def create_lifted_controllers(
         """Controller for placing a cylinder."""
 
         def __init__(self, objects):
-            super().__init__(objects, sim, fixed_place_params.get(objects[1].name))
+            super().__init__(
+                objects, sim, fixed_place_params.get(objects[1].name), base_clearance
+            )
 
     # Create variables for lifted controllers
     robot = Variable("?robot", Kinematic3DRobotType)

--- a/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
@@ -131,6 +131,12 @@ PRE_PLACE_BACKOFF = 0.10
 PRE_PLACE_LIFT = 0.02
 # Spacing of the continuation targets along the in-plane reach path.
 PLANAR_PATH_STEP = 0.025
+# Interpolation points the base motion planner collision-checks per RRT
+# edge. Edges run up to ~0.2 m with the base turning along them, and its
+# corners sweep out further than its centre moves, so the default 10
+# lets the executed path dip 2-3 cm inside the configured base clearance
+# between checks; 25 keeps it at the clearance at negligible cost.
+BASE_MOTION_EXTEND_NUM_INTERP = 25
 
 # The arm joints that move during the planar reach: joint 1 (index 0)
 # for the small lateral plane correction, and the pitch joints 2, 4, 6
@@ -544,7 +550,8 @@ class GroundMoveToPreGraspController(
         self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target = objects
         self._base_motion_hyperparameters = MotionPlanningHyperparameters(
-            platform_clearance=base_clearance
+            platform_clearance=base_clearance,
+            birrt_extend_num_interp=BASE_MOTION_EXTEND_NUM_INTERP,
         )
         self._current_params: np.ndarray | None = None
         self._current_plan: list[SE2Pose] | None = None
@@ -834,7 +841,8 @@ class GroundPlaceController(
         self._joint_infos = sim.robot.arm.get_arm_joint_infos()[:7]
         self._robot, self._target, self._target_shelf = objects
         self._base_motion_hyperparameters = MotionPlanningHyperparameters(
-            platform_clearance=base_clearance
+            platform_clearance=base_clearance,
+            birrt_extend_num_interp=BASE_MOTION_EXTEND_NUM_INTERP,
         )
         if place_params is not None and len(place_params) not in (2, 3):
             raise ValueError(

--- a/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
@@ -2,6 +2,7 @@
 
 import kinder
 import numpy as np
+import pybullet as p
 import pytest
 from bilevel_planning.trajectory_samplers.trajectory_sampler import (
     TrajectorySamplingFailure,
@@ -331,5 +332,44 @@ def test_place_with_fixed_offset_and_base_distance():
         create_lifted_controllers(
             env.action_space, sim, place_params={"cylinder0": (0.10,)}
         )["place"].ground((robot, target, shelf))
+    env.close()
+    sim.close()
+
+
+def test_base_clearance_keeps_the_base_off_the_shelf_and_cylinder():
+    """With base_clearance set, the base never comes closer than that to the shelf
+    or the (still standing) cylinder while driving to the pre-grasp pose."""
+    clearance = 0.08
+    env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    state, _ = env.reset(seed=456)
+    sim = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    controllers = create_lifted_controllers(
+        env.action_space, sim, base_clearance=clearance
+    )
+    robot = state.get_object_from_name("robot")
+    target = state.get_object_from_name("cylinder0")
+    controller = controllers["move_to_pre_grasp"].ground((robot, target))
+    controller.reset(state, _STAGING_PARAMS)
+    visited = [state]
+    for _ in range(600):
+        state, _, _, _, _ = env.step(controller.step())
+        controller.observe(state)
+        visited.append(state)
+        if controller.terminated():
+            break
+    assert controller.terminated()
+
+    base_id = env.robot.base.robot_id
+    # pylint: disable=protected-access
+    obstacles = {"shelf": env._shelf_id, "cylinder0": env._cylinders["cylinder0"]}
+    # pylint: enable=protected-access
+    for visited_state in visited:
+        env.set_state(visited_state)
+        for name, body in obstacles.items():
+            points = p.getClosestPoints(
+                base_id, body, 1.0, physicsClientId=env.physics_client_id
+            )
+            distance = min((point[8] for point in points), default=1.0)
+            assert distance >= clearance - 0.03, (name, distance)
     env.close()
     sim.close()


### PR DESCRIPTION
## Summary

`create_bilevel_planning_models(..., base_clearance=0.05)` (and `create_lifted_controllers(..., base_clearance=...)`) sets the distance in metres the base must keep from the shelf and the cylinders along the base paths that MoveToPreGrasp and Place plan. It goes to pybullet_helpers' new `MotionPlanningHyperparameters.platform_clearance` (Princeton-Robot-Planning-and-Learning/prpl-mono#538). Default 0 keeps today's behaviour.

The skills also collision-check base motion edges at 25 interpolation points instead of the default 10: the executed path is re-sampled along the RRT edges, and with the base turning as it goes, its corners dipped 2–3 cm inside the clearance between checks (replayed real runs: closest approach 0.024 m at a 0.05 m clearance with 10 checks, 0.052 m with 25; ~0.1 s more planning).

Why: the planner's base collision check is contact-only, so a planned path can graze a cylinder with millimetres of modelled clearance (Princeton-Robot-Planning-and-Learning/prpl-tidybot#123). A real base with cables past its chassis and ~2 cm of tracking error then knocks the can over.

## Tests

- kinder-models: with `base_clearance=0.08` the base stays at least that far (minus a 3 cm interpolation allowance) from the shelf and the standing cylinder at every state on its way to the pre-grasp pose.
- kinder-bilevel-planning: planning with a clearance succeeds.

## Dependency

Blocked on prpl-mono#538 shipping as pybullet_helpers 0.1.2 (the tests construct `MotionPlanningHyperparameters(platform_clearance=...)`, which 0.1.1 does not have); `kinder-models/pyproject.toml` should then require `pybullet_helpers>=0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
