### PR TITLE
Use bounded 18D actions in Tossing controllers

### DIFF
--- a/kinder-bilevel-planning/experiments/conf/env/tidybot3d_tossing-o1.yaml
+++ b/kinder-bilevel-planning/experiments/conf/env/tidybot3d_tossing-o1.yaml
@@ -1,0 +1,14 @@
+env_name: "tidybot3d_tossing3D"
+
+make_kwargs:
+  id: "kinder/Tossing3D-o1-v0"
+  max_episode_steps: 1000
+
+env_model_kwargs:
+  num_objects: 1
+
+# Pickup and move-and-toss each contain several motion phases.
+max_skill_horizon: 400
+max_abstract_plans: 10
+samples_per_step: 10
+planning_timeout: 120

--- a/kinder-bilevel-planning/experiments/conf/env/tidybot3d_tossing-o2.yaml
+++ b/kinder-bilevel-planning/experiments/conf/env/tidybot3d_tossing-o2.yaml
@@ -1,0 +1,14 @@
+env_name: "tidybot3d_tossing3D"
+
+make_kwargs:
+  id: "kinder/Tossing3D-o2-v0"
+  max_episode_steps: 1000
+
+env_model_kwargs:
+  num_objects: 2
+
+# Pickup and move-and-toss each contain several motion phases.
+max_skill_horizon: 400
+max_abstract_plans: 10
+samples_per_step: 10
+planning_timeout: 120

--- a/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
+++ b/kinder-bilevel-planning/src/kinder_bilevel_planning/env_models/dynamic3d/tidybot3d_tossing3D.py
@@ -4,7 +4,8 @@ Two operators over five predicates. The base move and the throw are one skill, s
 predicate has to name the pose between them; the pick takes no continuous parameters,
 so refinement backtracks over the throw alone.
 
