### PR TITLE
Sample coupled simulated throw profiles for the Tossing room

### DIFF
--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -1349,15 +1349,20 @@ class MoveToTossLocationAndTossController(
     # Leave room for the physical chassis on the launch side of the fixed barrier.
     LAUNCH_CLEARANCE_BOUNDS = (0.025, 0.055)
 
-    # TossController's two dials, opened up as sampled parameters. Narrowed from the
-    # originally-shipped (60, TOSS_MAX_VELOCITY) / (600, 840): measured directly
-    # (toss_param_probe4.py, isolated toss draws from a real post-pick state, 480
-    # draws across 16 seeds) that every scoring draw fell in speed_deg [117.5, 140.0]
-    # and release_ms [710.4, 836.1] -- the wide bounds spent the large majority of
-    # the sampler's budget on combinations that can never score. A few degrees/ms of
-    # margin below the measured minimums, since 480 draws is not exhaustive.
-    SPEED_BOUNDS = (np.deg2rad(115.0), TOSS_MAX_VELOCITY)
-    RELEASE_MS_BOUNDS = (700.0, 840.0)
+    # Coupled speed/release candidates for the farther simulated receiver. Faster
+    # swings need earlier release; sampling these independently wastes refinements.
+    # Every instance uses the same candidates, selected with the planner's RNG.
+    THROW_PROFILES = (
+        (190.0, 680.0),
+        (220.0, 590.0),
+        (230.0, 590.0),
+        (250.0, 550.0),
+        (280.0, 550.0),
+        (320.0, 520.0),
+        (360.0, 500.0),
+        (400.0, 480.0),
+    )
+    MAX_SWING_VELOCITY = np.deg2rad(400.0)
 
     def __init__(
         self, *args, pybullet_sim: PyBulletSim | None = None, **kwargs
@@ -1403,13 +1408,15 @@ class MoveToTossLocationAndTossController(
         launch_x -= rng.uniform(*self.LAUNCH_CLEARANCE_BOUNDS)
         receiver = x.get_object_from_name("bin_0")
         distance = x.get(receiver, "x") - launch_x
-        max_rotation = float(np.arcsin(0.5 * WAYPOINT_TOLERANCE / distance))
+        speed_degrees, release_ms = self.THROW_PROFILES[
+            rng.integers(len(self.THROW_PROFILES))
+        ]
         return np.array(
             [
                 distance,
-                rng.uniform(-max_rotation, max_rotation),
-                rng.uniform(*self.SPEED_BOUNDS),
-                rng.uniform(*self.RELEASE_MS_BOUNDS),
+                0.0,  # Aim along the receiver axis.
+                np.deg2rad(speed_degrees),
+                release_ms,
             ]
         )
 
@@ -1546,6 +1553,7 @@ class MoveToTossLocationAndTossController(
             windup_plan[-1],
             self._release_speed,
             self._gripper_release_ms,
+            max_velocity=self.MAX_SWING_VELOCITY,
         )
 
     def terminated(self) -> bool:

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
@@ -94,6 +94,8 @@ def plan_toss_swing(
     current_joint_angles: JointPositions,
     release_speed: float = TOSS_MAX_VELOCITY,
     gripper_release_ms: int = TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+    *,
+    max_velocity: float = TOSS_MAX_VELOCITY,
 ) -> TossSwing:
     """Time a motion plan as a toss, and fix the millisecond the gripper opens on.
 
@@ -106,7 +108,9 @@ def plan_toss_swing(
     s_total = float(np.linalg.norm(dq))
     # Do not align this with the _compute_per_joint_profile siblings.
     direction = dq / s_total if s_total > 1e-4 else np.zeros(7)
-    max_vel, max_accel, max_decel = toss_profile_limits(release_speed)
+    max_vel, max_accel, max_decel = toss_profile_limits(
+        release_speed, max_velocity=max_velocity
+    )
     trajectory = _trapezoidal_motion_profile(
         s_total,
         max_vel=max_vel,
@@ -128,14 +132,19 @@ def plan_toss_swing(
 
 def toss_profile_limits(
     release_speed: float = TOSS_MAX_VELOCITY,
+    *,
+    max_velocity: float = TOSS_MAX_VELOCITY,
 ) -> tuple[float, float, float]:
     """The (max_vel, max_accel, max_decel) triple a toss at release_speed is timed by.
 
     One factor on all three, so this is an effort and not a speed cap: raising max_vel
     alone turns the profile triangular and moves the release into the acceleration
-    phase. Clamped at 1, the real arm's own ceiling.
+    phase. The default preserves the demonstrated real-arm ceiling. Simulated
+    controllers can explicitly select a higher ceiling without changing other callers.
     """
-    effort = min(max(release_speed / TOSS_MAX_VELOCITY, 0.0), 1.0)
+    if not np.isfinite(max_velocity) or max_velocity <= 0:
+        raise ValueError("max_velocity must be finite and positive")
+    effort = np.clip(release_speed, 0.0, max_velocity) / TOSS_MAX_VELOCITY
     return (
         TOSS_MAX_VELOCITY * effort,
         TOSS_MAX_ACCELERATION * effort,

--- a/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
@@ -159,9 +159,26 @@ def test_toss_release_speed_clamps_the_effort_to_zero_and_one():
 
 
 def test_the_release_speeds_the_sampler_draws_are_never_clamped():
-    """SPEED_BOUNDS' top edge is the clamp point, so it must pass through."""
-    for speed in np.linspace(*MoveToTossLocationAndTossController.SPEED_BOUNDS, 25):
-        assert np.isclose(toss_profile_limits(speed)[0], speed)
+    """The simulation controller explicitly enables its higher-speed profiles."""
+    controller = MoveToTossLocationAndTossController
+    for speed_degrees, _ in controller.THROW_PROFILES:
+        speed = np.deg2rad(speed_degrees)
+        assert np.isclose(
+            toss_profile_limits(speed, max_velocity=controller.MAX_SWING_VELOCITY)[0],
+            speed,
+        )
+
+
+def test_simulated_swing_uses_explicit_higher_ceiling():
+    """A higher ceiling changes the trajectory, while the default stays capped."""
+    start = list(TOSS_WINDUP_ARM_CONFIGURATION) + [0.0] * 6
+    end = list(TOSS_RELEASE_ARM_CONFIGURATION) + [0.0] * 6
+    speed = np.deg2rad(280.0)
+    default = plan_toss_swing([end], start, speed, 550)
+    fast = plan_toss_swing([end], start, speed, 550, max_velocity=np.deg2rad(400.0))
+    assert len(fast.trajectory) < len(default.trajectory)
+    assert fast.release_step == default.release_step
+    assert fast.release_slice == default.release_slice
 
 
 def test_plan_toss_swing_is_unmoved_by_a_whole_turn_on_a_continuous_joint():

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -1696,19 +1696,16 @@ def test_move_to_toss_location_and_toss_samples_four_parameters():
             ]
         )
         assert draws.shape == (50, 4)
-        assert np.max(np.abs(draws[:, 1])) < 0.1
+        assert np.all(draws[:, 1] == 0.0)
         assert np.ptp(draws[:, 0]) > 0
-        assert np.ptp(draws[:, 2]) > 0
-        assert np.ptp(draws[:, 3]) > 0
+        assert len(np.unique(draws[:, 2:], axis=0)) > 1
         receiver = state.get_object_from_name("bin_0")
         for distance, _, speed, release in draws:
             launch_x = state.get(receiver, "x") - distance
             assert launch_x + 0.275 < state.get(barrier, "x") - 0.03
-            assert controller.SPEED_BOUNDS[0] <= speed <= controller.SPEED_BOUNDS[1]
-            assert (
-                controller.RELEASE_MS_BOUNDS[0]
-                <= release
-                <= controller.RELEASE_MS_BOUNDS[1]
+            assert any(
+                np.isclose(speed, np.deg2rad(degrees)) and release == milliseconds
+                for degrees, milliseconds in controller.THROW_PROFILES
             )
     finally:
         sim.close()


### PR DESCRIPTION
**Superseded by #165:** this controller layer was folded into the geometry PR because the geometry-only intermediate failed the existing planner test. Its changes are preserved in #165; #168 remains above the combined layer. The original description and evidence follow.

**Merge dependency:** This change targets the new Tossing layout in [Kinder #198](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/198), stacked on #191 and #187. Keep this PR draft and do not merge it until that Kinder stack is merged. It is not intended for the current upstream Tossing layout.

Merge after baseline #165 as well. Stacked on #165; companion to [Kinder #198](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/198).

The old throw sampler only explores 115–140 deg/s and 700–840 ms release timing, which excludes the stronger, earlier-release throws demonstrated to reach the farther receiver. This change samples a shared set of coupled speed/release profiles, aims along the receiver axis, and explicitly enables a 400 deg/s ceiling for this simulated controller.

The swing helper retains its original 140 deg/s default for other callers. A keyword-only ceiling lets this controller scale velocity, acceleration and deceleration together. Every instance uses the same candidate set and planner RNG; there are no seed-specific profiles or runtime controller overrides.

Validation against Kinder270e5cd and this source f031f5b:

- Actual BilevelPlanningAgent succeeds on normal-reset o1 seeds 0 and 3: 322 planned actions plus 60 settling actions each.
- Independent fresh-reset replays confirm all 60 settling checks have full cube containment, released gripper and no robot contact. Sampled contact-free flight is about 0.97 m; barrier displacement and simulator warnings are zero.
- 16 targeted swing/controller tests and one room-integration test pass. Scoped mypy passes for the two changed source files; changed files are formatted with the package Black/isort settings.

These two positive instances are not a population success rate or a completeness claim. They use the supported 18-value/timed-release interface; high-level o2 support remains separate. The shared rotated-region goal issue is deferred, and these successes use independent physical containment checks.

The GIF is the earlier 326-action planner calibration demonstration using runtime profile overrides. The final 322-action validation above runs the implemented sampler without those overrides; see [Kinder #198](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/198) for additional room/corner demonstrations.

![Earlier planner calibration demonstration](https://raw.githubusercontent.com/Princeton-Robot-Planning-and-Learning/kindergarden/333f1fa6a36892cf4fef2b38c9e75b5aa983d808/planner-calibration-demo.gif)


### Stack review and current validation

The earlier rollouts above use the legacy low-level controls and predate the declared-action-bound audit. They are not evidence that this layer alone emits actions within the public Box. [#168](https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines/pull/168) adds ordinary bounded 18D outputs, full planning-state restoration, and two-block support. Its body includes actual maintained SeSamE GIFs, normal-reset and near-corner successes, and both far-corner failures. No sampler tuning was added to force complete coverage.

The geometry dependency and shared lint/type repairs now start in #165 and propagate through the stack. #165/#166 test against Kinder #198; #168 additionally requires Kinder #200. All remain drafts, with Kinder dependencies to merge first.
