### PR TITLE
Model the Tossing room and sample compatible throw profiles

### DIFF
--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -10,6 +10,7 @@ TODO: only Tossing3D-o1 is supported; no operator says which cube a throw is aim
 from pathlib import Path
 
 import kinder
+import mujoco
 import numpy as np
 from bilevel_planning.structs import (
     LiftedSkill,
@@ -23,7 +24,8 @@ from kinder.envs.dynamic3d.object_types import (
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
 )
-from kinder.envs.dynamic3d.objects.primitive_objects import Bin
+from kinder.envs.dynamic3d.objects.fixtures import FixedCuboid
+from kinder.envs.dynamic3d.objects.primitive_objects import Bin, Cuboid
 from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBot3DRobotActionSpace
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     PyBulletSim,
@@ -119,7 +121,7 @@ def create_bilevel_planning_models(
     # Pick the cube up off the ground.
     robot = Variable("?robot", MujocoTidyBotRobotObjectType)
     cube = Variable("?cube", MujocoMovableObjectType)
-    barrier = Variable("?barrier", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoObjectType)
 
     PickCubeOperator = LiftedOperator(
         "pick_cube",
@@ -140,7 +142,7 @@ def create_bilevel_planning_models(
     # Drive to a pose to throw from, and throw.
     robot = Variable("?robot", MujocoTidyBotRobotObjectType)
     held = Variable("?held", MujocoMovableObjectType)
-    barrier = Variable("?barrier", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoObjectType)
 
     MoveToTossLocationAndTossOperator = LiftedOperator(
         "move_to_toss_location_and_toss",
@@ -172,9 +174,7 @@ def create_bilevel_planning_models(
     pybullet_sim.add_bin(
         name=BIN_NAME,
         pose=Pose(
-            tuple(
-                initial_state.get(bin_state_object, key) for key in ("x", "y", "z")
-            ),
+            tuple(initial_state.get(bin_state_object, key) for key in ("x", "y", "z")),
             tuple(
                 initial_state.get(bin_state_object, key)
                 for key in ("qx", "qy", "qz", "qw")
@@ -185,6 +185,39 @@ def create_bilevel_planning_models(
         height=bin_geometry.height,
         wall_thickness=bin_geometry.wall_thickness,
     )
+    for name, fixture in sim._fixtures_dict.items():  # pylint: disable=protected-access
+        if not isinstance(fixture, FixedCuboid) or not isinstance(
+            fixture.primitive, Cuboid
+        ):
+            continue
+        obj = initial_state.get_object_from_name(name)
+        pybullet_sim.add_box(
+            name=name,
+            pose=Pose(
+                tuple(initial_state.get(obj, key) for key in ("x", "y", "z")),
+                tuple(initial_state.get(obj, key) for key in ("qx", "qy", "qz", "qw")),
+            ),
+            dimensions=fixture.primitive.get_bounding_box_dimensions(),
+        )
+    # Task room geometry is static and deliberately independent of scene backgrounds.
+    robot_env = sim._robot_env  # pylint: disable=protected-access
+    assert robot_env is not None
+    model = robot_env.sim.model.mj_model
+    data = robot_env.sim.data.mj_data
+    for geom_id in range(model.ngeom):
+        if model.body(int(model.geom_bodyid[geom_id])).name != "tossing_room":
+            continue
+        if not (model.geom_contype[geom_id] or model.geom_conaffinity[geom_id]):
+            continue
+        assert model.geom_type[geom_id] == mujoco.mjtGeom.mjGEOM_BOX
+        quaternion = np.empty(4)
+        mujoco.mju_mat2Quat(quaternion, data.geom_xmat[geom_id])
+        pybullet_sim.add_box(
+            name=model.geom(geom_id).name,
+            pose=Pose(tuple(data.geom_xpos[geom_id]), tuple(quaternion[[1, 2, 3, 0]])),
+            dimensions=tuple(2 * model.geom_size[geom_id]),
+            state_object=False,
+        )
     controllers = create_lifted_controllers(
         action_space, sim.initial_constant_state, pybullet_sim=pybullet_sim
     )

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -7,6 +7,9 @@ so refinement backtracks over the throw alone.
 TODO: only Tossing3D-o1 is supported; no operator says which cube a throw is aimed at.
 """
 
+# MuJoCo exposes its API through a C extension.
+# pylint: disable=no-member
+
 from pathlib import Path
 
 import kinder

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
@@ -1,8 +1,11 @@
 """The tossing planner must see the same fixed obstacles as the simulator."""
 
+from typing import cast
+
 import kinder
 import numpy as np
 import pybullet as p
+from gymnasium import Env
 from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv, TidyBot3DEnv
 from kinder.envs.dynamic3d.object_types import (
     MujocoFixtureObjectType,
@@ -99,4 +102,4 @@ def test_fixed_tossing_obstacles_match_both_planning_scenes(monkeypatch) -> None
     finally:
         for planner in captured:
             planner.close()
-        env.close()
+        cast(Env, env).close()

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
@@ -1,0 +1,102 @@
+"""The tossing planner must see the same fixed obstacles as the simulator."""
+
+import kinder
+import numpy as np
+import pybullet as p
+from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv, TidyBot3DEnv
+from kinder.envs.dynamic3d.object_types import (
+    MujocoFixtureObjectType,
+    MujocoMovableObjectType,
+)
+from kinder.envs.dynamic3d.objects.fixtures import FixedCuboid
+from kinder.envs.dynamic3d.objects.primitive_objects import Cuboid
+from kinder_models.dynamic3d.tossing.parameterized_skills import (
+    MoveToTossLocationAndTossController,
+)
+from kinder_models.dynamic3d.tossing.state_abstractions import MovableIsDownX
+from kinder_models.dynamic3d.utils import (
+    PyBulletSim,
+    get_overhead_kinematic2ds,
+    get_overhead_object_se2_pose,
+    get_target_robot_pose_from_parameters,
+)
+from relational_structs import GroundAtom
+from relational_structs.spaces import ObjectCentricBoxSpace
+from tomsgeoms2d.structs import Rectangle
+
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+
+def test_fixed_tossing_obstacles_match_both_planning_scenes(monkeypatch) -> None:
+    """Fixture typing, arm collision boxes and base footprints all use real geometry."""
+    kinder.register_all_environments()
+    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array")
+    captured = []
+    original_init = PyBulletSim.__init__
+
+    def capture(self, *args, **kwargs) -> None:
+        original_init(self, *args, **kwargs)
+        captured.append(self)
+
+    monkeypatch.setattr(PyBulletSim, "__init__", capture)
+    try:
+        obs, _ = env.reset(seed=0)
+        assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+        assert isinstance(env.unwrapped, TidyBot3DEnv)
+        state = env.observation_space.devectorize(obs)
+        models = create_bilevel_planning_models(
+            "tidybot3d_tossing3D",
+            env.observation_space,
+            env.action_space,
+            num_objects=1,
+        )
+        planner = captured[-1]
+        sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
+        assert isinstance(sim, ObjectCentricTidyBot3DEnv)
+        fixtures = sim._fixtures_dict  # pylint: disable=protected-access
+        bin_obj = state.get_object_from_name("bin_0")
+        barrier = state.get_object_from_name("cuboid_barrier")
+        cube = state.get_object_from_name("cube_0")
+        assert bin_obj.is_instance(MujocoMovableObjectType)
+        assert barrier.is_instance(MujocoFixtureObjectType)
+        assert (
+            GroundAtom(MovableIsDownX, [cube, barrier])
+            in models.state_abstractor(state).atoms
+        )
+        geoms = get_overhead_kinematic2ds(state, planner.bounding_boxes)
+        planner.set_state(state)
+        boxes = planner._boxes  # pylint: disable=protected-access
+        assert len(boxes) == 1
+        assert len(planner._static_boxes) == 6  # pylint: disable=protected-access
+        assert len(planner.static_base_obstacles) == 6
+        assert set(boxes.values()) <= planner.get_collision_bodies()
+        for name, fixture in fixtures.items():
+            if not isinstance(fixture, FixedCuboid) or not isinstance(
+                fixture.primitive, Cuboid
+            ):
+                continue
+            dims = fixture.primitive.get_bounding_box_dimensions()
+            assert planner.bounding_boxes[name] == dims
+            geom = geoms[name]
+            assert isinstance(geom, Rectangle)
+            assert np.allclose([geom.width, geom.height], dims[:2])
+            low, high = p.getAABB(
+                boxes[name], physicsClientId=planner.physics_client_id
+            )
+            assert np.allclose(np.subtract(high, low), dims, atol=1e-7)
+        assert planner.has_bin("bin_0")
+        robot = state.get_object_from_name("robot")
+        controller = MoveToTossLocationAndTossController(
+            [robot, cube, barrier], pybullet_sim=planner
+        )
+        for _ in range(20):
+            params = controller.sample_parameters(state, np.random.default_rng(_))
+            target = get_target_robot_pose_from_parameters(
+                get_overhead_object_se2_pose(state, bin_obj), params[0], params[1]
+            )
+            assert target.x + 0.275 < state.get(barrier, "x") - 0.03
+
+    finally:
+        for planner in captured:
+            planner.close()
+        env.close()

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
@@ -1,11 +1,8 @@
 """The tossing planner must see the same fixed obstacles as the simulator."""
 
-from typing import cast
-
 import kinder
 import numpy as np
 import pybullet as p
-from gymnasium import Env
 from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv, TidyBot3DEnv
 from kinder.envs.dynamic3d.object_types import (
     MujocoFixtureObjectType,
@@ -102,4 +99,4 @@ def test_fixed_tossing_obstacles_match_both_planning_scenes(monkeypatch) -> None
     finally:
         for planner in captured:
             planner.close()
-        cast(Env, env).close()
+        env.close()  # type: ignore[no-untyped-call]

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -1349,15 +1349,20 @@ class MoveToTossLocationAndTossController(
     # Leave room for the physical chassis on the launch side of the fixed barrier.
     LAUNCH_CLEARANCE_BOUNDS = (0.025, 0.055)
 
-    # TossController's two dials, opened up as sampled parameters. Narrowed from the
-    # originally-shipped (60, TOSS_MAX_VELOCITY) / (600, 840): measured directly
-    # (toss_param_probe4.py, isolated toss draws from a real post-pick state, 480
-    # draws across 16 seeds) that every scoring draw fell in speed_deg [117.5, 140.0]
-    # and release_ms [710.4, 836.1] -- the wide bounds spent the large majority of
-    # the sampler's budget on combinations that can never score. A few degrees/ms of
-    # margin below the measured minimums, since 480 draws is not exhaustive.
-    SPEED_BOUNDS = (np.deg2rad(115.0), TOSS_MAX_VELOCITY)
-    RELEASE_MS_BOUNDS = (700.0, 840.0)
+    # Coupled speed/release candidates for the farther simulated receiver. Faster
+    # swings need earlier release; sampling these independently wastes refinements.
+    # Every instance uses the same candidates, selected with the planner's RNG.
+    THROW_PROFILES = (
+        (190.0, 680.0),
+        (220.0, 590.0),
+        (230.0, 590.0),
+        (250.0, 550.0),
+        (280.0, 550.0),
+        (320.0, 520.0),
+        (360.0, 500.0),
+        (400.0, 480.0),
+    )
+    MAX_SWING_VELOCITY = np.deg2rad(400.0)
 
     def __init__(
         self, *args, pybullet_sim: PyBulletSim | None = None, **kwargs
@@ -1403,13 +1408,15 @@ class MoveToTossLocationAndTossController(
         launch_x -= rng.uniform(*self.LAUNCH_CLEARANCE_BOUNDS)
         receiver = x.get_object_from_name("bin_0")
         distance = x.get(receiver, "x") - launch_x
-        max_rotation = float(np.arcsin(0.5 * WAYPOINT_TOLERANCE / distance))
+        speed_degrees, release_ms = self.THROW_PROFILES[
+            rng.integers(len(self.THROW_PROFILES))
+        ]
         return np.array(
             [
                 distance,
-                rng.uniform(-max_rotation, max_rotation),
-                rng.uniform(*self.SPEED_BOUNDS),
-                rng.uniform(*self.RELEASE_MS_BOUNDS),
+                0.0,  # Aim along the receiver axis.
+                np.deg2rad(speed_degrees),
+                release_ms,
             ]
         )
 
@@ -1546,6 +1553,7 @@ class MoveToTossLocationAndTossController(
             windup_plan[-1],
             self._release_speed,
             self._gripper_release_ms,
+            max_velocity=self.MAX_SWING_VELOCITY,
         )
 
     def terminated(self) -> bool:

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -20,6 +20,24 @@ from kinder.envs.dynamic3d.object_types import (
 from kinder.envs.dynamic3d.robots.tidybot_robot_env import (
     TidyBot3DRobotActionSpace,
 )
+from prpl_utils.utils import get_signed_angle_distance
+from pybullet_helpers.geometry import Pose, Quaternion, multiply_poses
+from pybullet_helpers.inverse_kinematics import (
+    JointPositions,
+    inverse_kinematics,
+)
+from pybullet_helpers.motion_planning import (
+    remap_joint_position_plan_to_constant_distance,
+    run_motion_planning,
+)
+from relational_structs import (
+    Array,
+    Object,
+    ObjectCentricState,
+    Variable,
+)
+from spatialmath import SE2
+
 from kinder_models.dynamic3d.tossing.toss_swing import (
     TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
     TOSS_MAX_VELOCITY,
@@ -52,23 +70,6 @@ from kinder_models.dynamic3d.utils import (
     upright_grasp_rotations,
     wrap_arm_joint_difference,
 )
-from prpl_utils.utils import get_signed_angle_distance
-from pybullet_helpers.geometry import Pose, Quaternion, multiply_poses
-from pybullet_helpers.inverse_kinematics import (
-    JointPositions,
-    inverse_kinematics,
-)
-from pybullet_helpers.motion_planning import (
-    remap_joint_position_plan_to_constant_distance,
-    run_motion_planning,
-)
-from relational_structs import (
-    Array,
-    Object,
-    ObjectCentricState,
-    Variable,
-)
-from spatialmath import SE2
 
 logger = logging.getLogger(__name__)
 

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -20,24 +20,6 @@ from kinder.envs.dynamic3d.object_types import (
 from kinder.envs.dynamic3d.robots.tidybot_robot_env import (
     TidyBot3DRobotActionSpace,
 )
-from prpl_utils.utils import get_signed_angle_distance
-from pybullet_helpers.geometry import Pose, Quaternion, multiply_poses
-from pybullet_helpers.inverse_kinematics import (
-    JointPositions,
-    inverse_kinematics,
-)
-from pybullet_helpers.motion_planning import (
-    remap_joint_position_plan_to_constant_distance,
-    run_motion_planning,
-)
-from relational_structs import (
-    Array,
-    Object,
-    ObjectCentricState,
-    Variable,
-)
-from spatialmath import SE2
-
 from kinder_models.dynamic3d.tossing.toss_swing import (
     TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
     TOSS_MAX_VELOCITY,
@@ -63,12 +45,30 @@ from kinder_models.dynamic3d.utils import (
     WORLD_Y_BOUNDS,
     PyBulletSim,
     _compute_per_joint_profile,
+    get_bounding_box,
     get_overhead_object_se2_pose,
     get_target_robot_pose_from_parameters,
     run_base_motion_planning,
     upright_grasp_rotations,
     wrap_arm_joint_difference,
 )
+from prpl_utils.utils import get_signed_angle_distance
+from pybullet_helpers.geometry import Pose, Quaternion, multiply_poses
+from pybullet_helpers.inverse_kinematics import (
+    JointPositions,
+    inverse_kinematics,
+)
+from pybullet_helpers.motion_planning import (
+    remap_joint_position_plan_to_constant_distance,
+    run_motion_planning,
+)
+from relational_structs import (
+    Array,
+    Object,
+    ObjectCentricState,
+    Variable,
+)
+from spatialmath import SE2
 
 logger = logging.getLogger(__name__)
 
@@ -894,6 +894,12 @@ class PickCubeController(GroundParameterizedController[ObjectCentricState, Array
             extend_xy_magnitude=extend_xy_magnitude,
             extend_rot_magnitude=extend_rot_magnitude,
             disable_collision_objects=[cube_to_pick_up.name],
+            bounding_boxes=(
+                self._pybullet_sim.bounding_boxes if self._pybullet_sim else None
+            ),
+            static_obstacles=(
+                self._pybullet_sim.static_base_obstacles if self._pybullet_sim else ()
+            ),
         )
 
     def _plan_motions(
@@ -1339,14 +1345,8 @@ class MoveToTossLocationAndTossController(
         # known-good starting pose instead of wherever the release left the arm.
         RETURN_HOME = enum.auto()
 
-    # Where a throw is possible; the upper part does not score.
-    TARGET_DISTANCE_BOUNDS = (1.25, 1.45)
-
-    # Widest rotation that stays within half of WAYPOINT_TOLERANCE at max standoff.
-    MAX_TARGET_ROTATION = float(
-        np.arcsin(0.5 * WAYPOINT_TOLERANCE / TARGET_DISTANCE_BOUNDS[1])
-    )
-    TARGET_ROTATION_BOUNDS = (-MAX_TARGET_ROTATION, MAX_TARGET_ROTATION)
+    # Leave room for the physical chassis on the launch side of the fixed barrier.
+    LAUNCH_CLEARANCE_BOUNDS = (0.025, 0.055)
 
     # TossController's two dials, opened up as sampled parameters. Narrowed from the
     # originally-shipped (60, TOSS_MAX_VELOCITY) / (600, 840): measured directly
@@ -1394,11 +1394,19 @@ class MoveToTossLocationAndTossController(
         )
 
     def sample_parameters(self, x: ObjectCentricState, rng: np.random.Generator) -> Any:
-        del x  # not used
+        assert self._pybullet_sim is not None
+        robot, _, barrier = self.objects[:3]
+        barrier_width = self._pybullet_sim.bounding_boxes[barrier.name][0]
+        robot_width = get_bounding_box(x, robot)[0]
+        launch_x = x.get(barrier, "x") - (barrier_width + robot_width) / 2
+        launch_x -= rng.uniform(*self.LAUNCH_CLEARANCE_BOUNDS)
+        receiver = x.get_object_from_name("bin_0")
+        distance = x.get(receiver, "x") - launch_x
+        max_rotation = float(np.arcsin(0.5 * WAYPOINT_TOLERANCE / distance))
         return np.array(
             [
-                rng.uniform(*self.TARGET_DISTANCE_BOUNDS),
-                rng.uniform(*self.TARGET_ROTATION_BOUNDS),
+                distance,
+                rng.uniform(-max_rotation, max_rotation),
                 rng.uniform(*self.SPEED_BOUNDS),
                 rng.uniform(*self.RELEASE_MS_BOUNDS),
             ]
@@ -1460,6 +1468,12 @@ class MoveToTossLocationAndTossController(
             extend_xy_magnitude=extend_xy_magnitude,
             extend_rot_magnitude=extend_rot_magnitude,
             disable_collision_objects=disable_collision_objects,
+            bounding_boxes=(
+                self._pybullet_sim.bounding_boxes if self._pybullet_sim else None
+            ),
+            static_obstacles=(
+                self._pybullet_sim.static_base_obstacles if self._pybullet_sim else ()
+            ),
         )
         if base_motion_plan is None:
             logger.debug(
@@ -1747,7 +1761,7 @@ def create_lifted_controllers(
 
     robot = Variable("?robot", MujocoTidyBotRobotObjectType)
     cube = Variable("?cube", MujocoMovableObjectType)
-    barrier = Variable("?barrier", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoObjectType)
 
     class PickCube(PickCubeController):
         """Inject the shared simulator and remaining movable collision context."""
@@ -1785,7 +1799,7 @@ def create_lifted_controllers(
 
     robot = Variable("?robot", MujocoTidyBotRobotObjectType)
     held = Variable("?held", MujocoMovableObjectType)
-    barrier = Variable("?barrier", MujocoMovableObjectType)
+    barrier = Variable("?barrier", MujocoObjectType)
 
     LiftedMoveToTossLocationAndTossController: LiftedParameterizedController = (
         LiftedParameterizedController(

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -19,6 +19,14 @@ from kinder.envs.dynamic3d.object_types import (
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
 )
+from pybullet_helpers.geometry import Quaternion
+from relational_structs import (
+    GroundAtom,
+    Object,
+    ObjectCentricState,
+    Predicate,
+)
+
 from kinder_models.dynamic3d.utils import (
     END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
     GRIPPER_GRASPING_THRESHOLD,
@@ -27,13 +35,6 @@ from kinder_models.dynamic3d.utils import (
     ON_GROUND_TOLERANCE,
     PyBulletSim,
     cube_tilt_from_upright,
-)
-from pybullet_helpers.geometry import Quaternion
-from relational_structs import (
-    GroundAtom,
-    Object,
-    ObjectCentricState,
-    Predicate,
 )
 
 # Upstream types cube, bin and barrier alike, so names state the type, not the subset.

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -19,14 +19,6 @@ from kinder.envs.dynamic3d.object_types import (
     MujocoObjectType,
     MujocoTidyBotRobotObjectType,
 )
-from pybullet_helpers.geometry import Quaternion
-from relational_structs import (
-    GroundAtom,
-    Object,
-    ObjectCentricState,
-    Predicate,
-)
-
 from kinder_models.dynamic3d.utils import (
     END_EFFECTOR_TO_OBJECT_HOLDING_TOLERANCE,
     GRIPPER_GRASPING_THRESHOLD,
@@ -36,6 +28,13 @@ from kinder_models.dynamic3d.utils import (
     PyBulletSim,
     cube_tilt_from_upright,
 )
+from pybullet_helpers.geometry import Quaternion
+from relational_structs import (
+    GroundAtom,
+    Object,
+    ObjectCentricState,
+    Predicate,
+)
 
 # Upstream types cube, bin and barrier alike, so names state the type, not the subset.
 MovableInGoalRegion = Predicate("MovableInGoalRegion", [MujocoMovableObjectType])
@@ -43,7 +42,7 @@ OnGround = Predicate("OnGround", [MujocoObjectType])
 Holding = Predicate("Holding", [MujocoTidyBotRobotObjectType, MujocoMovableObjectType])
 HandEmpty = Predicate("HandEmpty", [MujocoTidyBotRobotObjectType])
 MovableIsDownX = Predicate(
-    "MovableIsDownX", [MujocoMovableObjectType, MujocoMovableObjectType]
+    "MovableIsDownX", [MujocoMovableObjectType, MujocoObjectType]
 )
 # The environment's inflated region, not the task JSON's "ranges".
 GOAL_REGION_NAME = "blocks_goal_region"
@@ -82,7 +81,7 @@ class Tossing3DStateAbstractor:
         movables = state.get_objects(MujocoMovableObjectType)
         all_mujoco_objects = set(fixtures) | set(movables)
         cubes = self._get_cubes(state)
-        barriers = [o for o in movables if o.name == BARRIER_NAME]
+        barriers = [o for o in fixtures + movables if o.name == BARRIER_NAME]
 
         if self._check_gripper_open(state, robot):
             atoms.add(GroundAtom(HandEmpty, [robot]))

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
@@ -94,6 +94,8 @@ def plan_toss_swing(
     current_joint_angles: JointPositions,
     release_speed: float = TOSS_MAX_VELOCITY,
     gripper_release_ms: int = TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+    *,
+    max_velocity: float = TOSS_MAX_VELOCITY,
 ) -> TossSwing:
     """Time a motion plan as a toss, and fix the millisecond the gripper opens on.
 
@@ -106,7 +108,9 @@ def plan_toss_swing(
     s_total = float(np.linalg.norm(dq))
     # Do not align this with the _compute_per_joint_profile siblings.
     direction = dq / s_total if s_total > 1e-4 else np.zeros(7)
-    max_vel, max_accel, max_decel = toss_profile_limits(release_speed)
+    max_vel, max_accel, max_decel = toss_profile_limits(
+        release_speed, max_velocity=max_velocity
+    )
     trajectory = _trapezoidal_motion_profile(
         s_total,
         max_vel=max_vel,
@@ -128,14 +132,19 @@ def plan_toss_swing(
 
 def toss_profile_limits(
     release_speed: float = TOSS_MAX_VELOCITY,
+    *,
+    max_velocity: float = TOSS_MAX_VELOCITY,
 ) -> tuple[float, float, float]:
     """The (max_vel, max_accel, max_decel) triple a toss at release_speed is timed by.
 
     One factor on all three, so this is an effort and not a speed cap: raising max_vel
     alone turns the profile triangular and moves the release into the acceleration
-    phase. Clamped at 1, the real arm's own ceiling.
+    phase. The default preserves the demonstrated real-arm ceiling. Simulated
+    controllers can explicitly select a higher ceiling without changing other callers.
     """
-    effort = min(max(release_speed / TOSS_MAX_VELOCITY, 0.0), 1.0)
+    if not np.isfinite(max_velocity) or max_velocity <= 0:
+        raise ValueError("max_velocity must be finite and positive")
+    effort = np.clip(release_speed, 0.0, max_velocity) / TOSS_MAX_VELOCITY
     return (
         TOSS_MAX_VELOCITY * effort,
         TOSS_MAX_ACCELERATION * effort,

--- a/kinder-models/src/kinder_models/dynamic3d/utils.py
+++ b/kinder-models/src/kinder_models/dynamic3d/utils.py
@@ -164,7 +164,10 @@ def get_bounding_box(
     raise NotImplementedError
 
 
-def get_overhead_kinematic2ds(state: ObjectCentricState) -> dict[str, Geom2D]:
+def get_overhead_kinematic2ds(
+    state: ObjectCentricState,
+    bounding_boxes: dict[str, tuple[float, float, float]] | None = None,
+) -> dict[str, Geom2D]:
     """Get a mapping from object name to Geom2D from an overhead perspective."""
     geoms: dict[str, Geom2D] = {}
     for obj in state:
@@ -179,7 +182,10 @@ def get_overhead_kinematic2ds(state: ObjectCentricState) -> dict[str, Geom2D]:
             pose = get_overhead_object_se2_pose(state, obj)
         else:
             raise NotImplementedError
-        width, height, _ = get_bounding_box(state, obj)
+        if bounding_boxes is not None and obj.name in bounding_boxes:
+            width, height, _ = bounding_boxes[obj.name]
+        else:
+            width, height, _ = get_bounding_box(state, obj)
         geom = Rectangle.from_center(
             pose.x, pose.y, width, height, rotation_about_center=pose.theta()
         )
@@ -236,6 +242,8 @@ def run_base_motion_planning(
     num_iters: int = 100,
     smooth_amt: int = 50,
     disable_collision_objects: list[str] | None = None,
+    bounding_boxes: dict[str, tuple[float, float, float]] | None = None,
+    static_obstacles: Iterable[Geom2D] = (),
 ) -> list[SE2] | None:
     """Run motion planning for the robot base."""
     rng = np.random.default_rng(seed)
@@ -249,8 +257,9 @@ def run_base_motion_planning(
     # Drawers are MujocoObjectType, but get_overhead_kinematic2ds() cannot build a
     # Geom2D for one, so they are absent from geoms and would KeyError below.
     obstacles = [o for o in obstacles if not o.is_instance(MujocoDrawerObjectType)]
-    geoms = get_overhead_kinematic2ds(state)
+    geoms = get_overhead_kinematic2ds(state, bounding_boxes)
     obstacle_geoms: set[Geom2D] = {geoms[o.name] for o in obstacles}
+    obstacle_geoms.update(static_obstacles)
 
     # Set up the RRT methods.
     def sample_fn(_: SE2) -> SE2:
@@ -491,6 +500,10 @@ class PyBulletSim:
 
         # Create all the cubes.
         self._bins: dict[str, int] = {}
+        self._boxes: dict[str, int] = {}
+        self._static_boxes: dict[str, int] = {}
+        self._static_base_obstacles: list[Geom2D] = []
+        self._bounding_boxes: dict[str, tuple[float, float, float]] = {}
         self._cubes: dict[str, int] = {}
         for cube_name in initial_state.get_object_names():
             if "cube" in cube_name:
@@ -573,8 +586,67 @@ class PyBulletSim:
             baseOrientation=pose.orientation,
             physicsClientId=self._physics_client_id,
         )
+        self._bounding_boxes[name] = (length, width, height)
         self._bins[name] = body
         return body
+
+    @property
+    def bounding_boxes(self) -> dict[str, tuple[float, float, float]]:
+        """Actual dimensions of explicitly registered planning obstacles."""
+        return dict(self._bounding_boxes)
+
+    def add_box(
+        self,
+        *,
+        name: str,
+        pose: Pose,
+        dimensions: tuple[float, float, float],
+        state_object: bool = True,
+    ) -> int:
+        """Opt in a fixed cuboid obstacle, centered at its primitive origin."""
+        if name in self._boxes or name in self._static_boxes or name in self._bins:
+            raise ValueError(f"Obstacle {name} is already in the collision model")
+        if any(d <= 0 for d in dimensions):
+            raise ValueError("Box dimensions must be positive")
+        shape = p.createCollisionShape(
+            p.GEOM_BOX,
+            halfExtents=[d / 2 for d in dimensions],
+            physicsClientId=self._physics_client_id,
+        )
+        body = p.createMultiBody(
+            baseMass=0,
+            baseCollisionShapeIndex=shape,
+            basePosition=pose.position,
+            baseOrientation=pose.orientation,
+            physicsClientId=self._physics_client_id,
+        )
+        if state_object:
+            self._boxes[name] = body
+            self._bounding_boxes[name] = dimensions
+        else:
+            self._static_boxes[name] = body
+            rotation = Rotation.from_quat(pose.orientation).as_matrix()
+            horizontal = np.flatnonzero(np.abs(rotation[2]) < 1e-6)
+            if len(horizontal) != 2:
+                raise ValueError("Static base obstacles must have a vertical box axis")
+            first, second = horizontal
+            self._static_base_obstacles.append(
+                Rectangle.from_center(
+                    pose.position[0],
+                    pose.position[1],
+                    dimensions[first],
+                    dimensions[second],
+                    rotation_about_center=float(
+                        np.arctan2(rotation[1, first], rotation[0, first])
+                    ),
+                )
+            )
+        return body
+
+    @property
+    def static_base_obstacles(self) -> tuple[Geom2D, ...]:
+        """Task-owned static geometry that has no observation object."""
+        return tuple(self._static_base_obstacles)
 
     def has_bin(self, name: str) -> bool:
         """Whether this bin has collision geometry in the planning scene."""
@@ -642,7 +714,7 @@ class PyBulletSim:
                 )
                 set_pose(self._cubes[cube_name], cube_pose, self._physics_client_id)
 
-        for name, body in self._bins.items():
+        for name, body in (self._bins | self._boxes).items():
             obj = x.get_object_from_name(name)
             pose = Pose(
                 tuple(x.get(obj, f) for f in ("x", "y", "z")),
@@ -691,6 +763,8 @@ class PyBulletSim:
         collision_bodies: set[int] = set()
         collision_bodies.update(self._cubes.values())
         collision_bodies.update(self._bins.values())
+        collision_bodies.update(self._boxes.values())
+        collision_bodies.update(self._static_boxes.values())
         if self._cupboard1_shelf_id is not None:
             collision_bodies.add(self._cupboard1_shelf_id)
         if held_object is not None:

--- a/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
@@ -159,9 +159,26 @@ def test_toss_release_speed_clamps_the_effort_to_zero_and_one():
 
 
 def test_the_release_speeds_the_sampler_draws_are_never_clamped():
-    """SPEED_BOUNDS' top edge is the clamp point, so it must pass through."""
-    for speed in np.linspace(*MoveToTossLocationAndTossController.SPEED_BOUNDS, 25):
-        assert np.isclose(toss_profile_limits(speed)[0], speed)
+    """The simulation controller explicitly enables its higher-speed profiles."""
+    controller = MoveToTossLocationAndTossController
+    for speed_degrees, _ in controller.THROW_PROFILES:
+        speed = np.deg2rad(speed_degrees)
+        assert np.isclose(
+            toss_profile_limits(speed, max_velocity=controller.MAX_SWING_VELOCITY)[0],
+            speed,
+        )
+
+
+def test_simulated_swing_uses_explicit_higher_ceiling():
+    """A higher ceiling changes the trajectory, while the default stays capped."""
+    start = list(TOSS_WINDUP_ARM_CONFIGURATION) + [0.0] * 6
+    end = list(TOSS_RELEASE_ARM_CONFIGURATION) + [0.0] * 6
+    speed = np.deg2rad(280.0)
+    default = plan_toss_swing([end], start, speed, 550)
+    fast = plan_toss_swing([end], start, speed, 550, max_velocity=np.deg2rad(400.0))
+    assert len(fast.trajectory) < len(default.trajectory)
+    assert fast.release_step == default.release_step
+    assert fast.release_slice == default.release_slice
 
 
 def test_plan_toss_swing_is_unmoved_by_a_whole_turn_on_a_continuous_joint():

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1131,7 +1131,8 @@ def test_pick_toss():
     cube = state.get_object_from_name("bin_0")
     object_parameters = (robot, cube)
     controller = lifted_controller.ground(object_parameters)
-    target_distance = 1.35
+    # Keep the test launch pose on the reachable side of the fixed barrier.
+    target_distance = state.get(cube, "x") - 0.9
     target_rotation = 0.0
     params = np.array([target_distance, target_rotation])
 
@@ -1264,7 +1265,8 @@ def test_pick_ground_toss():
     cube = state.get_object_from_name("bin_0")
     object_parameters = (robot, cube)
     controller = lifted_controller.ground(object_parameters)
-    target_distance = 1.35
+    # Keep the test launch pose on the reachable side of the fixed barrier.
+    target_distance = state.get(cube, "x") - 0.9
     target_rotation = 0.0
     params = np.array([target_distance, target_rotation])
 
@@ -1463,7 +1465,8 @@ def test_toss_schedules_its_release_at_the_requested_millisecond():
     move = tossing["move_to_target"].ground(
         (robot, state.get_object_from_name("bin_0"))
     )
-    _run(move, np.array([1.35, 0.0]), disable_collision_objects=["cube_0"])
+    distance = state.get(state.get_object_from_name("bin_0"), "x") - 0.9
+    _run(move, np.array([distance, 0.0]), disable_collision_objects=["cube_0"])
 
     robot = _get_robot_from_state(state)
     _run(tossing["move_arm_to_conf"].ground((robot,)), TOSS_WINDUP_ARM_CONFIGURATION)

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1671,45 +1671,48 @@ def test_pick_cube_never_unwinds_a_joint_by_a_whole_turn():
 
 
 def test_move_to_toss_location_and_toss_samples_four_parameters():
-    """Standoff, rotation, release speed and release millisecond, all in bounds."""
-    num_cubes = 1
-    env = kinder.make(
-        "kinder/Tossing3D-o1-v0", render_mode="rgb_array", num_objects=num_cubes
-    )
+    """Launch stays behind the barrier while throw parameters vary."""
+    env = kinder.make("kinder/Tossing3D-o1-v0", num_objects=1)
     obs, _ = env.reset(seed=125)
     assert isinstance(env.observation_space, ObjectCentricBoxSpace)
     state = env.observation_space.devectorize(obs)
-    controllers = create_lifted_controllers(env.action_space)
     robot = state.get_objects(MujocoTidyBotRobotObjectType)[0]
     cube = state.get_object_from_name("cube_0")
     barrier = state.get_object_from_name("cuboid_barrier")
-    controller = controllers["move_to_toss_location_and_toss"].ground(
-        (robot, cube, barrier)
-    )
-    draws = np.array(
-        [
-            controller.sample_parameters(state, np.random.default_rng(seed))
-            for seed in range(50)
-        ]
-    )
-    assert draws.shape == (50, 4)
-    receiver = state.get_object_from_name("bin_0")
-    launch_x = state.get(receiver, "x") - draws[:, 0] * np.cos(draws[:, 1])
-    assert np.all(launch_x + 0.275 < state.get(barrier, "x"))
-    assert np.ptp(draws[:, 0]) > 0
-    assert np.ptp(draws[:, 1]) > 0
-    for column, (low, high) in enumerate(
-        [
-            MoveToTossLocationAndTossController.SPEED_BOUNDS,
-            MoveToTossLocationAndTossController.RELEASE_MS_BOUNDS,
-        ],
-        start=2,
-    ):
-        assert draws[:, column].min() >= low
-        assert draws[:, column].max() <= high
-        # A sampler, not a constant, in every component.
-        assert draws[:, column].min() < draws[:, column].max()
-    env.close()
+    sim = PyBulletSim(state)
+    try:
+        sim.add_box(
+            name=barrier.name,
+            pose=Pose((1.3, 0.0, 0.1)),
+            dimensions=(0.06, 10.0, 0.2),
+        )
+        controller = MoveToTossLocationAndTossController(
+            [robot, cube, barrier], pybullet_sim=sim
+        )
+        draws = np.array(
+            [
+                controller.sample_parameters(state, np.random.default_rng(seed))
+                for seed in range(50)
+            ]
+        )
+        assert draws.shape == (50, 4)
+        assert np.max(np.abs(draws[:, 1])) < 0.1
+        assert np.ptp(draws[:, 0]) > 0
+        assert np.ptp(draws[:, 2]) > 0
+        assert np.ptp(draws[:, 3]) > 0
+        receiver = state.get_object_from_name("bin_0")
+        for distance, _, speed, release in draws:
+            launch_x = state.get(receiver, "x") - distance
+            assert launch_x + 0.275 < state.get(barrier, "x") - 0.03
+            assert controller.SPEED_BOUNDS[0] <= speed <= controller.SPEED_BOUNDS[1]
+            assert (
+                controller.RELEASE_MS_BOUNDS[0]
+                <= release
+                <= controller.RELEASE_MS_BOUNDS[1]
+            )
+    finally:
+        sim.close()
+        env.close()
 
 
 def test_open_gripper_commands_open_until_the_gripper_reads_open():

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1696,19 +1696,16 @@ def test_move_to_toss_location_and_toss_samples_four_parameters():
             ]
         )
         assert draws.shape == (50, 4)
-        assert np.max(np.abs(draws[:, 1])) < 0.1
+        assert np.all(draws[:, 1] == 0.0)
         assert np.ptp(draws[:, 0]) > 0
-        assert np.ptp(draws[:, 2]) > 0
-        assert np.ptp(draws[:, 3]) > 0
+        assert len(np.unique(draws[:, 2:], axis=0)) > 1
         receiver = state.get_object_from_name("bin_0")
         for distance, _, speed, release in draws:
             launch_x = state.get(receiver, "x") - distance
             assert launch_x + 0.275 < state.get(barrier, "x") - 0.03
-            assert controller.SPEED_BOUNDS[0] <= speed <= controller.SPEED_BOUNDS[1]
-            assert (
-                controller.RELEASE_MS_BOUNDS[0]
-                <= release
-                <= controller.RELEASE_MS_BOUNDS[1]
+            assert any(
+                np.isclose(speed, np.deg2rad(degrees)) and release == milliseconds
+                for degrees, milliseconds in controller.THROW_PROFILES
             )
     finally:
         sim.close()

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1693,13 +1693,17 @@ def test_move_to_toss_location_and_toss_samples_four_parameters():
         ]
     )
     assert draws.shape == (50, 4)
+    receiver = state.get_object_from_name("bin_0")
+    launch_x = state.get(receiver, "x") - draws[:, 0] * np.cos(draws[:, 1])
+    assert np.all(launch_x + 0.275 < state.get(barrier, "x"))
+    assert np.ptp(draws[:, 0]) > 0
+    assert np.ptp(draws[:, 1]) > 0
     for column, (low, high) in enumerate(
         [
-            MoveToTossLocationAndTossController.TARGET_DISTANCE_BOUNDS,
-            MoveToTossLocationAndTossController.TARGET_ROTATION_BOUNDS,
             MoveToTossLocationAndTossController.SPEED_BOUNDS,
             MoveToTossLocationAndTossController.RELEASE_MS_BOUNDS,
-        ]
+        ],
+        start=2,
     ):
         assert draws[:, column].min() >= low
         assert draws[:, column].max() <= high

--- a/scripts/install_all.py
+++ b/scripts/install_all.py
@@ -14,12 +14,11 @@ from generate_topological_order import get_topological_order
 # kindergarden would break every package that depends on that package), so
 # the git pin lives here instead of in the pyprojects.
 #
-# kindergarden: pinned to the merge of #173 (explicit board heights,
-# per-cylinder radii, staging boxes for the real restock scene), not yet in
-# a PyPI release. Remove at the next kindergarden release.
+# kindergarden: requires the Tossing room geometry in #198.
+# Merge that PR before this companion; remove the pin once released.
 PREINSTALL_REQUIREMENTS = [
     "kindergarden @ git+https://github.com/Princeton-Robot-Planning-and-Learning/"
-    "kindergarden.git@582aaeb6fd96d1d9a56b4cf02d0061b8e6ce6df5",
+    "kindergarden.git@0dbc1c0fe7b60985134e2e14f1dc79c43595263f",
 ]
 
 


### PR DESCRIPTION
**Depends on [Kinder #198](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/198), above #191/#187. Keep this draft until those environment changes merge.** Development/CI is pinned to that required revision.

The new Tossing room anchors the barrier and adds wall collisions. Update the planner to represent the fixed barrier, use its actual dimensions, and include all six room collision boxes in arm and base planning. Derive launch standoff from the observed receiver and robot/barrier geometry.

The farther receiver also requires the stronger coupled speed/release profiles formerly in #166. Include those here, with an explicit 400 deg/s ceiling for this simulated controller. Other callers retain the swing helper's original 140 deg/s default. Every instance uses the same candidate set and planner RNG.

**Stack correction:** #166 has been folded into this PR. Geometry alone failed the unchanged end-to-end planner test with “No plan found”; the combined source passes. Keeping both changes together avoids a broken intermediate layer. The combined production code is unchanged from the tested #166 tree; the fixture corrections below make its legacy tests respect the fixed barrier.

Validation:

- Existing maintained seed-125 planner test passes against the exact Kinder #198 revision, without changing its settings.
- All 33 Tossing controller tests pass after updating legacy test launch poses to stay behind the fixed barrier, including the three previously failing movement/release tests. The 15 swing/profile and sampler checks and fixture/room integration test also pass.
- Independent audit confirms all six PyBullet wall poses and projected footprints match compiled MuJoCo geometry to floating-point precision.
- Shared CI fixes include the required dependency pin, import ordering, public test cleanup calls, and a sampler test initialized with its required planning scene.

This layer remains o1-only and retains legacy low-level control output. [#168](https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/168) adds ordinary bounded 18D actions, complete simulation-state restoration during search, and two-block support. Its body includes actual maintained SeSamE GIFs, successful normal-reset/near-corner checks, and both far-corner failures. Those final-stack demonstrations are not claims that this intermediate layer alone uses the declared public Box.

No success predicates or environment physics change in this baseline PR.

Full-stack example with #168 applied: actual maintained SeSamE, normal-reset one-block task. This clip illustrates the completed stack, including its 18D action corrections.

![Maintained SeSamE with the complete Tossing stack](https://raw.githubusercontent.com/Princeton-Robot-Planning-and-Learning/kindergarden/3b2c234828b764faaf634a2b377784f81a384623/tossing-sesame-o1.gif)