-TODO: only Tossing3D-o1 is supported; no operator says which cube a throw is aimed at.
+Each pick and throw binds its own cube, so completed cubes remain goals while the
+robot returns for the remaining cubes.
 """
 
 # MuJoCo exposes its API through a C extension.
@@ -62,12 +63,6 @@ def create_bilevel_planning_models(
     """Create the env models for TidyBot Tossing3D."""
     assert isinstance(observation_space, ObjectCentricBoxSpace)
     assert isinstance(action_space, TidyBot3DRobotActionSpace)
-    if num_objects != 1:
-        raise NotImplementedError(
-            f"Tossing3D bilevel planning supports one cube, got {num_objects}. The "
-            "operators do not say which cube a throw is aimed at."
-        )
-
     task_config_path = str(
         Path(kinder.__file__).parent
         / "envs"
@@ -94,14 +89,46 @@ def create_bilevel_planning_models(
         """Convert the vectors back into (hashable) object-centric states."""
         return observation_space.devectorize(o)
 
+    robot_env = sim._robot_env  # pylint: disable=protected-access
+    assert robot_env is not None
+    model = robot_env.sim.model.mj_model
+    data = robot_env.sim.data.mj_data
+    state_spec = mujoco.mjtState.mjSTATE_INTEGRATION
+    state_size = mujoco.mj_stateSize(model, state_spec)
+
+    def snapshot() -> NDArray[np.float64]:
+        result = np.empty(state_size)
+        mujoco.mj_getState(model, data, result, state_spec)
+        return result
+
+    reset_snapshot = snapshot()
+    snapshots: dict[tuple[tuple[str, str, bytes], ...], NDArray[np.float64]] = {}
+
     def transition_fn(
         x: ObjectCentricState,
         u: NDArray[np.float32],
     ) -> ObjectCentricState:
-        """Simulate the action."""
-        state = x.copy()
-        sim.set_state(state)
+        """Simulate with complete physics state, including on search backtracking.
+
+        Object observations omit finger positions and contact solver state. Restoring
+        only those observations at every step changes the grasp and the resulting
+        throw. Preserve integration snapshots for states reached by this model.
+        """
+        key = tuple((obj.name, obj.type.name, x[obj].tobytes()) for obj in x)
+        if key not in snapshots:
+            # A new external observation starts a new planning problem. Initialize
+            # its unobserved state from reset, not a previous failed refinement.
+            snapshots.clear()
+            mujoco.mj_setState(model, data, reset_snapshot, state_spec)
+            sim.set_state(x.copy())
+            snapshots[key] = snapshot()
+        else:
+            mujoco.mj_setState(model, data, snapshots[key], state_spec)
+            mujoco.mj_forward(model, data)
         obs, _, _, _, _ = sim.step(u)
+        snapshots[
+            tuple((obj.name, obj.type.name, obs[obj].tobytes()) for obj in obs)
+        ] = snapshot()
         return obs.copy()
 
     types = {

--- a/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
+++ b/kinder-bilevel-planning/tests/env_models/dynamic3d/test_tossing_fixed_planning_scene.py
@@ -1,8 +1,9 @@
-"""The tossing planner must see the same fixed obstacles as the simulator."""
+"""Tossing planning geometry, cube bindings and physics-state restoration."""
 
 import kinder
 import numpy as np
 import pybullet as p
+from bilevel_planning.structs import RelationalAbstractGoal, RelationalAbstractState
 from kinder.envs.dynamic3d.envs import ObjectCentricTidyBot3DEnv, TidyBot3DEnv
 from kinder.envs.dynamic3d.object_types import (
     MujocoFixtureObjectType,
@@ -13,7 +14,13 @@ from kinder.envs.dynamic3d.objects.primitive_objects import Cuboid
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     MoveToTossLocationAndTossController,
 )
-from kinder_models.dynamic3d.tossing.state_abstractions import MovableIsDownX
+from kinder_models.dynamic3d.tossing.state_abstractions import (
+    HandEmpty,
+    Holding,
+    MovableInGoalRegion,
+    MovableIsDownX,
+    OnGround,
+)
 from kinder_models.dynamic3d.utils import (
     PyBulletSim,
     get_overhead_kinematic2ds,
@@ -99,4 +106,86 @@ def test_fixed_tossing_obstacles_match_both_planning_scenes(monkeypatch) -> None
     finally:
         for planner in captured:
             planner.close()
+        env.close()  # type: ignore[no-untyped-call]
+
+
+def test_tossing_two_cubes_have_independent_operator_effects() -> None:
+    """One completed toss must not satisfy or delete the other cube's facts."""
+    kinder.register_all_environments()
+    env = kinder.make("kinder/Tossing3D-o2-v0", scene_bg=False)
+    assert isinstance(env.unwrapped, TidyBot3DEnv)
+    try:
+        obs, _ = env.reset(seed=3)
+        models = create_bilevel_planning_models(
+            "tidybot3d_tossing3D",
+            env.observation_space,
+            env.action_space,
+            num_objects=2,
+        )
+        state = models.observation_to_state(obs)
+        robot = state.get_object_from_name("robot")
+        barrier = state.get_object_from_name("cuboid_barrier")
+        cubes = [state.get_object_from_name(f"cube_{i}") for i in range(2)]
+        goal = models.goal_deriver(state)
+        assert isinstance(goal, RelationalAbstractGoal)
+        assert goal.atoms == {GroundAtom(MovableInGoalRegion, [c]) for c in cubes}
+        abstract = models.state_abstractor(state)
+        atoms = set(abstract.atoms)
+        skills = {s.operator.name: s for s in models.skills}
+        for index, cube in enumerate(cubes):
+            pick = skills["pick_cube"].ground((robot, cube, barrier))
+            toss = skills["move_to_toss_location_and_toss"].ground(
+                (robot, cube, barrier)
+            )
+            assert pick.controller.objects[1] == cube
+            assert toss.controller.objects[1] == cube
+            assert pick.operator.preconditions <= atoms
+            atoms.difference_update(pick.operator.delete_effects)
+            atoms.update(pick.operator.add_effects)
+            assert GroundAtom(Holding, [robot, cube]) in atoms
+            assert toss.operator.preconditions <= atoms
+            atoms.difference_update(toss.operator.delete_effects)
+            atoms.update(toss.operator.add_effects)
+            assert GroundAtom(HandEmpty, [robot]) in atoms
+            assert GroundAtom(MovableInGoalRegion, [cube]) in atoms
+            if index == 0:
+                other = cubes[1]
+                assert GroundAtom(OnGround, [other]) in atoms
+                assert GroundAtom(MovableIsDownX, [other, barrier]) in atoms
+                assert GroundAtom(MovableInGoalRegion, [other]) not in atoms
+                assert not goal.check_abstract_state(
+                    RelationalAbstractState(atoms, abstract.objects)
+                )
+        assert goal.check_abstract_state(
+            RelationalAbstractState(atoms, abstract.objects)
+        )
+    finally:
+        env.close()  # type: ignore[no-untyped-call]
+
+
+def test_tossing_transition_restores_hidden_gripper_state() -> None:
+    """A failed close-gripper branch cannot contaminate replay of an open branch."""
+    kinder.register_all_environments()
+    env = kinder.make("kinder/Tossing3D-o2-v0", scene_bg=False)
+    assert isinstance(env.unwrapped, TidyBot3DEnv)
+    try:
+        obs, _ = env.reset(seed=3)
+        models = create_bilevel_planning_models(
+            "tidybot3d_tossing3D",
+            env.observation_space,
+            env.action_space,
+            num_objects=2,
+        )
+        start = models.observation_to_state(obs)
+        close_action = np.zeros(18, dtype=np.float32)
+        close_action[10] = 1.0
+        open_action = np.zeros(18, dtype=np.float32)
+        expected = models.transition_fn(start, open_action)
+        branch = start
+        for _ in range(10):
+            branch = models.transition_fn(branch, close_action)
+        replayed = models.transition_fn(start.copy(), open_action)
+        for obj in expected:
+            np.testing.assert_array_equal(expected[obj], replayed[obj])
+    finally:
         env.close()  # type: ignore[no-untyped-call]

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -44,6 +44,7 @@ from kinder_models.dynamic3d.tossing.toss_swing import (
     TOSS_RELEASE_ARM_CONFIGURATION,
     TOSS_WINDUP_ARM_CONFIGURATION,
     TossSwing,
+    bound_tossing_action,
     plan_toss_swing,
     toss_swing_action,
 )
