### PR TITLE
CylinderShelf3D: staging poses must lie inside the base pose box

### DIFF
--- a/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/kinematic3d/cylinder_shelf3d/parameterized_skills.py
@@ -523,6 +523,22 @@ def _arm_action(
     return np.array([0.0] * 3 + delta_lst + [0.0], dtype=np.float32)
 
 
+def _check_base_pose_in_bounds(
+    sim: ObjectCentricCylinderShelf3DEnv, pose: SE2Pose, what: str
+) -> None:
+    """Raise ``TrajectorySamplingFailure`` when a sampled base pose lies outside
+    the env's base pose box. The base motion planner only samples inside the box;
+    a goal outside it (a cylinder near the floor's edge staged from the far
+    side) would otherwise be planned to and driven to."""
+    lower = sim.config.robot_base_pose_lower_bound
+    upper = sim.config.robot_base_pose_upper_bound
+    if not (lower.x <= pose.x <= upper.x and lower.y <= pose.y <= upper.y):
+        raise TrajectorySamplingFailure(
+            f"{what} ({pose.x:.2f}, {pose.y:.2f}) is outside the base pose box "
+            f"x [{lower.x:.2f}, {upper.x:.2f}] y [{lower.y:.2f}, {upper.y:.2f}]"
+        )
+
+
 class GroundMoveToPreGraspController(
     GroundParameterizedController[ObjectCentricState, np.ndarray],
     OutcomePredictor[ObjectCentricState],
@@ -592,6 +608,9 @@ class GroundMoveToPreGraspController(
             target_base_pose = get_target_robot_pose_from_parameters(
                 target_pose, self._current_params[0], self._current_params[1]
             )
+            _check_base_pose_in_bounds(
+                self._sim, target_base_pose, "Pre-grasp base pose"
+            )
             base_plan = run_single_arm_mobile_base_motion_planning(
                 self._sim.robot,
                 self._sim.robot.base.get_pose(),
@@ -660,6 +679,7 @@ class GroundMoveToPreGraspController(
         staged_base_pose = get_target_robot_pose_from_parameters(
             target_se2, params[0], params[1]
         )
+        _check_base_pose_in_bounds(self._sim, staged_base_pose, "Pre-grasp base pose")
         staged = x.copy()
         _set_base_pose(staged, staged_base_pose)
         _set_arm_joints(staged, HOME_JOINT_POSITIONS.tolist())
@@ -915,6 +935,7 @@ class GroundPlaceController(
             target_base_pose = get_target_robot_pose_from_parameters(
                 target_place_pose_se2, self._current_params[2], np.pi / 2
             )
+            _check_base_pose_in_bounds(self._sim, target_base_pose, "Place base pose")
             all_collision_ids = (
                 self._sim._get_collision_object_ids()  # pylint: disable=protected-access
             )

--- a/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
+++ b/kinder-models/tests/kinematic3d/cylinder_shelf3d/test_cylinder_shelf3d_parameterized_skills.py
@@ -9,7 +9,11 @@ from bilevel_planning.trajectory_samplers.trajectory_sampler import (
 )
 from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
-from kinder.envs.kinematic3d.cylinder_shelf3d import ObjectCentricCylinderShelf3DEnv
+from kinder.envs.kinematic3d.cylinder_shelf3d import (
+    CylinderShelf3DEnvConfig,
+    ObjectCentricCylinderShelf3DEnv,
+)
+from pybullet_helpers.geometry import SE2Pose
 from relational_structs.spaces import ObjectCentricBoxSpace
 
 from kinder_models.kinematic3d.cylinder_shelf3d.parameterized_skills import (
@@ -371,5 +375,34 @@ def test_base_clearance_keeps_the_base_off_the_shelf_and_cylinder():
             )
             distance = min((point[8] for point in points), default=1.0)
             assert distance >= clearance - 0.03, (name, distance)
+    env.close()
+    sim.close()
+
+
+def test_staging_pose_outside_the_base_box_is_rejected():
+    """A sampled pre-grasp or place base pose outside the env's base pose box is a
+    sampling failure (the planner resamples the angle), not a goal to drive to."""
+    env = ObjectCentricCylinderShelf3DEnv(num_cylinders=1, allow_state_access=True)
+    state, _ = env.reset(seed=456)
+    target = state.get_object_from_name("cylinder0")
+    cx = state.get(target, "pose_x")
+    # A box whose +x edge is just past the cylinder: staging from +x (rot 0
+    # puts the base at cx - 0.8, inside) is fine, staging from -x (rot pi puts
+    # it at cx + 0.8) is out.
+    config = CylinderShelf3DEnvConfig(
+        robot_base_pose_lower_bound=SE2Pose(-10.0, -10.0, -np.pi),
+        robot_base_pose_upper_bound=SE2Pose(cx + 0.3, 10.0, np.pi),
+    )
+    sim = ObjectCentricCylinderShelf3DEnv(
+        num_cylinders=1, config=config, allow_state_access=True
+    )
+    controllers = create_lifted_controllers(env.action_space, sim)
+    robot = state.get_object_from_name("robot")
+    controller = controllers["move_to_pre_grasp"].ground((robot, target))
+    controller.reset(state, np.array([0.8, np.pi]))
+    with pytest.raises(TrajectorySamplingFailure, match="outside the base pose box"):
+        controller.step()
+    with pytest.raises(TrajectorySamplingFailure, match="outside the base pose box"):
+        controller.predict_outcome(state, np.array([0.8, np.pi]))
     env.close()
     sim.close()


### PR DESCRIPTION
## Summary

The base motion planner only samples inside the env's base pose box (`robot_base_pose_lower_bound` / `upper_bound`), but a sampled pre-grasp or place base pose was never checked against it. A cylinder near the floor's edge, staged from the far side, gives a goal outside the box that is then planned to and driven to. Real rollout in prpl-tidybot on 2026-08-29 16:01: cylinder2 at (1.17, −0.90), pre-grasp goal at (1.91, −1.35) with the box ending at x = 1.70; the robot drove off the floor.

## Change

`_check_base_pose_in_bounds` raises `TrajectorySamplingFailure` for a staging pose outside the box, in MoveToPreGrasp (plan and `predict_outcome`) and Place, so the planner resamples the approach angle instead. Default box is ±10 m, so nothing changes for envs that don't set it.

## Test

With a box whose +x edge is 0.3 m past the cylinder, staging from −x (base at cx + 0.8) is rejected by both `step` and `predict_outcome`; the existing skill tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