@@ -171,7 +172,7 @@ class MoveToTargetGroundController(
         action[1] = dy
         action[2] = drot
         action[-1] = self._get_current_robot_gripper_pose()
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -340,7 +341,7 @@ class MoveArmToConfController(GroundParameterizedController[ObjectCentricState, 
         action[10] = gripper_pose
 
         self._step_idx += 1
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -409,7 +410,7 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         x: ObjectCentricState,
         params: Any,
         release_speed: float = TOSS_MAX_VELOCITY,
-        gripper_release_ms: int = TOSS_DEFAULT_GRIPPER_RELEASE_MILLISECONDS,
+        gripper_release_ms: int = 700,
     ) -> None:
         """Plan the swing, and fix the millisecond the gripper opens on.
 
@@ -418,6 +419,11 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         the swing's duration: a value at or past the end means the gripper never opens
         and the cube is never thrown.
         """
+        # Public actions run at 10 Hz. Keep sub-step schedules in the low-level
+        # swing helper; the controller's default is the nearest boundary to 720 ms.
+        control_step_ms = int(round(_CONTROL_TIMESTEP * 1000))
+        if gripper_release_ms % control_step_ms != 0:
+            raise ValueError("gripper_release_ms must align with a control step")
         # Initialize the PyBullet interface if this is the first time ever.
         if self._pybullet_sim is None:
             self._pybullet_sim = PyBulletSim(x)
@@ -454,12 +460,7 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         return self._step_idx >= len(self._swing.trajectory)
 
     def step(self) -> Array:
-        """The swing's command for one control step, opening the gripper mid-step.
-
-        The usual (18,) action, except on the step the release falls inside, which
-        returns a (TOSS_SLICES_PER_CONTROL_STEP, 18) schedule so gripper_release_ms
-        means the millisecond it names rather than the next step boundary.
-        """
+        """Return one bounded 18D control action, opening on a step boundary."""
         assert self._swing is not None
         action = toss_swing_action(
             self._swing,
@@ -471,7 +472,7 @@ class TossController(GroundParameterizedController[ObjectCentricState, Array]):
         if self._step_idx == self._swing.release_step:
             self._has_released = True
         self._step_idx += 1
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -633,7 +634,7 @@ class MoveArmToEndEffectorController(
         action[10] = gripper_pose
 
         self._step_idx += 1
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -695,7 +696,7 @@ class CloseGripperController(GroundParameterizedController[ObjectCentricState, A
         self.last_gripper_state = self._get_current_gripper_pose()
         action = np.zeros(11, dtype=np.float32)
         action[-1] = 1
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -742,7 +743,7 @@ class OpenGripperController(GroundParameterizedController[ObjectCentricState, Ar
         self.last_gripper_state = self._get_current_gripper_pose()
         action = np.zeros(11, dtype=np.float32)
         action[-1] = 0
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -790,7 +791,7 @@ class NoOpController(GroundParameterizedController[ObjectCentricState, Array]):
     def step(self) -> Array:
         action = np.zeros(11, dtype=np.float32)
         action[-1] = self._get_current_gripper_pose()
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -1135,7 +1136,7 @@ class PickCubeController(GroundParameterizedController[ObjectCentricState, Array
             return self._step_base_motion()
         action = np.zeros(11, dtype=np.float32)
         action[-1] = 0
-        return action
+        return bound_tossing_action(action)
 
     def _step_base_motion(self) -> Array:
         base_plan = self.plans[self.PickCubeControllerPhase.BASE_MOTION]
@@ -1165,7 +1166,7 @@ class PickCubeController(GroundParameterizedController[ObjectCentricState, Array
         action[1] = dy
         action[2] = drot
         action[-1] = self._get_current_robot_gripper_pose()
-        return action
+        return bound_tossing_action(action)
 
     def _step_trajectory_phase(
         self,
@@ -1199,7 +1200,7 @@ class PickCubeController(GroundParameterizedController[ObjectCentricState, Array
                 self.current_phase = next_phase
             else:
                 self._lifted = True
-        return action
+        return bound_tossing_action(action)
 
     def _step_close_gripper(self) -> Array:
         if self._get_current_robot_gripper_pose() > 0.2 and np.isclose(
@@ -1212,7 +1213,7 @@ class PickCubeController(GroundParameterizedController[ObjectCentricState, Array
         action = np.zeros(11, dtype=np.float32)
         action[-1] = 1
         self._last_gripper_state = self._get_current_robot_gripper_pose()
-        return action
+        return bound_tossing_action(action)
 
     def observe(self, x: ObjectCentricState) -> None:
         self._last_state = x
@@ -1595,7 +1596,7 @@ class MoveToTossLocationAndTossController(
         action[1] = next_pose.y - robot_pose.y
         action[2] = get_signed_angle_distance(next_pose.theta(), robot_pose.theta())
         action[-1] = self._get_current_robot_gripper_pose()
-        return action
+        return bound_tossing_action(action)
 
     def _action_windup(self) -> Array:
         action = np.zeros(18, dtype=np.float32)
@@ -1617,7 +1618,7 @@ class MoveToTossLocationAndTossController(
         self._windup_step_idx += 1
         if self._windup_step_idx >= len(self._windup_trajectory):
             self._phase = self.MoveToTossLocationAndTossControllerPhase.SWING
-        return action
+        return bound_tossing_action(action)
 
     def _action_swing(self) -> Array:
         assert self._swing is not None
@@ -1636,7 +1637,7 @@ class MoveToTossLocationAndTossController(
                 "MoveToTossLocationAndToss: swing done -- entering RETURN_HOME"
             )
             self._phase = self.MoveToTossLocationAndTossControllerPhase.RETURN_HOME
-        return action
+        return bound_tossing_action(action)
 
     def _action_return_home(self) -> Array:
         # wrap_arm_joint_difference, not a raw subtraction: the retract target holds
@@ -1650,7 +1651,7 @@ class MoveToTossLocationAndTossController(
         action = np.zeros(18, dtype=np.float32)
         action[3:10] = kp * wrap_arm_joint_difference(target - curr)
         action[10] = self._get_current_robot_gripper_pose()
-        return action
+        return bound_tossing_action(action)
 
     def _get_current_robot_pose(self) -> SE2:
         assert self._last_state is not None

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/parameterized_skills.py
@@ -1352,16 +1352,17 @@ class MoveToTossLocationAndTossController(
 
     # Coupled speed/release candidates for the farther simulated receiver. Faster
     # swings need earlier release; sampling these independently wastes refinements.
+    # Release times align with 10 Hz actions; no sub-step schedules are emitted.
     # Every instance uses the same candidates, selected with the planner's RNG.
     THROW_PROFILES = (
-        (190.0, 680.0),
-        (220.0, 590.0),
-        (230.0, 590.0),
-        (250.0, 550.0),
-        (280.0, 550.0),
-        (320.0, 520.0),
+        (190.0, 700.0),
+        (220.0, 600.0),
+        (230.0, 600.0),
+        (250.0, 600.0),
+        (280.0, 600.0),
+        (320.0, 500.0),
         (360.0, 500.0),
-        (400.0, 480.0),
+        (400.0, 500.0),
     )
     MAX_SWING_VELOCITY = np.deg2rad(400.0)
 
@@ -1436,6 +1437,8 @@ class MoveToTossLocationAndTossController(
         self._last_state = x
         self._release_speed = float(current_params[2])
         self._gripper_release_ms = int(round(float(current_params[3])))
+        if self._gripper_release_ms % int(round(_CONTROL_TIMESTEP * 1000)) != 0:
+            raise ValueError("gripper_release_ms must align with a control step")
         self._phase = self.MoveToTossLocationAndTossControllerPhase.BASE_MOTION
         self._windup_step_idx = 0
         self._swing = None

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/state_abstractions.py
@@ -4,7 +4,7 @@ MovableIsDownX records that one movable is at lower x than another -- in practic
 side of cuboid_barrier (x ~ 1.3) a cube is on, so an operator model can express that a
 toss past it is irreversible.
 
-TODO: only Tossing3D-o1 is supported; no operator says which cube a throw is aimed at.
+Each cube has separate holding, barrier-side and goal predicates.
 """
 
 import numpy as np
@@ -60,11 +60,6 @@ class Tossing3DStateAbstractor:
     def __init__(self, sim: ObjectCentricTidyBot3DEnv) -> None:
         """Initialize the state abstractor."""
         initial_state, _ = sim.reset()
-        cubes = self._get_cubes(initial_state)
-        assert len(cubes) == 1, (
-            f"only Tossing3D-o1 is supported, got {len(cubes)} cubes; see this "
-            "module's TODO for what o2 would need"
-        )
         self._pybullet_sim = PyBulletSim(initial_state, rendering=False)
         self._robot_name = sim.robot_name
         self._sim = sim

--- a/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
+++ b/kinder-models/src/kinder_models/dynamic3d/tossing/toss_swing.py
@@ -10,6 +10,7 @@ from typing import NamedTuple
 
 import numpy as np
 from kinder.envs.dynamic3d.mujoco_utils import CONTROL_SCHEDULE_TIMESTEP
+from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBotRobotEnv
 from pybullet_helpers.inverse_kinematics import JointPositions
 from relational_structs import Array
 
@@ -48,6 +49,28 @@ class TossSwing(NamedTuple):
     release_slice: int
 
 
+def bound_tossing_action(action: Array) -> Array:
+    """Emit 18D commands with bounded position deltas and unchanged arm PD torque.
+
+    The Tossing controllers assume the default TidyBot PD gains. Transfer clipped
+    arm position error to velocity targets using those public gains; clipping alone
+    weakens the throw. Velocity targets retain their existing unrestricted range.
+    Legacy 11D setup commands have zero velocity targets before this conversion.
+    """
+    bounded = np.array(action, dtype=np.float32, copy=True)
+    if bounded.shape[-1] == 11:
+        bounded = np.concatenate(
+            [bounded, np.zeros((*bounded.shape[:-1], 7), dtype=np.float32)], axis=-1
+        )
+    position_delta = bounded[..., 3:10].copy()
+    bounded[..., :10] = np.clip(bounded[..., :10], -0.1, 0.1)
+    bounded[..., 10] = np.clip(bounded[..., 10], 0.0, 1.0)
+    bounded[..., 11:18] += (position_delta - bounded[..., 3:10]) * (
+        TidyBotRobotEnv.ARM_KP / TidyBotRobotEnv.ARM_KD
+    )
+    return bounded
+
+
 def toss_swing_action(
     swing: TossSwing,
     step_idx: int,
@@ -73,6 +96,7 @@ def toss_swing_action(
     target_joint_angles = swing.start_joint_angles + swing.direction * s
     action[3:10] = kp * (target_joint_angles - np.array(current_joint_angles[:7]))
     action[11:18] = swing.direction * (ds * kv)
+    action = bound_tossing_action(action)
 
     if has_released or step_idx > swing.release_step:
         action[10] = 0.0

--- a/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
@@ -1,6 +1,7 @@
 """Tests for toss_swing.py."""
 
 import numpy as np
+from kinder.envs.dynamic3d.robots.tidybot_robot_env import TidyBotRobotEnv
 
 from kinder_models.dynamic3d.tossing.parameterized_skills import (
     MoveToTossLocationAndTossController,
@@ -13,6 +14,7 @@ from kinder_models.dynamic3d.tossing.toss_swing import (
     TOSS_RELEASE_ARM_CONFIGURATION,
     TOSS_SLICES_PER_CONTROL_STEP,
     TOSS_WINDUP_ARM_CONFIGURATION,
+    bound_tossing_action,
     plan_toss_swing,
     toss_profile_limits,
     toss_swing_action,
@@ -200,3 +202,41 @@ def test_plan_toss_swing_is_unmoved_by_a_whole_turn_on_a_continuous_joint():
     assert np.allclose(wrapped.direction, plain.direction)
     assert wrapped.release_step == plain.release_step
     assert wrapped.release_slice == plain.release_slice
+
+
+def test_bounded_tossing_action_preserves_pd_torque_and_gripper_schedule():
+    """Position limits must not silently weaken a planned throw or alter release."""
+    rng = np.random.default_rng(12)
+    action = rng.normal(size=(100, 18)).astype(np.float32)
+    action[:, 10] = np.arange(100) < 45
+    original = action.copy()
+    velocity = rng.normal(size=(100, 7))
+    bounded = bound_tossing_action(action)
+    kp, kd = TidyBotRobotEnv.ARM_KP, TidyBotRobotEnv.ARM_KD
+    expected_torque = kp * action[:, 3:10] + kd * (action[:, 11:18] - velocity)
+    actual_torque = kp * bounded[:, 3:10] + kd * (bounded[:, 11:18] - velocity)
+    assert np.allclose(actual_torque, expected_torque, atol=1e-4)
+    assert np.all(np.abs(bounded[:, :10]) <= np.float32(0.1))
+    assert np.array_equal(bounded[:, 10], action[:, 10])
+    assert np.array_equal(action, original)
+
+
+def test_bounded_tossing_action_pads_setup_without_moving_the_gripper_index():
+    """Open, close, and base-only actions use the same 18D interface as swings."""
+    action = np.zeros(11, dtype=np.float32)
+    action[0] = 0.05
+    action[10] = 1.0
+    bounded = bound_tossing_action(action)
+    assert bounded.shape == (18,)
+    assert np.array_equal(bounded[:11], action)
+    assert np.array_equal(bounded[11:], np.zeros(7))
+
+
+def test_toss_swing_bounds_position_error_even_when_tracking_lags():
+    """The authoritative helper bounds every row, including a timed release."""
+    swing = _straight_swing(release_ms=725)
+    action = toss_swing_action(swing, swing.release_step, [0.0] * 13, 1.0, False)
+    assert action.shape == (100, 18)
+    assert np.all(np.abs(action[:, :10]) <= np.float32(0.1))
+    assert np.all(action[:25, 10] == 1.0)
+    assert np.all(action[25:, 10] == 0.0)

--- a/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_toss_swing.py
@@ -240,3 +240,22 @@ def test_toss_swing_bounds_position_error_even_when_tracking_lags():
     assert np.all(np.abs(action[:, :10]) <= np.float32(0.1))
     assert np.all(action[:25, 10] == 1.0)
     assert np.all(action[25:, 10] == 0.0)
+
+
+def test_room_profiles_emit_only_declared_action_vectors():
+    """Every shipped profile releases on a 10 Hz boundary, without a schedule."""
+    start = list(TOSS_WINDUP_ARM_CONFIGURATION)
+    target = list(TOSS_RELEASE_ARM_CONFIGURATION)
+    for speed, release_ms in MoveToTossLocationAndTossController.THROW_PROFILES:
+        swing = plan_toss_swing(
+            [target],
+            start,
+            np.deg2rad(speed),
+            int(release_ms),
+            max_velocity=MoveToTossLocationAndTossController.MAX_SWING_VELOCITY,
+        )
+        assert swing.release_slice == 0
+        action = toss_swing_action(swing, swing.release_step, start, 1.0, False)
+        assert action.shape == (18,)
+        assert np.all(np.abs(action[:10]) <= np.float32(0.1))
+        assert action[10] == 0.0

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -42,6 +42,7 @@ from kinder_models.dynamic3d.tossing.toss_swing import (
     TOSS_RELEASE_ARM_CONFIGURATION,
     TOSS_SLICES_PER_CONTROL_STEP,
     TOSS_WINDUP_ARM_CONFIGURATION,
+    bound_tossing_action,
     toss_profile_limits,
 )
 from kinder_models.dynamic3d.utils import (
@@ -1042,7 +1043,7 @@ def test_pick_toss():
     controller.reset(state, params)
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1074,7 +1075,7 @@ def test_pick_toss():
     controller.reset(state, params)
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1094,7 +1095,7 @@ def test_pick_toss():
     controller.reset(state)
     for _ in range(20):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1115,7 +1116,7 @@ def test_pick_toss():
     controller.reset(state, params)
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1131,7 +1132,7 @@ def test_pick_toss():
     cube = state.get_object_from_name("bin_0")
     object_parameters = (robot, cube)
     controller = lifted_controller.ground(object_parameters)
-    # Keep the test launch pose on the reachable side of the fixed barrier.
+    # The fixed barrier requires the robot to stay on its original side.
     target_distance = state.get(cube, "x") - 0.9
     target_rotation = 0.0
     params = np.array([target_distance, target_rotation])
@@ -1140,7 +1141,7 @@ def test_pick_toss():
     controller.reset(state, params, disable_collision_objects=["cube_0"])
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1161,7 +1162,7 @@ def test_pick_toss():
     controller.reset(state, params)
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1182,7 +1183,7 @@ def test_pick_toss():
     controller.reset(state, params)
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1249,7 +1250,7 @@ def test_pick_ground_toss():
     controller.reset(state, params)
     for _ in range(400):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1265,7 +1266,7 @@ def test_pick_ground_toss():
     cube = state.get_object_from_name("bin_0")
     object_parameters = (robot, cube)
     controller = lifted_controller.ground(object_parameters)
-    # Keep the test launch pose on the reachable side of the fixed barrier.
+    # The fixed barrier requires the robot to stay on its original side.
     target_distance = state.get(cube, "x") - 0.9
     target_rotation = 0.0
     params = np.array([target_distance, target_rotation])
@@ -1274,7 +1275,7 @@ def test_pick_ground_toss():
     controller.reset(state, params, disable_collision_objects=["cube_0"])
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1295,7 +1296,7 @@ def test_pick_ground_toss():
     controller.reset(state, params)
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1316,7 +1317,7 @@ def test_pick_ground_toss():
     controller.reset(state, params)
     for _ in range(200):
         action = controller.step()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(bound_tossing_action(action))
         next_state = env.observation_space.devectorize(obs)
         controller.observe(next_state)
         state = next_state
@@ -1424,77 +1425,18 @@ def test_a_release_ms_past_the_swing_never_opens_the_gripper():
     assert late_step >= len(trajectory)
 
 
-def test_toss_schedules_its_release_at_the_requested_millisecond():
-    """End to end: exactly one action of a real toss is a control schedule.
-
-    That schedule has to reach the simulator and land on the millisecond asked for
-    rather than the next control-step boundary. Every other action is a plain (18,).
-    """
-    requested_ms = 812  # deliberately not a multiple of 100
-    expected_step, expected_slice = divmod(requested_ms, TOSS_SLICES_PER_CONTROL_STEP)
-
-    env = kinder.make("kinder/Tossing3D-o1-v0", render_mode="rgb_array", scene_bg=False)
-    assert isinstance(env.observation_space, ObjectCentricBoxSpace)
+def test_public_toss_rejects_substep_release_schedules():
+    """The public controller emits vectors from the declared 10 Hz action space."""
+    env = kinder.make("kinder/Tossing3D-o1-v0", scene_bg=False)
     obs, _ = env.reset(seed=125)
     state = env.observation_space.devectorize(obs)
-    shelf = shelf_skills.create_lifted_controllers(env.action_space)
-    tossing = create_lifted_controllers(env.action_space)
-
-    def _run(controller, params, **reset_kwargs):
-        """Drive one controller to termination, returning the actions it emitted."""
-        nonlocal state
-        controller.reset(state, params, **reset_kwargs)
-        emitted = []
-        for _ in range(400):
-            action = controller.step()
-            emitted.append(np.array(action, copy=True))
-            observation, _, _, _, _ = env.step(action)
-            state = env.observation_space.devectorize(observation)
-            controller.observe(state)
-            if controller.terminated():
-                return emitted
-        assert False, "Controller did not terminate"
-
-    # The cube has to be *in* the gripper, or the release is a no-op: an empty hand
-    # commands 0.0 both sides of the release.
     robot = _get_robot_from_state(state)
-    pick = shelf["pick_shelf"].ground((robot, state.get_object_from_name("cube_0")))
-    _run(pick, pick.sample_parameters(state, np.random.default_rng(123)))
-
-    robot = _get_robot_from_state(state)
-    move = tossing["move_to_target"].ground(
-        (robot, state.get_object_from_name("bin_0"))
-    )
-    distance = state.get(state.get_object_from_name("bin_0"), "x") - 0.9
-    _run(move, np.array([distance, 0.0]), disable_collision_objects=["cube_0"])
-
-    robot = _get_robot_from_state(state)
-    _run(tossing["move_arm_to_conf"].ground((robot,)), TOSS_WINDUP_ARM_CONFIGURATION)
-
-    robot = _get_robot_from_state(state)
-    toss = tossing["toss"].ground((robot,))
-    actions = _run(
-        toss, TOSS_RELEASE_ARM_CONFIGURATION, gripper_release_ms=requested_ms
-    )
-
-    scheduled = [i for i, action in enumerate(actions) if action.ndim == 2]
-    assert scheduled == [expected_step]
-    schedule = actions[expected_step]
-    # A schedule covers the whole control period, so release is located by index.
-    assert schedule.shape == (TOSS_SLICES_PER_CONTROL_STEP, 18)
-    assert np.all(schedule[:expected_slice, 10] == schedule[0, 10])
-    assert schedule[0, 10] > 0.0
-    assert np.all(schedule[expected_slice:, 10] == 0.0)
-
-    # Only the gripper column varies; the arm is commanded identically across slices.
-    columns = [c for c in range(18) if c != 10]
-    assert np.all(schedule[:, columns] == schedule[0, columns])
-
-    # Everything before the release still holds the cube, everything after is open.
-    assert all(action[10] > 0.0 for action in actions[:expected_step])
-    assert all(action[10] == 0.0 for action in actions[expected_step + 1 :])
-
-    env.close()
+    toss = create_lifted_controllers(env.action_space)["toss"].ground((robot,))
+    try:
+        with pytest.raises(ValueError, match="align with a control step"):
+            toss.reset(state, TOSS_RELEASE_ARM_CONFIGURATION, gripper_release_ms=812)
+    finally:
+        env.close()
 
 
 def test_pick_cube_takes_no_continuous_parameters():
@@ -1733,8 +1675,8 @@ def test_open_gripper_commands_open_until_the_gripper_reads_open():
     controller.reset(shut)
     assert not controller.terminated()
     action = controller.step()
-    assert action.shape == (11,)
-    assert action[-1] == 0
+    assert action.shape == (18,)
+    assert action[10] == 0
 
     opened = state.copy()
     opened.set(robot, "pos_gripper", 0.0)
@@ -1764,7 +1706,7 @@ def test_no_op_controller_terminates_immediately_and_holds_the_gripper_command()
     controller.reset(open_gripper)
     assert controller.terminated()
     action = controller.step()
-    assert action.shape == (11,)
+    assert action.shape == (18,)
     assert np.all(action == 0)
 
     closed_gripper = state.copy()
@@ -1772,8 +1714,8 @@ def test_no_op_controller_terminates_immediately_and_holds_the_gripper_command()
     controller.reset(closed_gripper)
     assert controller.terminated()
     action = controller.step()
-    assert action[:-1].tolist() == [0.0] * (action.shape[0] - 1)
-    assert action[-1] == GRASP_CLOSE_THRESHOLD
+    assert np.delete(action, 10).tolist() == [0.0] * (action.shape[0] - 1)
+    assert action[10] == GRASP_CLOSE_THRESHOLD
     env.close()
 
 

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_parameterized_skills.py
@@ -11,7 +11,7 @@ import pytest
 from bilevel_planning.structs import GroundParameterizedController
 from conftest import MAKE_VIDEOS
 from gymnasium.wrappers import RecordVideo
-from kinder.envs.dynamic3d.envs import TidyBot3DEnv
+from kinder.envs.dynamic3d.envs import TidyBot3DConfig, TidyBot3DEnv
 from kinder.envs.dynamic3d.object_types import (
     MujocoMovableObjectType,
     MujocoObjectTypeFeatures,
@@ -1796,7 +1796,7 @@ def test_move_to_toss_location_and_toss_plans_every_phase_in_reset():
     controller = controllers["move_to_toss_location_and_toss"].ground(
         (robot, cube, barrier)
     )
-    controller.reset(state, np.array([1.30, 0.0, TOSS_MAX_VELOCITY, 720.0]))
+    controller.reset(state, np.array([1.30, 0.0, TOSS_MAX_VELOCITY, 700.0]))
     # Every phase is planned before the first action is asked for.
     # pylint: disable-next=protected-access
     assert controller._current_base_motion_plan is not None
@@ -1913,8 +1913,9 @@ def test_pick_cube_retrieves_from_bin_after_toss(tmp_path):
     )
     task_path = tmp_path / "bin-retrieval.json"
     task_path.write_text(json.dumps(config), encoding="utf-8")
-    env = kinder.make(
-        "kinder/Tossing3D-o1-v0",
+    env = TidyBot3DEnv(
+        num_objects=1,
+        config=TidyBot3DConfig(use_arm_velocities=True),
         render_mode="rgb_array",
         task_config_path=str(task_path),
     )
@@ -1944,7 +1945,7 @@ def test_pick_cube_retrieves_from_bin_after_toss(tmp_path):
                 "toss",
                 "move_to_toss_location_and_toss",
                 (robot, cube, barrier),
-                np.array([1.35, 0, np.deg2rad(130), 792]),
+                np.array([1.35, 0, np.deg2rad(130), 800]),
             ),
             ("retrieval", "pick_cube", (robot, cube, barrier), None),
         ):

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -152,13 +152,17 @@ def test_the_goal_is_every_cube_in_the_goal_region():
     env.close()
 
 
-def test_the_abstractor_rejects_the_two_cube_variant():
-    """O2 is out of scope: no operator says which cube a throw is aimed at."""
+def test_the_abstractor_requires_both_cubes_in_the_goal():
+    """The two-cube goal contains a separate atom for each cube."""
     kinder.register_all_environments()
     env = kinder.make("kinder/Tossing3D-o2-v0", render_mode="rgb_array")
     sim = env.unwrapped._object_centric_env  # pylint: disable=protected-access
-    with pytest.raises(AssertionError, match="only Tossing3D-o1 is supported"):
-        Tossing3DStateAbstractor(sim)
+    abstractor = Tossing3DStateAbstractor(sim)
+    state, _ = sim.reset(seed=3)
+    cubes = [state.get_object_from_name(f"cube_{i}") for i in range(2)]
+    goal = abstractor.goal_deriver(state)
+    assert goal.atoms == {GroundAtom(MovableInGoalRegion, [cube]) for cube in cubes}
+    assert not goal.check_state(state)
     env.close()
 
 

--- a/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
+++ b/kinder-models/tests/dynamic3d/tossing/test_tossing_state_abstractions.py
@@ -2,7 +2,6 @@
 
 import kinder
 import numpy as np
-import pytest
 from conftest import MAKE_VIDEOS  # pylint: disable=import-error
 from gymnasium.wrappers import RecordVideo
 from kinder.envs.dynamic3d.object_types import MujocoTidyBotRobotObjectType

--- a/scripts/install_all.py
+++ b/scripts/install_all.py
@@ -14,11 +14,11 @@ from generate_topological_order import get_topological_order
 # kindergarden would break every package that depends on that package), so
 # the git pin lives here instead of in the pyprojects.
 #
-# kindergarden: requires the Tossing room geometry in #198.
-# Merge that PR before this companion; remove the pin once released.
+# kindergarden: requires the Tossing geometry and 18D interface in #198/#200.
+# Merge those PRs before this companion; remove the pin once released.
 PREINSTALL_REQUIREMENTS = [
     "kindergarden @ git+https://github.com/Princeton-Robot-Planning-and-Learning/"
-    "kindergarden.git@0dbc1c0fe7b60985134e2e14f1dc79c43595263f",
+    "kindergarden.git@9884e8b3bdfb5715592796dbefdd39902a0fffa9",
 ]
 
 


### PR DESCRIPTION
Tossing controllers can exceed the declared position bounds and emit mixed action shapes. Keep their outputs within the intended 18D interface: clip position deltas, preserve arm feedback through velocity targets, pad setup actions, and align public releases to 100 ms boundaries.

SeSamE also restored incomplete observations between simulated actions, which could change a grasp and make a predicted successful throw miss during execution. Preserve full MuJoCo integration snapshots during search. Remove the obsolete one-cube restriction: the existing operators already bind the picked and thrown cube separately.

Add Tossing o1/o2 experiment presets with a 400-step skill horizon and 120-second planning budget. The generic 100-step cap cuts off pickup before any throw; generic planner defaults stay unchanged.

**Depends on Kinder [#198](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/198) and [#200](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/200). Merge those first.** Development/CI is pinned to the required Kinder revision. Stacked above #165 (which now includes the former #166 controller layer); remains a draft for review.

Validation:

- Action-bound/controller regressions, multi-cube goal/operator checks, and search-backtracking state restoration tests pass. The existing maintained planner test (seed 125) also passes.
- Normal-reset o1 seed 3: 321 planned actions plus 60 settling actions; all 60 physical containment checks pass.
- Normal-reset o2 seed 3: both throws complete, with 709 actions including settling. Both cubes are at rest inside the bin; one has approximately 0.4 micrometres of wall contact penetration. This is a contact-tolerant success, not exact mathematical containment.
- Both near receiver corners (o1 seed 0) pass maintained-controller execution with 60/60 containment checks in 395/394 actions including settling. Both far corners return no plan with the 120-second planning budget; no sampler tuning was added. The planner timeout is soft: these attempts took 146/163 seconds total.

The actual RoboCode adapter also succeeds on o1 seed 3 with `approach.max_skill_horizon=400`, `eval_timeout=120`, and `max_steps=1000`. RoboCode’s generic settings are unchanged.

The snapshot validation covers planning from normal reset and search backtracking. It does not establish exact reconstruction from arbitrary external mid-grasp observations, which omit finger state. These selected checks give reviewers examples of capability and failures; they are not a full-distribution success-rate estimate.

Maintained SeSamE execution, normal-reset o1 seed 3, with the scene background:

![Maintained SeSamE Tossing success](https://raw.githubusercontent.com/Princeton-Robot-Planning-and-Learning/kindergarden/3b2c234828b764faaf634a2b377784f81a384623/tossing-sesame-o1.gif)

Maintained SeSamE execution, normal-reset o2 seed 3 (contact tolerance described above):

![Maintained SeSamE two-block Tossing success](https://raw.githubusercontent.com/Princeton-Robot-Planning-and-Learning/kindergarden/87c6134e69761f3dea24cf32aa3e401468fec179/tossing-sesame-o2.gif)
